### PR TITLE
[7.x.x] Make sure that all Child Nodes of a Document Node are accessible

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -850,6 +850,7 @@
                                 <include>src/test/java/org/exist/dom/persistent/NodeTest.java</include>
                                 <include>src/test/java/org/exist/dom/persistent/PersistentDomTest.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/ProcessingInstructionImpl.java</include>
+                                <include>src/main/java/org/exist/dom/persistent/SortedNodeSet.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/StoredNode.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/SymbolTable.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/TextImpl.java</include>
@@ -954,6 +955,7 @@
                                 <include>src/main/java/org/exist/xmldb/RemoteRestoreService.java</include>
                                 <include>src/test/java/org/exist/xmldb/ResourceTest.java</include>
                                 <include>src/test/java/org/exist/xmldb/TestEXistXMLSerialize.java</include>
+                                <include>src/test/java/org/exist/xmldb/TreeLevelOrderTest.java</include>
                                 <include>src/test/java/org/exist/xmldb/concurrent/XMLGenerator.java</include>
                                 <include>src/main/java/org/exist/xmlrpc/ExistRpcTypeFactory.java</include>
                                 <include>src/main/java/org/exist/xmlrpc/RpcConnection.java</include>
@@ -971,6 +973,7 @@
                                 <include>src/main/java/org/exist/xquery/XPathUtil.java</include>
                                 <include>src/main/java/org/exist/xquery/XQueryContext.java</include>
                                 <include>src/test/java/org/exist/xquery/XQueryFunctionsTest.java</include>
+                                <include>src/test/java/org/exist/xquery/XQueryTest.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/array/ArrayType.java</include>
                                 <include>src/test/java/org/exist/xquery/functions/fn/DocTest.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/FnModule.java</include>
@@ -1134,6 +1137,7 @@
                                 <exclude>src/test/java/org/exist/dom/persistent/NodeTest.java</exclude>
                                 <exclude>src/test/java/org/exist/dom/persistent/PersistentDomTest.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/ProcessingInstructionImpl.java</exclude>
+                                <exclude>src/main/java/org/exist/dom/persistent/SortedNodeSet.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/StoredNode.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/SymbolTable.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/TextImpl.java</exclude>
@@ -1299,6 +1303,7 @@
                                 <exclude>src/main/java/org/exist/xmldb/RemoteRestoreService.java</exclude>
                                 <exclude>src/test/java/org/exist/xmldb/ResourceTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xmldb/TestEXistXMLSerialize.java</exclude>
+                                <exclude>src/test/java/org/exist/xmldb/TreeLevelOrderTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xmldb/concurrent/XMLGenerator.java</exclude>
                                 <exclude>src/main/java/org/exist/xmlrpc/ACEAiderParser.java</exclude>
                                 <exclude>src/main/java/org/exist/xmlrpc/ACEAiderSerializer.java</exclude>
@@ -1330,6 +1335,7 @@
                                 <exclude>src/main/java/org/exist/xquery/XQueryContext.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/XQueryContextAttributesTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/XQueryFunctionsTest.java</exclude>
+                                <exclude>src/test/java/org/exist/xquery/XQueryTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/array/ArrayType.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/fn/DocTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FnModule.java</exclude>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -829,6 +829,7 @@
                                 <include>src/main/java/org/exist/config/ConfigurationImpl.java</include>
                                 <include>src/main/java/org/exist/config/Configurator.java</include>
                                 <include>src/main/java/org/exist/dom/NodeListImpl.java</include>
+                                <exclude>src/main/java/org/exist/dom/memtree/AbstractCharacterData.java</exclude>
                                 <include>src/main/java/org/exist/dom/memtree/AttrImpl.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/DocumentImpl.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/DOMIndexer.java</include>
@@ -836,7 +837,9 @@
                                 <include>src/test/java/org/exist/dom/memtree/DOMTest.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/ElementImpl.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/MemTreeBuilder.java</include>
+                                <exclude>src/main/java/org/exist/dom/memtree/NamespaceNode.java</exclude>
                                 <include>src/main/java/org/exist/dom/memtree/NodeImpl.java</include>
+                                <exclude>src/main/java/org/exist/dom/memtree/ProcessingInstructionImpl.java</exclude>
                                 <include>src/main/java/org/exist/dom/persistent/AbstractCharacterData.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/AttrImpl.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/CommentImpl.java</include>
@@ -1103,6 +1106,7 @@
                                 <exclude>src/main/java/org/exist/config/ConfigurationImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/config/Configurator.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/NodeListImpl.java</exclude>
+                                <exclude>src/main/java/org/exist/dom/memtree/AbstractCharacterData.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/AttrImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/DocumentImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/DocumentTypeImpl.java</exclude>
@@ -1111,7 +1115,9 @@
                                 <exclude>src/test/java/org/exist/dom/memtree/DOMTest.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/ElementImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/MemTreeBuilder.java</exclude>
+                                <exclude>src/main/java/org/exist/dom/memtree/NamespaceNode.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/NodeImpl.java</exclude>
+                                <exclude>src/main/java/org/exist/dom/memtree/ProcessingInstructionImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/reference/AbstractReferenceCharacterData.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/reference/AbstractReferenceNodeImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/reference/CommentReferenceImpl.java</exclude>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -866,6 +866,7 @@
                                 <include>src/main/java/org/exist/http/urlrewrite/Redirect.java</include>
                                 <include>src/main/java/org/exist/http/urlrewrite/RewriteConfig.java</include>
                                 <include>src/main/java/org/exist/indexing/Index.java</include>
+                                <include>src/main/java/org/exist/indexing/IndexController.java</include>
                                 <include>src/main/java/org/exist/indexing/IndexManager.java</include>
                                 <include>src/main/java/org/exist/jetty/JettyStart.java</include>
                                 <include>src/main/java/org/exist/jetty/ServerShutdown.java</include>
@@ -1154,6 +1155,7 @@
                                 <exclude>src/main/java/org/exist/http/urlrewrite/Redirect.java</exclude>
                                 <exclude>src/main/java/org/exist/http/urlrewrite/RewriteConfig.java</exclude>
                                 <exclude>src/main/java/org/exist/indexing/Index.java</exclude>
+                                <include>src/main/java/org/exist/indexing/IndexController.java</include>
                                 <exclude>src/main/java/org/exist/indexing/IndexManager.java</exclude>
                                 <exclude>src/main/java/org/exist/jetty/JettyStart.java</exclude>
                                 <exclude>src/main/java/org/exist/jetty/ServerShutdown.java</exclude>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -783,11 +783,15 @@
                                 <include>src/test/xquery/util/util.xml</include>
                                 <include>src/test/xquery/xquery3/serialize.xql</include>
                                 <include>src/main/java/org/exist/Indexer.java</include>
+                                <include>src/test/java/org/exist/IndexerTest.java</include>
+                                <include>src/test/java/org/exist/IndexerTest2.java</include>
+                                <include>src/test/java/org/exist/IndexerTest3.java</include>
                                 <include>src/main/resources-filtered/org/exist/system.properties</include>
                                 <include>src/main/java/org/exist/backup/ExportGUI.java</include>
                                 <include>src/main/java/org/exist/backup/ExportMain.java</include>
                                 <include>src/main/java/org/exist/backup/Main.java</include>
                                 <include>src/main/java/org/exist/backup/SystemExport.java</include>
+                                <include>src/main/java/org/exist/backup/ZipWriter.java</include>
                                 <include>src/main/java/org/exist/backup/restore/AppRestoreUtils.java</include>
                                 <include>src/main/java/org/exist/client/ClientFrame.java</include>
                                 <include>src/main/java/org/exist/client/CommandlineOptions.java</include>
@@ -823,9 +827,12 @@
                                 <include>src/main/java/org/exist/collections/triggers/XQueryStartupTrigger.java</include>
                                 <include>src/main/java/org/exist/config/Configuration.java</include>
                                 <include>src/main/java/org/exist/config/ConfigurationImpl.java</include>
+                                <include>src/main/java/org/exist/config/Configurator.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/AttrImpl.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/DocumentImpl.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/DOMIndexer.java</include>
+                                <include>src/test/java/org/exist/dom/memtree/DOMIndexerTest.java</include>
+                                <include>src/test/java/org/exist/dom/memtree/DOMTest.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/ElementImpl.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/MemTreeBuilder.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/NodeImpl.java</include>
@@ -843,6 +850,7 @@
                                 <include>src/main/java/org/exist/dom/persistent/SymbolTable.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/TextImpl.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/VirtualNodeSet.java</include>
+                                <include>src/main/java/org/exist/dom/persistent/XMLUtil.java</include>
                                 <include>src/test/java/org/exist/http/AbstractHttpTest.java</include>
                                 <include>src/main/java/org/exist/http/Descriptor.java</include>
                                 <include>src/main/java/org/exist/http/RESTServer.java</include>
@@ -882,48 +890,77 @@
                                 <include>src/main/java/org/exist/repo/ExistRepository.java</include>
                                 <include>src/main/java/org/exist/scheduler/impl/QuartzSchedulerImpl.java</include>
                                 <include>src/main/java/org/exist/security/EffectiveSubject.java</include>
+                                <include>src/test/java/org/exist/security/FnDocSecurityTest.java</include>
                                 <include>src/main/java/org/exist/security/SecurityManager.java</include>
                                 <include>src/main/java/org/exist/security/SimpleACLPermission.java</include>
+                                <include>src/test/java/org/exist/security/XqueryApiTest.java</include>
                                 <include>src/main/java/org/exist/security/internal/AccountImpl.java</include>
                                 <include>src/main/java/org/exist/source/Source.java</include>
                                 <include>src/main/java/org/exist/source/SourceFactory.java</include>
+                                <include>src/test/java/org/exist/storage/BFileRecoverTest.java</include>
                                 <include>src/main/java/org/exist/storage/BrokerFactory.java</include>
                                 <include>src/main/java/org/exist/storage/BrokerPool.java</include>
+                                <include>src/test/java/org/exist/storage/CollectionTest.java</include>
                                 <include>src/test/java/org/exist/storage/CopyResourceTest.java</include>
                                 <include>src/main/java/org/exist/storage/DBBroker.java</include>
+                                <include>src/test/java/org/exist/storage/DOMFileRecoverTest.java</include>
                                 <include>src/main/java/org/exist/storage/Indexable.java</include>
                                 <include>src/main/java/org/exist/storage/IndexSpec.java</include>
                                 <include>src/main/java/org/exist/storage/NativeBroker.java</include>
                                 <include>src/main/java/org/exist/storage/ProcessMonitor.java</include>
+                                <include>src/test/java/org/exist/storage/RecoveryTest.java</include>
+                                <include>src/test/java/org/exist/storage/RecoveryTest2.java</include>
+                                <include>src/test/java/org/exist/storage/btree/BTreeTest.java</include>
+                                <include>src/main/java/org/exist/storage/btree/TreeMetrics.java</include>
                                 <include>src/main/java/org/exist/storage/lock/FileLock.java</include>
                                 <include>src/main/java/org/exist/storage/recovery/RecoveryManager.java</include>
                                 <include>src/main/java/org/exist/storage/serializers/Serializer.java</include>
                                 <include>src/test/resources-filtered/org/exist/storage/statistics/conf.xml</include>
                                 <include>src/main/java/org/exist/storage/sync/SyncTask.java</include>
                                 <include>src/main/java/org/exist/test/ExistXmldbEmbeddedServer.java</include>
+                                <include>src/main/java/org/exist/test/runner/ExtTestFailureFunction.java</include>
                                 <include>src/main/java/org/exist/test/runner/XMLTestRunner.java</include>
                                 <include>src/main/java/org/exist/test/runner/XQueryTestRunner.java</include>
                                 <include>src/main/java/org/exist/test/runner/XSuite.java</include>
+                                <include>src/test/java/org/exist/util/AbstractXMLReaderSecurityTest.java</include>
                                 <include>src/main/java/org/exist/util/Collations.java</include>
                                 <include>src/main/java/org/exist/util/Configuration.java</include>
+                                <include>src/test/java/org/exist/util/DOMSerializerTest.java</include>
                                 <include>src/main/java/org/exist/util/ParametersExtractor.java</include>
                                 <include>src/main/java/org/exist/util/crypto/digest/DigestType.java</include>
                                 <include>src/main/java/org/exist/util/serializer/AttrList.java</include>
                                 <include>src/main/java/org/exist/util/serializer/DOMStreamer.java</include>
                                 <include>src/main/java/org/exist/util/serializer/EXISerializer.java</include>
+                                <include>src/test/java/org/exist/util/serializer/HTML5WriterTest.java</include>
                                 <include>src/main/java/org/exist/util/serializer/SerializerObjectFactory.java</include>
+                                <include>src/main/java/org/exist/util/serializer/json/JSONObject.java</include>
+                                <include>src/test/java/org/exist/util/serializer/json/JSONObjectTest.java</include>
+                                <include>src/test/java/org/exist/util/serializer/json/JSONWriterTest.java</include>
                                 <include>src/test/resources/org/exist/validation/catalog.xml</include>
                                 <include>src/test/java/org/exist/validation/CollectionConfigurationValidationModeTest.java</include>
+                                <include>src/main/java/org/exist/validation/resolver/SearchResourceResolver.java</include>
                                 <include>src/test/java/org/exist/w3c/tests/TestCase.java</include>
                                 <include>src/main/java/org/exist/webstart/JnlpJarFiles.java</include>
+                                <include>src/test/java/org/exist/xmldb/ContentAsDOMTest.java</include>
                                 <include>src/test/java/org/exist/xmldb/CreateCollectionsTest.java</include>
+                                <include>src/test/java/org/exist/xmldb/IndexingTest.java</include>
+                                <include>src/main/java/org/exist/xmldb/LocalResourceSet.java</include>
+                                <include>src/main/java/org/exist/xmldb/LocalXMLResource.java</include>
                                 <include>src/main/java/org/exist/xmldb/RemoteRestoreService.java</include>
+                                <include>src/test/java/org/exist/xmldb/ResourceTest.java</include>
+                                <include>src/test/java/org/exist/xmldb/TestEXistXMLSerialize.java</include>
+                                <include>src/test/java/org/exist/xmldb/concurrent/XMLGenerator.java</include>
                                 <include>src/main/java/org/exist/xmlrpc/ExistRpcTypeFactory.java</include>
+                                <include>src/main/java/org/exist/xmlrpc/RpcConnection.java</include>
                                 <include>src/main/java/org/exist/xqj/Marshaller.java</include>
+                                <include>src/test/java/org/exist/xqj/MarshallerTest.java</include>
+                                <include>src/test/java/org/exist/xquery/ConstructedNodesRecoveryTest.java</include>
                                 <include>src/main/java/org/exist/xquery/DynamicTypeCheck.java</include>
                                 <include>src/main/java/org/exist/xquery/ErrorCodes.java</include>
+                                <include>src/test/java/org/exist/xquery/ForwardReferenceTest.java</include>
                                 <include>src/main/java/org/exist/xquery/FunctionFactory.java</include>
                                 <include>src/main/java/org/exist/xquery/Optimizer.java</include>
+                                <include>src/main/java/org/exist/xquery/PerformanceStatsImpl.java</include>
                                 <include>src/main/java/org/exist/xquery/TryCatchExpression.java</include>
                                 <include>src/main/java/org/exist/xquery/UserDefinedFunction.java</include>
                                 <include>src/main/java/org/exist/xquery/XPathUtil.java</include>
@@ -935,12 +972,15 @@
                                 <include>src/main/java/org/exist/xquery/functions/fn/FunBaseURI.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/FunDeepEqual.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/FunParseIetfDate.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunSerialize.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/FunTrace.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunUnparsedText.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/FunUriCollection.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/FunXmlToJson.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/LoadXQueryModule.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/ParsingFunctions.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/transform/Convert.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/transform/Delivery.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/transform/Options.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/transform/Transform.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/transform/TreeUtils.java</include>
@@ -955,11 +995,14 @@
                                 <include>src/main/java/org/exist/xquery/functions/util/BuiltinFunctions.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/util/DescribeFunction.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/util/FunctionFunction.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/util/LogFunction.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/util/ModuleInfo.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/validation/Jaxp.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/xmldb/XMLDBStore.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/xmldb/XMLDBXUpdate.java</include>
                                 <include>src/main/antlr/org/exist/xquery/parser/XQueryTree.g</include>
                                 <include>src/test/java/org/exist/xquery/update/UpdateReplaceTest.java</include>
+                                <include>src/main/java/org/exist/xquery/util/ExpressionDumper.java</include>
                                 <include>src/main/java/org/exist/xquery/util/SerializerUtils.java</include>
                                 <include>src/main/java/org/exist/xquery/value/AbstractDateTimeValue.java</include>
                                 <include>src/test/java/org/exist/xquery/value/Base64BinaryValueTypeTest.java</include>
@@ -967,6 +1010,7 @@
                                 <include>src/main/java/org/exist/xquery/value/Type.java</include>
                                 <include>src/main/java/org/exist/xslt/EXistURIResolver.java</include>
                                 <include>src/main/java/org/exist/xslt/XsltURIResolverHelper.java</include>
+                                <include>src/test/java/org/exist/xupdate/RemoveAppendTest.java</include>
                             </includes>
                         </licenseSet>
 
@@ -1011,11 +1055,15 @@
                                 <exclude>src/test/xquery/xquery3/postfix-expr.xqm</exclude>
                                 <exclude>src/test/xquery/xquery3/serialize.xql</exclude>
                                 <exclude>src/main/java/org/exist/Indexer.java</exclude>
+                                <exclude>src/test/java/org/exist/IndexerTest.java</exclude>
+                                <exclude>src/test/java/org/exist/IndexerTest2.java</exclude>
+                                <exclude>src/test/java/org/exist/IndexerTest3.java</exclude>
                                 <exclude>src/main/resources-filtered/org/exist/system.properties</exclude>
                                 <exclude>src/main/java/org/exist/backup/ExportGUI.java</exclude>
                                 <exclude>src/main/java/org/exist/backup/ExportMain.java</exclude>
                                 <exclude>src/main/java/org/exist/backup/Main.java</exclude>
                                 <exclude>src/main/java/org/exist/backup/SystemExport.java</exclude>
+                                <exclude>src/main/java/org/exist/backup/ZipWriter.java</exclude>
                                 <exclude>src/main/java/org/exist/backup/restore/AppRestoreUtils.java</exclude>
                                 <exclude>src/main/java/org/exist/client/ClientFrame.java</exclude>
                                 <exclude>src/main/java/org/exist/client/CommandlineOptions.java</exclude>
@@ -1051,15 +1099,17 @@
                                 <exclude>src/main/java/org/exist/collections/triggers/XQueryStartupTrigger.java</exclude>
                                 <exclude>src/main/java/org/exist/config/Configuration.java</exclude>
                                 <exclude>src/main/java/org/exist/config/ConfigurationImpl.java</exclude>
+                                <exclude>src/main/java/org/exist/config/Configurator.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/AttrImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/DocumentImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/DocumentTypeImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/DOMIndexer.java</exclude>
+                                <exclude>src/test/java/org/exist/dom/memtree/DOMIndexerTest.java</exclude>
+                                <exclude>src/test/java/org/exist/dom/memtree/DOMTest.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/ElementImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/MemTreeBuilder.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/NodeImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/reference/AbstractReferenceCharacterData.java</exclude>
-                                <exclude>src/main/java/org/exist/dom/memtree/reference/AbstractReferenceNodeImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/reference/AbstractReferenceNodeImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/reference/CommentReferenceImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/reference/ElementReferenceImpl.java</exclude>
@@ -1080,6 +1130,7 @@
                                 <exclude>src/main/java/org/exist/dom/persistent/TextImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/VirtualNodeSet.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/XMLDeclarationImpl.java</exclude>
+                                <exclude>src/main/java/org/exist/dom/persistent/XMLUtil.java</exclude>
                                 <exclude>src/test/java/org/exist/http/AbstractHttpTest.java</exclude>
                                 <exclude>src/main/java/org/exist/http/Descriptor.java</exclude>
                                 <exclude>src/main/java/org/exist/http/RESTServer.java</exclude>
@@ -1121,12 +1172,15 @@
                                 <exclude>src/main/java/org/exist/resolver/XercesXmlResolverAdapter.java</exclude>
                                 <exclude>src/main/java/org/exist/scheduler/impl/QuartzSchedulerImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/security/EffectiveSubject.java</exclude>
+                                <exclude>src/test/java/org/exist/security/FnDocSecurityTest.java</exclude>
                                 <exclude>src/main/java/org/exist/security/SecurityManager.java</exclude>
                                 <exclude>src/main/java/org/exist/security/SimpleACLPermission.java</exclude>
+                                <exclude>src/test/java/org/exist/security/XqueryApiTest.java</exclude>
                                 <exclude>src/main/java/org/exist/security/internal/AccountImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/source/Source.java</exclude>
                                 <exclude>src/main/java/org/exist/source/SourceFactory.java</exclude>
                                 <exclude>src/test/java/org/exist/storage/AbstractRecoverTest.java</exclude>
+                                <exclude>src/test/java/org/exist/storage/BFileRecoverTest.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/BrokerFactory.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/BrokerPool.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/BrokerPoolService.java</exclude>
@@ -1134,9 +1188,10 @@
                                 <exclude>src/main/java/org/exist/storage/BrokerPoolServicesManager.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/BrokerPoolServicesManagerException.java</exclude>
                                 <exclude>src/test/java/org/exist/storage/BrokerPoolServiceTest.java</exclude>
+                                <exclude>src/test/java/org/exist/storage/CollectionTest.java</exclude>
                                 <exclude>src/test/java/org/exist/storage/CopyResourceTest.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/DBBroker.java</exclude>
-                                <exclude>src/main/java/org/exist/storage/FluentBrokerAPI.java</exclude>
+                                <exclude>src/test/java/org/exist/storage/DOMFileRecoverTest.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/FluentBrokerAPI.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/Indexable.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/IndexSpec.java</exclude>
@@ -1145,9 +1200,13 @@
                                 <exclude>src/main/java/org/exist/storage/ProcessMonitor.java</exclude>
                                 <exclude>src/test/java/org/exist/storage/RecoverBinaryTest.java</exclude>
                                 <exclude>src/test/java/org/exist/storage/RecoverXmlTest.java</exclude>
+                                <exclude>src/test/java/org/exist/storage/RecoveryTest.java</exclude>
+                                <exclude>src/test/java/org/exist/storage/RecoveryTest2.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/XQueryPool.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/blob/**</exclude>
                                 <exclude>src/test/java/org/exist/storage/blob/**</exclude>
+                                <exclude>src/test/java/org/exist/storage/btree/BTreeTest.java</exclude>
+                                <exclude>src/main/java/org/exist/storage/btree/TreeMetrics.java</exclude>
                                 <exclude>src/test/java/org/exist/storage/journal/AbstractJournalTest.java</exclude>
                                 <exclude>src/test/java/org/exist/storage/journal/JournalBinaryTest.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/journal/JournalManager.java</exclude>
@@ -1190,14 +1249,17 @@
                                 <exclude>src/main/java/org/exist/test/DiffMatcher.java</exclude>
                                 <exclude>src/main/java/org/exist/test/ExistXmldbEmbeddedServer.java</exclude>
                                 <exclude>src/test/java/org/exist/test/Util.java</exclude>
+                                <exclude>src/main/java/org/exist/test/runner/ExtTestFailureFunction.java</exclude>
                                 <exclude>src/main/java/org/exist/test/runner/XMLTestRunner.java</exclude>
                                 <exclude>src/main/java/org/exist/test/runner/XQueryTestRunner.java</exclude>
                                 <exclude>src/main/java/org/exist/test/runner/XSuite.java</exclude>
+                                <exclude>src/test/java/org/exist/util/AbstractXMLReaderSecurityTest.java</exclude>
                                 <exclude>src/main/java/org/exist/util/ByteOrderMark.java</exclude>
                                 <exclude>src/main/java/org/exist/util/Collations.java</exclude>
                                 <exclude>src/main/java/org/exist/util/CollectionOfArrayIterator.java</exclude>
                                 <exclude>src/test/java/org/exist/util/CollectionOfArrayIteratorTest.java</exclude>
                                 <exclude>src/main/java/org/exist/util/Configuration.java</exclude>
+                                <exclude>src/test/java/org/exist/util/DOMSerializerTest.java</exclude>
                                 <exclude>src/main/java/org/exist/util/IPUtil.java</exclude>
                                 <exclude>src/main/java/org/exist/util/JREUtil.java</exclude>
                                 <exclude>src/main/java/org/exist/util/MapUtil.java</exclude>
@@ -1209,21 +1271,37 @@
                                 <exclude>src/main/java/org/exist/util/serializer/AttrList.java</exclude>
                                 <exclude>src/main/java/org/exist/util/serializer/DOMStreamer.java</exclude>
                                 <exclude>src/main/java/org/exist/util/serializer/EXISerializer.java</exclude>
+                                <exclude>src/test/java/org/exist/util/serializer/HTML5WriterTest.java</exclude>
                                 <exclude>src/main/java/org/exist/util/serializer/SerializerObjectFactory.java</exclude>
+                                <exclude>src/main/java/org/exist/util/serializer/json/JSONObject.java</exclude>
+                                <exclude>src/test/java/org/exist/util/serializer/json/JSONObjectTest.java</exclude>
+                                <exclude>src/test/java/org/exist/util/serializer/json/JSONWriterTest.java</exclude>
                                 <exclude>src/test/resources/org/exist/validation/catalog.xml</exclude>
                                 <exclude>src/test/java/org/exist/validation/CollectionConfigurationValidationModeTest.java</exclude>
+                                <exclude>src/main/java/org/exist/validation/resolver/SearchResourceResolver.java</exclude>
                                 <exclude>src/test/java/org/exist/w3c/tests/TestCase.java</exclude>
                                 <exclude>src/main/java/org/exist/webstart/JnlpJarFiles.java</exclude>
+                                <exclude>src/test/java/org/exist/xmldb/ContentAsDOMTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xmldb/CreateCollectionsTest.java</exclude>
+                                <exclude>src/test/java/org/exist/xmldb/IndexingTest.java</exclude>
+                                <exclude>src/main/java/org/exist/xmldb/LocalResourceSet.java</exclude>
+                                <exclude>src/main/java/org/exist/xmldb/LocalXMLResource.java</exclude>
                                 <exclude>src/main/java/org/exist/xmldb/RemoteRestoreService.java</exclude>
+                                <exclude>src/test/java/org/exist/xmldb/ResourceTest.java</exclude>
+                                <exclude>src/test/java/org/exist/xmldb/TestEXistXMLSerialize.java</exclude>
+                                <exclude>src/test/java/org/exist/xmldb/concurrent/XMLGenerator.java</exclude>
                                 <exclude>src/main/java/org/exist/xmlrpc/ACEAiderParser.java</exclude>
                                 <exclude>src/main/java/org/exist/xmlrpc/ACEAiderSerializer.java</exclude>
                                 <exclude>src/main/java/org/exist/xmlrpc/ExistRpcTypeFactory.java</exclude>
+                                <exclude>src/main/java/org/exist/xmlrpc/RpcConnection.java</exclude>
                                 <exclude>src/main/java/org/exist/xqj/Marshaller.java</exclude>
+                                <exclude>src/test/java/org/exist/xqj/MarshallerTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/Cardinality.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/CastExpressionTest.java</exclude>
+                                <exclude>src/test/java/org/exist/xquery/ConstructedNodesRecoveryTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/DynamicTypeCheck.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/ErrorCodes.java</exclude>
+                                <exclude>src/test/java/org/exist/xquery/ForwardReferenceTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/FunctionFactory.java</exclude>
                                 <exclude>src/test/resources-filtered/org/exist/xquery/import-from-pkg-test.conf.xml</exclude>
                                 <exclude>src/test/java/org/exist/xquery/ImportFromPkgTest.java</exclude>
@@ -1234,6 +1312,7 @@
                                 <exclude>src/main/java/org/exist/xquery/Materializable.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/NameTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/Optimizer.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/PerformanceStatsImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/TryCatchExpression.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/UserDefinedFunction.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/WatchdogTest.java</exclude>
@@ -1248,7 +1327,9 @@
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FunDeepEqual.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FunDocAvailable.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FunParseIetfDate.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunSerialize.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FunTrace.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunUnparsedText.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FunUriCollection.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FunXmlToJson.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/fn/FunXmlToJsonTest.java</exclude>
@@ -1257,6 +1338,7 @@
                                 <exclude>src/test/java/org/exist/xquery/functions/fn/ParsingFunctionsTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/transform/Convert.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/fn/transform/ConvertTest.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/transform/Delivery.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/fn/transform/FunTransformITTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/transform/Options.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/transform/Transform.java</exclude>
@@ -1277,7 +1359,9 @@
                                 <exclude>src/main/java/org/exist/xquery/functions/util/DescribeFunction.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/util/Eval.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/util/FunctionFunction.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/util/LogFunction.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/util/ModuleInfo.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/validation/Jaxp.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/xmldb/AbstractXMLDBTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/xmldb/XMLDBAuthenticateTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/xmldb/XMLDBStore.java</exclude>
@@ -1287,6 +1371,7 @@
                                 <exclude>src/main/antlr/org/exist/xquery/parser/XQueryTree.g</exclude>
                                 <exclude>src/main/java/org/exist/xquery/pragmas/TimePragma.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/update/UpdateReplaceTest.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/util/ExpressionDumper.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/util/SerializerUtils.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/util/URIUtilsTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/AbstractDateTimeValue.java</exclude>
@@ -1304,6 +1389,7 @@
                                 <exclude>src/main/java/org/exist/xquery/value/Type.java</exclude>
                                 <exclude>src/main/java/org/exist/xslt/EXistURIResolver.java</exclude>
                                 <exclude>src/main/java/org/exist/xslt/XsltURIResolverHelper.java</exclude>
+                                <exclude>src/test/java/org/exist/xupdate/RemoveAppendTest.java</exclude>
 
                                 <!--
                                     Derivative work licensed under dbXML 1.0 and LGPL 2.1

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -828,6 +828,7 @@
                                 <include>src/main/java/org/exist/config/Configuration.java</include>
                                 <include>src/main/java/org/exist/config/ConfigurationImpl.java</include>
                                 <include>src/main/java/org/exist/config/Configurator.java</include>
+                                <include>src/main/java/org/exist/dom/NodeListImpl.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/AttrImpl.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/DocumentImpl.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/DOMIndexer.java</include>
@@ -1101,6 +1102,7 @@
                                 <exclude>src/main/java/org/exist/config/Configuration.java</exclude>
                                 <exclude>src/main/java/org/exist/config/ConfigurationImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/config/Configurator.java</exclude>
+                                <exclude>src/main/java/org/exist/dom/NodeListImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/AttrImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/DocumentImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/DocumentTypeImpl.java</exclude>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -935,6 +935,7 @@
                                 <include>src/main/java/org/exist/util/serializer/SerializerObjectFactory.java</include>
                                 <include>src/main/java/org/exist/util/serializer/json/JSONObject.java</include>
                                 <include>src/test/java/org/exist/util/serializer/json/JSONObjectTest.java</include>
+                                <include>src/main/java/org/exist/util/serializer/json/JSONSerializer.java</include>
                                 <include>src/test/java/org/exist/util/serializer/json/JSONWriterTest.java</include>
                                 <include>src/test/resources/org/exist/validation/catalog.xml</include>
                                 <include>src/test/java/org/exist/validation/CollectionConfigurationValidationModeTest.java</include>
@@ -1275,6 +1276,7 @@
                                 <exclude>src/main/java/org/exist/util/serializer/SerializerObjectFactory.java</exclude>
                                 <exclude>src/main/java/org/exist/util/serializer/json/JSONObject.java</exclude>
                                 <exclude>src/test/java/org/exist/util/serializer/json/JSONObjectTest.java</exclude>
+                                <exclude>src/main/java/org/exist/util/serializer/json/JSONSerializer.java</exclude>
                                 <exclude>src/test/java/org/exist/util/serializer/json/JSONWriterTest.java</exclude>
                                 <exclude>src/test/resources/org/exist/validation/catalog.xml</exclude>
                                 <exclude>src/test/java/org/exist/validation/CollectionConfigurationValidationModeTest.java</exclude>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -924,6 +924,7 @@
                                 <include>src/main/java/org/exist/xquery/ErrorCodes.java</include>
                                 <include>src/main/java/org/exist/xquery/FunctionFactory.java</include>
                                 <include>src/main/java/org/exist/xquery/Optimizer.java</include>
+                                <include>src/main/java/org/exist/xquery/TryCatchExpression.java</include>
                                 <include>src/main/java/org/exist/xquery/UserDefinedFunction.java</include>
                                 <include>src/main/java/org/exist/xquery/XPathUtil.java</include>
                                 <include>src/main/java/org/exist/xquery/XQueryContext.java</include>
@@ -1233,6 +1234,7 @@
                                 <exclude>src/main/java/org/exist/xquery/Materializable.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/NameTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/Optimizer.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/TryCatchExpression.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/UserDefinedFunction.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/WatchdogTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/XPathUtil.java</exclude>

--- a/exist-core/src/main/java/org/exist/backup/ZipWriter.java
+++ b/exist-core/src/main/java/org/exist/backup/ZipWriter.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -21,6 +45,8 @@
  */
 package org.exist.backup;
 
+import org.apache.commons.io.output.StringBuilderWriter;
+
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -38,7 +64,7 @@ public class ZipWriter implements BackupWriter
 {
     private String currentPath;
     private final ZipOutputStream out;
-    private StringWriter contents;
+    private StringBuilderWriter contents;
     private boolean dataWritten = false;
 
     public ZipWriter(final String zipFile, final String collection) throws IOException
@@ -53,9 +79,9 @@ public class ZipWriter implements BackupWriter
         currentPath = collection;
     }
 
-    public Writer newContents() throws IOException
+    public Writer newContents()
     {
-        contents = new StringWriter();
+        contents = new StringBuilderWriter();
         return( contents );
     }
 

--- a/exist-core/src/main/java/org/exist/client/ClientFrame.java
+++ b/exist-core/src/main/java/org/exist/client/ClientFrame.java
@@ -45,6 +45,7 @@
  */
 package org.exist.client;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.SystemProperties;
 import org.exist.backup.Backup;
 import org.exist.backup.CreateBackupDialog;
@@ -1750,16 +1751,17 @@ public class ClientFrame extends JFrame implements WindowFocusListener, KeyListe
         msgArea.setEditable(false);
         msgArea.setBackground(null);
         if (t != null) {
-            final StringWriter out = new StringWriter();
-            final PrintWriter writer = new PrintWriter(out);
-            t.printStackTrace(writer);
-            final JTextArea stacktrace = new JTextArea(out.toString(), 20, 50);
-            stacktrace.setBackground(null);
-            stacktrace.setEditable(false);
-            scroll = new JScrollPane(stacktrace);
-            scroll.setPreferredSize(new Dimension(250, 300));
-            scroll.setBorder(BorderFactory
+            try (final StringBuilderWriter out = new StringBuilderWriter();
+                 final PrintWriter writer = new PrintWriter(out)) {
+                t.printStackTrace(writer);
+                final JTextArea stacktrace = new JTextArea(out.toString(), 20, 50);
+                stacktrace.setBackground(null);
+                stacktrace.setEditable(false);
+                scroll = new JScrollPane(stacktrace);
+                scroll.setPreferredSize(new Dimension(250, 300));
+                scroll.setBorder(BorderFactory
                     .createTitledBorder(Messages.getString("ClientFrame.215"))); //$NON-NLS-1$
+            }
         }
         final JOptionPane optionPane = new JOptionPane();
         optionPane.setMessage(new Object[]{msgArea, scroll});
@@ -1783,7 +1785,7 @@ public class ClientFrame extends JFrame implements WindowFocusListener, KeyListe
 
         JScrollPane scrollStacktrace = null;
         if (t != null) {
-            try (final StringWriter out = new StringWriter();
+            try (final StringBuilderWriter out = new StringBuilderWriter();
                  final PrintWriter writer = new PrintWriter(out)) {
                 t.printStackTrace(writer);
                 final JTextArea stacktrace = new JTextArea(out.toString(), 20, 50);
@@ -1795,8 +1797,6 @@ public class ClientFrame extends JFrame implements WindowFocusListener, KeyListe
                 scrollStacktrace.setPreferredSize(new Dimension(600, 300));
                 scrollStacktrace.setBorder(BorderFactory
                         .createTitledBorder(Messages.getString("ClientFrame.218"))); //$NON-NLS-1$
-            } catch (final IOException ioe) {
-                ioe.printStackTrace();
             }
         }
 

--- a/exist-core/src/main/java/org/exist/client/DocumentView.java
+++ b/exist-core/src/main/java/org/exist/client/DocumentView.java
@@ -83,6 +83,7 @@ import javax.swing.KeyStroke;
 import javax.swing.border.BevelBorder;
 import javax.xml.transform.OutputKeys;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.security.Account;
 import org.exist.storage.ElementIndex;
 import org.exist.util.ProgressIndicator;
@@ -186,16 +187,17 @@ class DocumentView extends JFrame {
         msgArea.setEditable(false);
         msgArea.setBackground(null);
         if (t != null) {
-            final StringWriter out = new StringWriter();
-            final PrintWriter writer = new PrintWriter(out);
-            t.printStackTrace(writer);
-            final JTextArea stacktrace = new JTextArea(out.toString(), 20, 50);
-            stacktrace.setBackground(null);
-            stacktrace.setEditable(false);
-            scroll = new JScrollPane(stacktrace);
-            scroll.setPreferredSize(new Dimension(250, 300));
-            scroll.setBorder(BorderFactory
+            try (final StringBuilderWriter out = new StringBuilderWriter();
+                 final PrintWriter writer = new PrintWriter(out)) {
+                t.printStackTrace(writer);
+                final JTextArea stacktrace = new JTextArea(out.toString(), 20, 50);
+                stacktrace.setBackground(null);
+                stacktrace.setEditable(false);
+                scroll = new JScrollPane(stacktrace);
+                scroll.setPreferredSize(new Dimension(250, 300));
+                scroll.setBorder(BorderFactory
                     .createTitledBorder("Exception Stacktrace:")); //$NON-NLS-1$
+            }
         }
         final JOptionPane optionPane = new JOptionPane();
         optionPane.setMessage(new Object[]{msgArea, scroll});

--- a/exist-core/src/main/java/org/exist/client/QueryDialog.java
+++ b/exist-core/src/main/java/org/exist/client/QueryDialog.java
@@ -86,6 +86,7 @@ import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.PopupMenuListener;
 import javax.xml.transform.OutputKeys;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.security.PermissionDeniedException;
 import org.exist.util.Holder;
 import org.exist.xmldb.EXistXQueryService;
@@ -538,9 +539,10 @@ public class QueryDialog extends JFrame {
             tCompiled = t1 - t0;
 
             // In this way we can see the parsed structure meanwhile the query is
-            final StringWriter writer = new StringWriter();
-            service.dump(compiled, writer);
-            exprDisplay.setText(writer.toString());
+            try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+                service.dump(compiled, writer);
+                exprDisplay.setText(writer.toString());
+            }
             resultTabs.setSelectedComponent(exprDisplayScrollPane);
 
             statusMessage.setText(Messages.getString(QUERY_DIALOG_COMPILATION) + ": " + tCompiled + "ms");
@@ -610,9 +612,10 @@ public class QueryDialog extends JFrame {
                 tCompiled = t1 - t0;
 
                 // In this way we can see the parsed structure meanwhile the query is
-                StringWriter writer = new StringWriter();
-                service.dump(compiled, writer);
-                exprDisplay.setText(writer.toString());
+                try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+                    service.dump(compiled, writer);
+                    exprDisplay.setText(writer.toString());
+                }
 
                 result = service.execute(compiled);
                 tResult = System.currentTimeMillis() - t1;
@@ -623,9 +626,10 @@ public class QueryDialog extends JFrame {
                 }
 
                 // jmfg: Is this still needed? I don't think so
-                writer = new StringWriter();
-                service.dump(compiled, writer);
-                exprDisplay.setText(writer.toString());
+                try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+                    service.dump(compiled, writer);
+                    exprDisplay.setText(writer.toString());
+                }
 
                 statusMessage.setText(Messages.getString("QueryDialog.retrievingmessage"));
                 final int howmany = count.getNumber().intValue();

--- a/exist-core/src/main/java/org/exist/config/Configurator.java
+++ b/exist-core/src/main/java/org/exist/config/Configurator.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -47,6 +71,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.Database;
@@ -1267,22 +1292,20 @@ public class Configurator {
     protected static final Set<FullXmldbURI> saving = new ConcurrentSkipListSet<>();
 
     public static DocumentImpl save(final Configurable instance, final DBBroker broker, final Collection collection, final XmldbURI uri) throws IOException, ConfigurationException {
-        
-        final StringWriter writer = new StringWriter();
-        final SAXSerializer serializer = new SAXSerializer(writer, null);
-        
-        try {
+        final String data;
+        try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+            final SAXSerializer serializer = new SAXSerializer(writer, null);
+
             serializer.startDocument();
             serialize(instance, serializer);
             serializer.endDocument();
-            
+
+            data = writer.toString();
+            if (data == null || data.isEmpty()) {
+                return null;
+            }
         } catch (final SAXException saxe) {
             throw new ConfigurationException(saxe.getMessage(), saxe);
-        }
-        
-        final String data = writer.toString();
-        if (data == null || data.length() == 0) {
-            return null;
         }
         
         FullXmldbURI fullURI = null;

--- a/exist-core/src/main/java/org/exist/dom/NodeListImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/NodeListImpl.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -47,6 +71,26 @@ public class NodeListImpl extends ArrayList<Node> implements NodeList {
     }
 
     /**
+     * Add all elements of the other NodeListImpl to
+     * this NodeListImpl.
+     *
+     * @param other NodeListImpl to add.
+     *
+     * @return true if the list was modified, false otherwise.
+     */
+    public boolean addAll(final NodeListImpl other) {
+        if (other == null) {
+            return false;
+        }
+
+        if (other.isEmpty()) {
+            return false;
+        }
+
+        return addAll((ArrayList<Node>) other);
+    }
+
+    /**
      * Add all elements of the other NodeList to
      * this NodeList
      * @param other NodeList to add
@@ -54,18 +98,26 @@ public class NodeListImpl extends ArrayList<Node> implements NodeList {
      *   if none or only some were added.
      */
     public boolean addAll(final NodeList other) {
+        if (other == null) {
+            return false;
+        }
+
+        if (other instanceof NodeListImpl) {
+            return addAll((NodeListImpl) other);
+        }
+
         if (other.getLength() == 0) {
             return false;
-        } else {
-            boolean result = true;
-            for(int i = 0; i < other.getLength(); i++) {
-                if(!add(other.item(i))) {
-                    result = false;
-                    break;
-                }
-            }
-            return result;
         }
+
+        boolean result = true;
+        for (int i = 0; i < other.getLength(); i++) {
+            if (!add(other.item(i))) {
+                result = false;
+                break;
+            }
+        }
+        return result;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/dom/memtree/AbstractCharacterData.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/AbstractCharacterData.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -278,11 +302,6 @@ public abstract class AbstractCharacterData extends NodeImpl implements Characte
     @Override
     public String getStringValue() {
         return getData();
-    }
-
-    @Override
-    public Node getFirstChild() {
-        return null;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/dom/memtree/AttrImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/AttrImpl.java
@@ -99,11 +99,6 @@ public class AttrImpl extends NodeImpl implements Attr {
     }
 
     @Override
-    public Node getFirstChild() {
-        return null;
-    }
-
-    @Override
     public Node getPreviousSibling() {
         return null;
     }

--- a/exist-core/src/main/java/org/exist/dom/memtree/DocumentImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/DocumentImpl.java
@@ -584,7 +584,8 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
 
     private NodeImpl referenceFromNodeProxy(final int nodeNum, final NodeProxy nodeProxy) {
         final NodeImpl<?> node;
-        switch (nodeProxy.getNodeType()) {
+        final int nodeType = nodeProxy.getNodeType();
+        switch (nodeType) {
             case Node.ELEMENT_NODE:
                 node = new ElementReferenceImpl(getExpression(), this, nodeNum, nodeProxy);
                 break;
@@ -651,7 +652,7 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
 
     @Override
     public Node getFirstChild() {
-        if(size > 1) {
+        if (size > 1) {
             return getNode(1);
         }
         return null;
@@ -706,9 +707,10 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
 
         final short level = treeLevel[nodeNumber];
         final int nextNode = nodeNumber + 1;
-        if((nextNode < size) && (treeLevel[nextNode] > level)) {
+        if ((nextNode < size) && (treeLevel[nextNode] > level)) {
             return nextNode;
         }
+
         return -1;
     }
 

--- a/exist-core/src/main/java/org/exist/dom/memtree/DocumentImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/DocumentImpl.java
@@ -660,7 +660,17 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
 
     @Override
     public Node getLastChild() {
-        return getFirstChild();
+        if (size > 1) {
+            int nodeNum = 1;
+            for (; nodeNum < size; nodeNum++) {
+                if (treeLevel[nodeNum] > 1) {
+                   nodeNum--;
+                   break;
+                }
+            }
+            return getNode(nodeNum);
+        }
+        return null;
     }
 
     public int getAttributesCountFor(final int nodeNumber) {

--- a/exist-core/src/main/java/org/exist/dom/memtree/ElementImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/ElementImpl.java
@@ -93,12 +93,12 @@ public class ElementImpl extends NodeImpl implements Element {
 
     @Override
     public Node getFirstChild() {
-        final short level = document.treeLevel[nodeNumber];
-        final int nextNode = nodeNumber + 1;
-        if(nextNode < document.size && document.treeLevel[nextNode] > level) {
-            return document.getNode(nextNode);
+        final int firstChildNodeNumber = document.getFirstChildFor(nodeNumber);
+        if (firstChildNodeNumber == -1) {
+            return null;
         }
-        return null;
+
+        return document.getNode(firstChildNodeNumber);
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/dom/memtree/NamespaceNode.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/NamespaceNode.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -76,11 +100,6 @@ public class NamespaceNode extends NodeImpl implements Attr {
 
     @Override
     public void setValue(final String value) throws DOMException {
-    }
-
-    @Override
-    public Node getFirstChild() {
-        return null;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/dom/memtree/ProcessingInstructionImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/ProcessingInstructionImpl.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -109,12 +133,6 @@ public class ProcessingInstructionImpl extends NodeImpl implements ProcessingIns
             baseURI = getOwnerDocument().getBaseURI();
         }
         return (baseURI);
-    }
-
-    @Override
-    public Node getFirstChild() {
-        //No child
-        return null;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/dom/memtree/reference/AbstractReferenceNodeImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/reference/AbstractReferenceNodeImpl.java
@@ -71,12 +71,20 @@ public abstract class AbstractReferenceNodeImpl<T extends AbstractReferenceNodeI
 
     @Override
     public String getNamespaceURI() {
-        return getProxiedNode().getNamespaceURI();
+        final QName qname = getNodeProxy().getQName();
+        if (qname == null) {
+            return null;
+        }
+        return qname.getNamespaceURI();
     }
 
     @Override
     public String getLocalName() {
-        return getProxiedNode().getLocalName();
+        final QName qname = getNodeProxy().getQName();
+        if (qname == null) {
+            return null;
+        }
+        return qname.getLocalPart();
     }
 
     @Override
@@ -158,11 +166,11 @@ public abstract class AbstractReferenceNodeImpl<T extends AbstractReferenceNodeI
 
     @Override
     public short getNodeType() {
-        return getProxiedNode().getNodeType();
+        return getNodeProxy().getNodeType();
     }
 
     @Override
     public QName getQName() {
-        return getProxiedNode().getQName();
+        return getNodeProxy().getQName();
     }
 }

--- a/exist-core/src/main/java/org/exist/dom/memtree/reference/ElementReferenceImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/reference/ElementReferenceImpl.java
@@ -51,7 +51,11 @@ public class ElementReferenceImpl extends AbstractReferenceNodeImpl<ElementRefer
 
     @Override
     public String getTagName() {
-        return getProxiedNode().getTagName();
+        final QName qname = getNodeProxy().getQName();
+        if (qname == null) {
+            return null;
+        }
+        return qname.getStringValue();
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/dom/persistent/DocumentImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/DocumentImpl.java
@@ -1046,9 +1046,9 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Resource, Do
     }
 
     /**
-     * The method <code>getFirstChildAddress</code>
+     * Get the address of the first child.
      *
-     * @return a <code>long</code> value
+     * @return the address of the first child.
      */
     @EnsureContainerLocked(mode=READ_LOCK)
     public long getFirstChildAddress() {
@@ -1058,6 +1058,37 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Resource, Do
         return childAddress[0];
     }
 
+    @Override
+    @EnsureContainerLocked(mode=READ_LOCK)
+    public Node getLastChild() {
+        if (children == 0) {
+            return null;
+        }
+        try (final DBBroker broker = pool.getBroker()) {
+            return broker.objectWith(getLastChildProxy());
+        } catch (final EXistException e) {
+            LOG.warn("Exception while inserting node: {}", e.getMessage(), e);
+        }
+        return null;
+    }
+
+    @EnsureContainerLocked(mode=READ_LOCK)
+    protected NodeProxy getLastChildProxy() {
+        return new NodeProxy(getExpression(), this, NodeId.ROOT_NODE, Node.ELEMENT_NODE, childAddress[children - 1]);
+    }
+
+    /**
+     * Get the address of the last child.
+     *
+     * @return the address of the last child.
+     */
+    @EnsureContainerLocked(mode=READ_LOCK)
+    public long getLastChildAddress() {
+        if (children == 0) {
+            return StoredNode.UNKNOWN_NODE_IMPL_ADDRESS;
+        }
+        return childAddress[children - 1];
+    }
 
     @Override
     public boolean hasChildNodes() {

--- a/exist-core/src/main/java/org/exist/dom/persistent/DocumentImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/DocumentImpl.java
@@ -1029,14 +1029,13 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Resource, Do
     @Override
     @EnsureContainerLocked(mode=READ_LOCK)
     public Node getFirstChild() {
-        if(children == 0) {
+        if (children == 0) {
             return null;
         }
-        try(final DBBroker broker = pool.getBroker()) {
-            return broker.objectWith(new NodeProxy(getExpression(), this, NodeId.DOCUMENT_NODE, childAddress[0]));
-        } catch(final EXistException e) {
+        try (final DBBroker broker = pool.getBroker()) {
+            return broker.objectWith(getFirstChildProxy());
+        } catch (final EXistException e) {
             LOG.warn("Exception while inserting node: {}", e.getMessage(), e);
-            //TODO : throw exception ?
         }
         return null;
     }
@@ -1069,14 +1068,18 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Resource, Do
     @EnsureContainerLocked(mode=READ_LOCK)
     public NodeList getChildNodes() {
         final org.exist.dom.NodeListImpl list = new org.exist.dom.NodeListImpl();
+
+        @Nullable final NodeProxy nodeProxy = children > 0 ? new NodeProxy(getExpression(), this, NodeId.DOCUMENT_NODE) : null;
         try (final DBBroker broker = pool.getBroker()) {
-            for(int i = 0; i < children; i++) {
-                final Node child = broker.objectWith(new NodeProxy(getExpression(), this, NodeId.DOCUMENT_NODE, childAddress[i]));
+            for (int i = 0; i < children; i++) {
+                nodeProxy.setInternalAddress(childAddress[i]);
+                final Node child = broker.objectWith(nodeProxy);
                 list.add(child);
             }
-        } catch(final EXistException e) {
+        } catch (final EXistException e) {
             LOG.warn("Exception while retrieving child nodes: {}", e.getMessage(), e);
         }
+
         return list;
     }
 
@@ -1397,7 +1400,7 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Resource, Do
     @Override
     public Element getDocumentElement() {
         try (final DBBroker broker = pool.getBroker()) {
-            final NodeProxy childNodeProxy = new NodeProxy(getExpression(), this, NodeId.DOCUMENT_NODE);
+            @Nullable final NodeProxy childNodeProxy = children > 0 ? new NodeProxy(getExpression(), this, NodeId.DOCUMENT_NODE) : null;
             for (int i = 0; i < children; i++) {
                 childNodeProxy.setInternalAddress(childAddress[i]);
                 final Node child = broker.objectWith(childNodeProxy);

--- a/exist-core/src/main/java/org/exist/dom/persistent/DocumentImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/DocumentImpl.java
@@ -793,12 +793,14 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Resource, Do
     }
 
     /**
-     * The method <code>getNode</code>
+     * Retrieve a node from the document
+     * by its nodeId
      *
-     * @param nodeId a <code>NodeId</code> value
-     * @return a <code>Node</code> value
+     * @param nodeId the nodeId of the node to find.
+     *
+     * @return the node, or null if it does not exist.
      */
-    public Node getNode(final NodeId nodeId) {
+    @Nullable Node getNode(final NodeId nodeId) {
         try(final DBBroker broker = pool.getBroker()) {
             return broker.objectWith(this, nodeId);
         } catch(final EXistException e) {
@@ -808,16 +810,21 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Resource, Do
     }
 
     /**
-     * The method <code>getNode</code>
+     * Retrieve a node from the document
+     * by its nodeProxy
      *
-     * @param p a <code>NodeProxy</code> value
-     * @return a <code>Node</code> value
+     * This should only be called from {@link NodeProxy#getNode()}.
+     *
+     * @param p the proxy of the node to find.
+     *
+     * @return the node, or null if it does not exist.
      */
-    public Node getNode(final NodeProxy p) {
-        if(p.getNodeId().getTreeLevel() == 1) {
-            return getDocumentElement();
+    Node getNode(final NodeProxy p) {
+        if (p.getNodeId() == NodeId.DOCUMENT_NODE || p.getNodeId().equals(NodeId.DOCUMENT_NODE)) {
+            return this;
         }
-        try(final DBBroker broker = pool.getBroker()) {
+
+        try (final DBBroker broker = pool.getBroker()) {
             return broker.objectWith(p);
         } catch(final Exception e) {
             LOG.warn("Error occurred while retrieving node: {}", e.getMessage(), e);

--- a/exist-core/src/main/java/org/exist/dom/persistent/DocumentImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/DocumentImpl.java
@@ -1062,7 +1062,7 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Resource, Do
     @EnsureContainerLocked(mode=READ_LOCK)
     public NodeList getChildNodes() {
         final org.exist.dom.NodeListImpl list = new org.exist.dom.NodeListImpl();
-        try(final DBBroker broker = pool.getBroker()) {
+        try (final DBBroker broker = pool.getBroker()) {
             for(int i = 0; i < children; i++) {
                 final Node child = broker.objectWith(new NodeProxy(getExpression(), this, NodeId.DOCUMENT_NODE, childAddress[i]));
                 list.add(child);
@@ -1604,8 +1604,9 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Resource, Do
 
     @Override
     public String toString() {
+        @Nullable final Element documentElement = getDocumentElement();
         return getURI() + " - <" +
-            (getDocumentElement() != null ? getDocumentElement().getNodeName() : null) + ">";
+            (documentElement != null ? documentElement.getNodeName() : null) + ">";
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/dom/persistent/DocumentImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/DocumentImpl.java
@@ -1389,12 +1389,19 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Resource, Do
      */
     @Override
     public Element getDocumentElement() {
-        final NodeList cl = getChildNodes();
-        for(int i = 0; i < cl.getLength(); i++) {
-            if(cl.item(i).getNodeType() == Node.ELEMENT_NODE) {
-                return (Element) cl.item(i);
+        try (final DBBroker broker = pool.getBroker()) {
+            final NodeProxy childNodeProxy = new NodeProxy(getExpression(), this, NodeId.DOCUMENT_NODE);
+            for (int i = 0; i < children; i++) {
+                childNodeProxy.setInternalAddress(childAddress[i]);
+                final Node child = broker.objectWith(childNodeProxy);
+                if (child.getNodeType() == Node.ELEMENT_NODE) {
+                    return (Element) child;
+                }
             }
+        } catch(final EXistException e) {
+            LOG.warn("Exception while retrieving document element: {}", e.getMessage(), e);
         }
+
         return null;
     }
 

--- a/exist-core/src/main/java/org/exist/dom/persistent/ElementImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/ElementImpl.java
@@ -1108,7 +1108,7 @@ public class ElementImpl extends NamedNode<ElementImpl> implements Element {
         Node node = null;
         if (!isDirty) {
             final NodeId child = nodeId.getChild(children);
-            node = ownerDocument.getNode(new NodeProxy(getExpression(), ownerDocument, child));
+            node = new NodeProxy(getExpression(), ownerDocument, child).getNode();
         }
         if (node == null) {
             final NodeList cl;

--- a/exist-core/src/main/java/org/exist/dom/persistent/NodeProxy.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NodeProxy.java
@@ -236,8 +236,8 @@ public class NodeProxy implements NodeSet, NodeValue, NodeHandle, DocumentSet, C
     public void update(final ElementImpl element) {
         invalidateCachedNode();
         this.doc = element.getOwnerDocument();
-        this.nodeType = UNKNOWN_NODE_TYPE;
-        this.internalAddress = StoredNode.UNKNOWN_NODE_IMPL_ADDRESS;
+        this.nodeType = Node.ELEMENT_NODE;
+        this.internalAddress = element.getInternalAddress();
         this.nodeId = element.getNodeId();
         this.match = null;
         this.context = null;

--- a/exist-core/src/main/java/org/exist/dom/persistent/NodeProxy.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NodeProxy.java
@@ -319,7 +319,7 @@ public class NodeProxy implements NodeSet, NodeValue, NodeHandle, DocumentSet, C
         return qname;
     }
 
-    public void setQName(QName qname) {
+    public void setQName(final QName qname) {
         this.qname = qname;
     }
 

--- a/exist-core/src/main/java/org/exist/dom/persistent/NodeProxy.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NodeProxy.java
@@ -290,8 +290,16 @@ public class NodeProxy implements NodeSet, NodeValue, NodeHandle, DocumentSet, C
         final DocumentImpl doc = node instanceof DocumentImpl ? (DocumentImpl) node : (DocumentImpl) node.getOwnerDocument();
         expression = expression != null ? expression : doc.getExpression();
 
-        final NodeProxy wrapper = new NodeProxy(expression, doc, node.getNodeId(), node.getNodeType());
+        final long address;
+        if (node instanceof StoredNode<?>) {
+            address = ((StoredNode<?>) node).getInternalAddress();
+        } else {
+            address = StoredNode.UNKNOWN_NODE_IMPL_ADDRESS;
+        }
+
+        final NodeProxy wrapper = new NodeProxy(expression, doc, node.getNodeId(), node.getNodeType(), address);
         wrapper.cachedNode = new WeakReference<>(node);
+        wrapper.qname = node.getQName();
 
         return wrapper;
     }

--- a/exist-core/src/main/java/org/exist/dom/persistent/SortedNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/SortedNodeSet.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -196,7 +220,7 @@ public class SortedNodeSet extends AbstractNodeSet {
     @Override
     public Node item(final int pos) {
         final NodeProxy p = ((IteratorItem) list.get(pos)).proxy;
-        return p == null ? null : p.getOwnerDocument().getNode(p);
+        return p == null ? null : p.getNode();
     }
 
     //TODO : evaluate both semantics (item/itemAt)

--- a/exist-core/src/main/java/org/exist/dom/persistent/XMLUtil.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/XMLUtil.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -21,6 +45,7 @@
  */
 package org.exist.dom.persistent;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -32,7 +57,6 @@ import org.xml.sax.InputSource;
 import javax.xml.transform.TransformerException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringWriter;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -52,14 +76,14 @@ public final class XMLUtil {
     }
 
     public static final String dump(final DocumentFragment fragment) {
-        final StringWriter writer = new StringWriter();
-        final DOMSerializer serializer = new DOMSerializer(writer, null);
-        try {
+        try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+            final DOMSerializer serializer = new DOMSerializer(writer, null);
             serializer.serialize(fragment);
+            return writer.toString();
         } catch(final TransformerException e) {
             //Nothing to do ?
         }
-        return writer.toString();
+        return null;
     }
 
     public static final String encodeAttrMarkup(final String str) {

--- a/exist-core/src/main/java/org/exist/http/RESTServer.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServer.java
@@ -45,6 +45,7 @@
  */
 package org.exist.http;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.EXistException;
@@ -1301,15 +1302,16 @@ public class RESTServer {
 
         final InputStream is = request.getInputStream();
         final Reader reader = new InputStreamReader(is, encoding);
-        final StringWriter content = new StringWriter();
-        final char ch[] = new char[4096];
-        int len = 0;
-        while ((len = reader.read(ch)) > -1) {
-            content.write(ch, 0, len);
-        }
+        try (final StringBuilderWriter content = new StringBuilderWriter()) {
+            final char ch[] = new char[4096];
+            int len = 0;
+            while ((len = reader.read(ch)) > -1) {
+                content.write(ch, 0, len);
+            }
 
-        final String xml = content.toString();
-        return xml;
+            final String xml = content.toString();
+            return xml;
+        }
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/http/RESTServer.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServer.java
@@ -2236,7 +2236,7 @@ public class RESTServer {
         outputProperties.setProperty(Serializer.GENERATE_DOC_EVENTS, "false");
         try {
             serializer.setProperties(outputProperties);
-            try (Writer writer = new OutputStreamWriter(response.getOutputStream(), getEncoding(outputProperties))) {
+            try (final Writer writer = new OutputStreamWriter(response.getOutputStream(), getEncoding(outputProperties))) {
                 final JSONObject root = new JSONObject();
                 root.addObject(new JSONSimpleProperty("start", Integer.toString(start), true));
                 root.addObject(new JSONSimpleProperty("count", Integer.toString(howmany), true));
@@ -2251,24 +2251,29 @@ public class RESTServer {
                 final JSONObject data = new JSONObject("data");
                 root.addObject(data);
 
-                Item item;
-                for (int i = --start; i < start + howmany; i++) {
-                    item = results.itemAt(i);
-                    if (Type.subTypeOf(item.getType(), Type.NODE)) {
-                        final NodeValue value = (NodeValue) item;
-                        JSONValue json;
-                        if ("json".equals(outputProperties.getProperty("method", "xml"))) {
-                            json = new JSONValue(serializer.serialize(value), false);
-                            json.setSerializationDataType(JSONNode.SerializationDataType.AS_LITERAL);
+                try (final StringBuilderWriter sbWriter = new StringBuilderWriter()) {
+                    for (int i = --start; i < start + howmany; i++) {
+                        final Item item = results.itemAt(i);
+                        if (Type.subTypeOf(item.getType(), Type.NODE)) {
+                            final NodeValue value = (NodeValue) item;
+                            sbWriter.getBuilder().setLength(0);
+                            serializer.serialize(value, sbWriter);
+
+                            final JSONValue json;
+                            if ("json".equals(outputProperties.getProperty("method", "xml"))) {
+                                json = new JSONValue(sbWriter.toString(), false);
+                                json.setSerializationDataType(JSONNode.SerializationDataType.AS_LITERAL);
+                            } else {
+                                json = new JSONValue(sbWriter.toString());
+                                json.setSerializationType(JSONNode.SerializationType.AS_ARRAY);
+                            }
+
+                            data.addObject(json);
                         } else {
-                            json = new JSONValue(serializer.serialize(value));
+                            final JSONValue json = new JSONValue(item.getStringValue());
                             json.setSerializationType(JSONNode.SerializationType.AS_ARRAY);
+                            data.addObject(json);
                         }
-                        data.addObject(json);
-                    } else {
-                        final JSONValue json = new JSONValue(item.getStringValue());
-                        json.setSerializationType(JSONNode.SerializationType.AS_ARRAY);
-                        data.addObject(json);
                     }
                 }
 

--- a/exist-core/src/main/java/org/exist/indexing/IndexController.java
+++ b/exist-core/src/main/java/org/exist/indexing/IndexController.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -225,7 +249,7 @@ public class IndexController {
 
         setReindexing(true);
         try {
-            final IStoredNode<? extends IStoredNode> node = broker.objectWith(new NodeProxy(null, reindexRoot.getOwnerDocument(), reindexRoot.getNodeId()));
+            final IStoredNode<? extends IStoredNode> node = broker.objectWith(new NodeProxy(null, reindexRoot.getOwnerDocument(), reindexRoot.getNodeId(), reindexRoot.getInternalAddress()));
             listener = getStreamListener(node.getOwnerDocument(), mode);
             listener.startIndexDocument(transaction);
             try {

--- a/exist-core/src/main/java/org/exist/management/client/JMXtoXML.java
+++ b/exist-core/src/main/java/org/exist/management/client/JMXtoXML.java
@@ -46,7 +46,6 @@
 package org.exist.management.client;
 
 import java.io.IOException;
-import java.io.StringWriter;
 
 import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
 import static java.lang.management.ManagementFactory.CLASS_LOADING_MXBEAN_NAME;
@@ -71,6 +70,7 @@ import javax.xml.transform.OutputKeys;
 import javax.xml.transform.TransformerException;
 
 import com.evolvedbinary.j8fu.tuple.Tuple2;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
@@ -208,10 +208,11 @@ public class JMXtoXML {
      */
     public String generateReport(final String categories[]) throws TransformerException {
         final Element root = generateXMLReport(null, categories);
-        final StringWriter writer = new StringWriter();
-        final DOMSerializer streamer = new DOMSerializer(writer, defaultProperties);
-        streamer.serialize(root);
-        return writer.toString();
+        try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+            final DOMSerializer streamer = new DOMSerializer(writer, defaultProperties);
+            streamer.serialize(root);
+            return writer.toString();
+        }
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/management/impl/Database.java
+++ b/exist-core/src/main/java/org/exist/management/impl/Database.java
@@ -45,12 +45,12 @@
  */
 package org.exist.management.impl;
 
-import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 
@@ -151,11 +151,14 @@ public class Database implements DatabaseMXBean {
 
     public String printStackTrace(final Thread thread) {
         final StackTraceElement[] stackElements = thread.getStackTrace();
-        final StringWriter writer = new StringWriter();
-        final int showItems = stackElements.length > 20 ? 20 : stackElements.length;
-        for (int i = 0; i < showItems; i++) {
-            writer.append(stackElements[i].toString()).append('\n');
+        try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+            final int showItems = stackElements.length > 20 ? 20 : stackElements.length;
+            for (int i = 0; i < showItems; i++) {
+                writer.append(stackElements[i].toString());
+                writer.append('\n');
+
+            }
+            return writer.toString();
         }
-        return writer.toString();
     }
 }

--- a/exist-core/src/main/java/org/exist/repo/Deployment.java
+++ b/exist-core/src/main/java/org/exist/repo/Deployment.java
@@ -849,7 +849,7 @@ public class Deployment {
                             storeBinary(broker, transaction, targetCollection, file, mime, name, permission);
                         } else {
                             // could neither store as xml nor binary: give up and report failure in outer catch
-                            throw new EXistException(FileUtils.fileName(file) + " cannot be stored");
+                            throw new EXistException(FileUtils.fileName(file) + " cannot be stored", e);
                         }
                     }
                 } catch (final SAXException | EXistException | PermissionDeniedException | LockException | IOException e) {

--- a/exist-core/src/main/java/org/exist/storage/BrokerPool.java
+++ b/exist-core/src/main/java/org/exist/storage/BrokerPool.java
@@ -49,6 +49,7 @@ import com.evolvedbinary.j8fu.fsm.AtomicFSM;
 import com.evolvedbinary.j8fu.fsm.FSM;
 import com.evolvedbinary.j8fu.lazy.AtomicLazyVal;
 import net.jcip.annotations.ThreadSafe;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.Database;
@@ -98,7 +99,6 @@ import org.exist.xquery.XQuery;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.lang.ref.Reference;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
@@ -1864,7 +1864,7 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
     }
 
     public void printSystemInfo() {
-        try(final StringWriter sout = new StringWriter();
+        try(final StringBuilderWriter sout = new StringBuilderWriter();
             final PrintWriter writer = new PrintWriter(sout)) {
 
             writer.println("SYSTEM INFO");
@@ -1875,8 +1875,6 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
             final String s = sout.toString();
             LOG.info(s);
             System.err.println(s);
-        } catch(final IOException e) {
-            LOG.error(e);
         }
     }
 

--- a/exist-core/src/main/java/org/exist/storage/btree/BTree.java
+++ b/exist-core/src/main/java/org/exist/storage/btree/BTree.java
@@ -72,6 +72,7 @@
  */
 package org.exist.storage.btree;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -810,14 +811,13 @@ public class BTree extends Paged implements Lockable {
         if (!node.page.getPageHeader().getLsn().equals(Lsn.LSN_INVALID) && requiresRedo(loggable, node.page)) {
             if (loggable.idx > node.ptrs.length) {
                 LOG.warn("{}; loggable.idx = {}; node.ptrs.length = {}", node.page.getPageInfo(), loggable.idx, node.ptrs.length);
-                final StringWriter writer = new StringWriter();
-                try {
+                try (final StringBuilderWriter writer = new StringBuilderWriter()) {
                     dump(writer);
+                    LOG.warn(writer.toString());
                 } catch (final Exception e) {
                     LOG.warn(e);
                     e.printStackTrace();
                 }
-                LOG.warn(writer.toString());
                 throw new LogException("Critical error during recovery");
             }
             node.ptrs[loggable.idx] = loggable.pointer;
@@ -1687,14 +1687,14 @@ public class BTree extends Paged implements Lockable {
 
         @Override
         public String toString() {
-            final StringWriter writer = new StringWriter();
-            try {
+            try (final StringBuilderWriter writer = new StringBuilderWriter()) {
                 dump(writer);
+                return writer.toString();
             } catch (final Exception e) {
                 LOG.error(e);
                 //TODO : add something here ! -pb
             }
-            return writer.toString();
+            return null;
         }
 
         private void treeStatistics(final TreeMetrics metrics) throws IOException {

--- a/exist-core/src/main/java/org/exist/storage/btree/TreeMetrics.java
+++ b/exist-core/src/main/java/org/exist/storage/btree/TreeMetrics.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -21,8 +45,9 @@
  */
 package org.exist.storage.btree;
 
+import org.apache.commons.io.output.StringBuilderWriter;
+
 import java.io.PrintWriter;
-import java.io.StringWriter;
 
 /**
  *
@@ -65,10 +90,12 @@ public class TreeMetrics {
     }
 
     public void toLogger() {
-        final StringWriter sw = new StringWriter();
-        final PrintWriter writer = new PrintWriter(sw);
-        print(writer);
-        if (BTree.LOG.isDebugEnabled())
-            {BTree.LOG.debug(sw.toString());}
+        try (final StringBuilderWriter sw = new StringBuilderWriter();
+             final PrintWriter writer = new PrintWriter(sw)) {
+            print(writer);
+            if (BTree.LOG.isDebugEnabled()) {
+                BTree.LOG.debug(sw.toString());
+            }
+        }
     }
 }

--- a/exist-core/src/main/java/org/exist/storage/serializers/Serializer.java
+++ b/exist-core/src/main/java/org/exist/storage/serializers/Serializer.java
@@ -46,7 +46,6 @@
 package org.exist.storage.serializers;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.io.Writer;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -69,11 +68,11 @@ import javax.xml.transform.stream.StreamSource;
 
 import com.evolvedbinary.j8fu.lazy.LazyVal;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.Namespaces;
 import org.exist.dom.persistent.DocumentImpl;
-import org.exist.dom.persistent.DocumentTypeImpl;
 import org.exist.dom.persistent.NodeProxy;
 import org.exist.dom.QName;
 import org.exist.dom.persistent.XMLUtil;
@@ -476,23 +475,46 @@ public abstract class Serializer implements XMLReader {
         this.documentStarted = false;
     }
 
+    /**
+     * Serialize a Document.
+     * Note if you have multiple documents to serialize, you may instead
+     * prefer to call {@link #serialize(DocumentImpl, Writer)} and reuse
+     * the writer for each call after clearing its buffer.
+     *
+     * @param doc the document to serialize.
+     *
+     * @return the serialized representation.
+     *
+     * @throws SAXException if an error occurs during serialization.
+     */
     public String serialize(final DocumentImpl doc) throws SAXException {
-        final StringWriter writer = new StringWriter();
-        serialize(doc, writer);
-        return writer.toString();
+        try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+            serialize(doc, writer);
+            return writer.toString();
+        }
     }
 
     /**
-     * Serialize a document to the supplied writer.
+     * Serialize a Document to the supplied writer.
      *
-     * @param doc    the document
-     * @param writer the output writer
-     * @throws SAXException if an error occurs during serialization
+     * @param doc the document to serialize.
+     * @param writer the output writer.
+     *
+     * @throws SAXException if an error occurs during serialization.
      */
     public void serialize(final DocumentImpl doc, final Writer writer) throws SAXException {
         serialize(doc, writer, true);
     }
 
+    /**
+     * Serialize a Document to the supplied Writer.
+     *
+     * @param doc the document to serialize.
+     * @param writer the output writer.
+     * @param prepareStylesheet true if stylesheets should be prepared, false otherwise.
+     *
+     * @throws SAXException if an error occurs during serialization.
+     */
     public void serialize(final DocumentImpl doc, final Writer writer, final boolean prepareStylesheet) throws SAXException {
         if (prepareStylesheet) {
             try {
@@ -519,17 +541,47 @@ public abstract class Serializer implements XMLReader {
         }
     }
 
+    /**
+     * Serialize a Node.
+     * Note if you have multiple node to serialize, you may instead
+     * prefer to call {@link #serialize(DocumentImpl, Writer)} and reuse
+     * the writer for each call after clearing its buffer.
+     *
+     * @param n the node to serialize.
+     *
+     * @return the serialized representation.
+     *
+     * @throws SAXException if an error occurs during serialization.
+     */
     public String serialize(final NodeValue n) throws SAXException {
-        final StringWriter out = new StringWriter();
-        serialize(n, out);
-        return out.toString();
+        try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+            serialize(n, writer);
+            return writer.toString();
+        }
     }
 
-    public void serialize(final NodeValue n, final Writer out) throws SAXException {
-        serialize(n, out, true);
+    /**
+     * Serialize a Node to the supplied Writer.
+     *
+     * @param n the node to serialize.
+     * @param writer the output writer.
+     *
+     * @throws SAXException if an error occurs during serialization.
+     */
+    public void serialize(final NodeValue n, final Writer writer) throws SAXException {
+        serialize(n, writer, true);
     }
 
-    public void serialize(final NodeValue n, final Writer out, final boolean prepareStylesheet) throws SAXException {
+    /**
+     * Serialize a Node to the supplied Writer.
+     *
+     * @param n the node to serialize.
+     * @param writer the output writer.
+     * @param prepareStylesheet true if stylesheets should be prepared, false otherwise.
+     *
+     * @throws SAXException if an error occurs during serialization.
+     */
+    public void serialize(final NodeValue n, final Writer writer, final boolean prepareStylesheet) throws SAXException {
         final Document doc;
         if (n.getItemType() == Type.DOCUMENT && !(n instanceof NodeProxy)) {
             doc = (Document) n;
@@ -547,10 +599,10 @@ public abstract class Serializer implements XMLReader {
 
         final SAXSerializer prettyPrinter;
         if (templates != null) {
-            applyXSLHandler(out);
+            applyXSLHandler(writer);
             prettyPrinter = null;
         } else {
-            prettyPrinter = setPrettyPrinter(out, "no".equals(outputProperties.getProperty(OutputKeys.OMIT_XML_DECLARATION, "yes")),
+            prettyPrinter = setPrettyPrinter(writer, "no".equals(outputProperties.getProperty(OutputKeys.OMIT_XML_DECLARATION, "yes")),
                     n.getImplementationType() == NodeValue.PERSISTENT_NODE ? (NodeProxy) n : null, false);
         }
 
@@ -564,26 +616,49 @@ public abstract class Serializer implements XMLReader {
     }
 
     /**
-     * Serialize a single NodeProxy.
+     * Serialize a Node.
+     * Note if you have multiple node to serialize, you may instead
+     * prefer to call {@link #serialize(DocumentImpl, Writer)} and reuse
+     * the writer for each call after clearing its buffer.
      *
-     * @param p the node proxy
-     * @return the serialized result
-     * @throws SAXException if a SAX error occurs
+     * @param n the node to serialize.
+     *
+     * @return the serialized representation.
+     *
+     * @throws SAXException if an error occurs during serialization.
      */
-    public String serialize(final NodeProxy p) throws SAXException {
-        final StringWriter out = new StringWriter();
-        serialize(p, out);
-        return out.toString();
+    public String serialize(final NodeProxy n) throws SAXException {
+        try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+            serialize(n, writer);
+            return writer.toString();
+        }
     }
 
-    public void serialize(final NodeProxy p, final Writer out) throws SAXException {
-        serialize(p, out, true);
+    /**
+     * Serialize a Node to the supplied Writer.
+     *
+     * @param n the node to serialize.
+     * @param writer the output writer.
+     *
+     * @throws SAXException if an error occurs during serialization.
+     */
+    public void serialize(final NodeProxy n, final Writer writer) throws SAXException {
+        serialize(n, writer, true);
     }
 
-    public void serialize(final NodeProxy p, final Writer out, final boolean prepareStylesheet) throws SAXException {
+    /**
+     * Serialize a Node to the supplied Writer.
+     *
+     * @param n the node to serialize.
+     * @param writer the output writer.
+     * @param prepareStylesheet true if stylesheets should be prepared, false otherwise.
+     *
+     * @throws SAXException if an error occurs during serialization.
+     */
+    public void serialize(final NodeProxy n, final Writer writer, final boolean prepareStylesheet) throws SAXException {
         if (prepareStylesheet) {
             try {
-                prepareStylesheets(p.getOwnerDocument());
+                prepareStylesheets(n.getOwnerDocument());
             } catch (final TransformerConfigurationException e) {
                 throw new SAXException(e.getMessage(), e);
             }
@@ -591,14 +666,14 @@ public abstract class Serializer implements XMLReader {
 
         final SAXSerializer prettyPrinter;
         if (templates != null) {
-            applyXSLHandler(out);
+            applyXSLHandler(writer);
             prettyPrinter = null;
         } else {
-            prettyPrinter = setPrettyPrinter(out, "no".equals(outputProperties.getProperty(OutputKeys.OMIT_XML_DECLARATION, "yes")), p, false);
+            prettyPrinter = setPrettyPrinter(writer, "no".equals(outputProperties.getProperty(OutputKeys.OMIT_XML_DECLARATION, "yes")), n, false);
         }
 
         try {
-            serializeToReceiver(p, false);
+            serializeToReceiver(n, false);
         } finally {
             if (prettyPrinter != null) {
                 releasePrettyPrinter(prettyPrinter);

--- a/exist-core/src/main/java/org/exist/test/runner/ExtTestFailureFunction.java
+++ b/exist-core/src/main/java/org/exist/test/runner/ExtTestFailureFunction.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -19,9 +43,9 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-
 package org.exist.test.runner;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.util.serializer.XQuerySerializer;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
@@ -38,7 +62,6 @@ import org.xml.sax.SAXException;
 
 import javax.xml.transform.OutputKeys;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Properties;
 
 import static org.exist.xquery.FunctionDSL.param;
@@ -117,16 +140,16 @@ public class ExtTestFailureFunction extends JUnitIntegrationFunction {
         }
     }
 
-    private String seqToString(final Sequence seq) throws IOException, XPathException, SAXException {
-        try(final StringWriter writer = new StringWriter()) {
+    private String seqToString(final Sequence seq) throws XPathException, SAXException {
+        try(final StringBuilderWriter writer = new StringBuilderWriter()) {
             final XQuerySerializer xquerySerializer = new XQuerySerializer(context.getBroker(), new Properties(), writer);
             xquerySerializer.serialize(seq);
             return writer.toString();
         }
     }
 
-    private String errorMapToString(final Sequence seqErrorMap) throws IOException, XPathException, SAXException {
-        try(final StringWriter writer = new StringWriter()) {
+    private String errorMapToString(final Sequence seqErrorMap) throws XPathException, SAXException {
+        try(final StringBuilderWriter writer = new StringBuilderWriter()) {
             final Properties properties = new Properties();
             properties.setProperty(OutputKeys.METHOD, "adaptive");
 

--- a/exist-core/src/main/java/org/exist/util/serializer/json/JSONObject.java
+++ b/exist-core/src/main/java/org/exist/util/serializer/json/JSONObject.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -22,8 +46,9 @@
 package org.exist.util.serializer.json;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.io.Writer;
+
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -200,12 +225,13 @@ public class JSONObject extends JSONNode {
 
     @Override
     public String toString() {
-        final StringWriter writer = new StringWriter();
-        try {
+
+        try (final StringBuilderWriter writer = new StringBuilderWriter()) {
             serialize(writer, false);
+            return writer.toString();
         } catch(final IOException e) {
             LOG.warn(e);
         }
-        return writer.toString();
+        return null;
     }
 }

--- a/exist-core/src/main/java/org/exist/util/serializer/json/JSONSerializer.java
+++ b/exist-core/src/main/java/org/exist/util/serializer/json/JSONSerializer.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -24,6 +48,7 @@ package org.exist.util.serializer.json;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import io.lacuna.bifurcan.IEntry;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.storage.DBBroker;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.storage.serializers.Serializer;
@@ -69,7 +94,11 @@ public class JSONSerializer {
             } else {
                 generator.disable(JsonGenerator.Feature.STRICT_DUPLICATE_DETECTION);
             }
-            serializeSequence(sequence, generator);
+
+            try (final StringBuilderWriter sbWriter = new StringBuilderWriter()) {
+                serializeSequence(sequence, generator, sbWriter);
+            }
+
             if ("yes".equals(outputProperties.getProperty(EXistOutputKeys.INSERT_FINAL_NEWLINE, "no"))) {
                 generator.writeRaw('\n');
             }
@@ -79,25 +108,25 @@ public class JSONSerializer {
         }
     }
 
-    private void serializeSequence(Sequence sequence, JsonGenerator generator) throws IOException, XPathException, SAXException {
+    private void serializeSequence(final Sequence sequence, final JsonGenerator generator, final StringBuilderWriter sbWriter) throws IOException, XPathException, SAXException {
         if (sequence.isEmpty()) {
             generator.writeNull();
         } else if (sequence.hasOne() && "no".equals(outputProperties.getProperty(EXistOutputKeys.JSON_ARRAY_OUTPUT, "no"))) {
-            serializeItem(sequence.itemAt(0), generator);
+            serializeItem(sequence.itemAt(0), generator, sbWriter);
         } else {
             generator.writeStartArray();
-            for (SequenceIterator i = sequence.iterate(); i.hasNext(); ) {
-                serializeItem(i.nextItem(), generator);
+            for (final SequenceIterator i = sequence.iterate(); i.hasNext(); ) {
+                serializeItem(i.nextItem(), generator, sbWriter);
             }
             generator.writeEndArray();
         }
     }
 
-    private void serializeItem(Item item, JsonGenerator generator) throws IOException, XPathException, SAXException {
+    private void serializeItem(final Item item, final JsonGenerator generator, final StringBuilderWriter sbWriter) throws IOException, XPathException, SAXException {
         if (item.getType() == Type.ARRAY_ITEM) {
-            serializeArray((ArrayType) item, generator);
+            serializeArray((ArrayType) item, generator, sbWriter);
         } else if (item.getType() == Type.MAP_ITEM) {
-            serializeMap((MapType) item, generator);
+            serializeMap((MapType) item, generator, sbWriter);
         } else if (Type.subTypeOf(item.getType(), Type.ANY_ATOMIC_TYPE)) {
             if (Type.subTypeOfUnion(item.getType(), Type.NUMERIC)) {
                 generator.writeNumber(item.getStringValue());
@@ -112,11 +141,11 @@ public class JSONSerializer {
                 }
             }
         } else if (Type.subTypeOf(item.getType(), Type.NODE)) {
-            serializeNode(item, generator);
+            serializeNode(item, generator, sbWriter);
         }
     }
 
-    private void serializeNode(Item item, JsonGenerator generator) throws SAXException {
+    private void serializeNode(final Item item, final JsonGenerator generator, final StringBuilderWriter sbWriter) throws SAXException {
         final Serializer serializer = broker.borrowSerializer();
         final Properties xmlOutput = new Properties();
         xmlOutput.setProperty(OutputKeys.METHOD, outputProperties.getProperty(EXistOutputKeys.JSON_NODE_OUTPUT_METHOD, "xml"));
@@ -124,7 +153,9 @@ public class JSONSerializer {
         xmlOutput.setProperty(OutputKeys.INDENT, outputProperties.getProperty(OutputKeys.INDENT, "no"));
         try {
             serializer.setProperties(xmlOutput);
-            generator.writeString(serializer.serialize((NodeValue)item));
+            sbWriter.getBuilder().setLength(0);
+            serializer.serialize((NodeValue) item, sbWriter);
+            generator.writeString(sbWriter.toString());
         } catch (IOException e) {
             throw new SAXException(e.getMessage(), e);
         } finally {
@@ -132,20 +163,20 @@ public class JSONSerializer {
         }
     }
 
-    private void serializeArray(ArrayType array, JsonGenerator generator) throws IOException, XPathException, SAXException {
+    private void serializeArray(final ArrayType array, final JsonGenerator generator, final StringBuilderWriter sbWriter) throws IOException, XPathException, SAXException {
         generator.writeStartArray();
         for (int i = 0; i < array.getSize(); i++) {
             final Sequence member = array.get(i);
-            serializeSequence(member, generator);
+            serializeSequence(member, generator, sbWriter);
         }
         generator.writeEndArray();
     }
 
-    private void serializeMap(MapType map, JsonGenerator generator) throws IOException, XPathException, SAXException {
+    private void serializeMap(final MapType map, final JsonGenerator generator, final StringBuilderWriter sbWriter) throws IOException, XPathException, SAXException {
         generator.writeStartObject();
         for (final IEntry<AtomicValue, Sequence> entry: map) {
             generator.writeFieldName(entry.key().getStringValue());
-            serializeSequence(entry.value(), generator);
+            serializeSequence(entry.value(), generator, sbWriter);
         }
         generator.writeEndObject();
     }

--- a/exist-core/src/main/java/org/exist/validation/resolver/SearchResourceResolver.java
+++ b/exist-core/src/main/java/org/exist/validation/resolver/SearchResourceResolver.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -19,19 +43,18 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-
 package org.exist.validation.resolver;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
-import java.io.StringWriter;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.Properties;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.xerces.xni.XMLResourceIdentifier;
@@ -202,7 +225,7 @@ public class SearchResourceResolver implements XMLEntityResolver {
             }
             final DocumentImpl doc = lockedDocument.getDocument();
 
-            try (final StringWriter stringWriter = new StringWriter()) {
+            try (final StringBuilderWriter stringWriter = new StringBuilderWriter()) {
                 final Properties outputProperties = new Properties();
                 outputProperties.setProperty(OutputKeys.METHOD, "XML");
                 outputProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");

--- a/exist-core/src/main/java/org/exist/xmldb/LocalResourceSet.java
+++ b/exist-core/src/main/java/org/exist/xmldb/LocalResourceSet.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -22,9 +46,9 @@
 package org.exist.xmldb;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.*;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.Namespaces;
@@ -124,9 +148,9 @@ public class LocalResourceSet extends AbstractLocal implements ResourceSet {
         return this.<Resource>withDb((broker, transaction) -> {
             final Serializer serializer = broker.borrowSerializer();
             final SAXSerializer handler = (SAXSerializer) SerializerPool.getInstance().borrowObject(SAXSerializer.class);
-            final StringWriter writer = new StringWriter();
-            handler.setOutput(writer, outputProperties);
-            try {
+            try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+                handler.setOutput(writer, outputProperties);
+
                 // configure the serializer
                 collection.setProperty(Serializer.GENERATE_DOC_EVENTS, "false");
                 serializer.setProperties(outputProperties);

--- a/exist-core/src/main/java/org/exist/xmldb/LocalXMLResource.java
+++ b/exist-core/src/main/java/org/exist/xmldb/LocalXMLResource.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -27,7 +51,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.io.StringWriter;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -45,6 +68,7 @@ import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.implementation.InvocationHandlerAdapter;
 import net.bytebuddy.matcher.ElementMatchers;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.dom.memtree.DocumentImpl;
 import org.exist.dom.memtree.NodeImpl;
 import org.exist.dom.persistent.NodeProxy;
@@ -120,7 +144,7 @@ public class LocalXMLResource extends AbstractEXistResource implements XMLResour
 
         // Case 1: content is an external DOM node
         else if (root != null && !(root instanceof NodeValue)) {
-            try(final StringWriter writer = new StringWriter()) {
+            try (final StringBuilderWriter writer = new StringBuilderWriter()) {
                 final DOMSerializer serializer = new DOMSerializer(writer, getProperties());
                 try {
                     serializer.serialize(root);
@@ -129,8 +153,6 @@ public class LocalXMLResource extends AbstractEXistResource implements XMLResour
                     throw new XMLDBException(ErrorCodes.INVALID_RESOURCE, e.getMessage(), e);
                 }
                 return content;
-            } catch(final IOException e) {
-                throw new XMLDBException(ErrorCodes.UNKNOWN_ERROR, e.getMessage(), e);
             }
 
         // Case 2: content is an atomic value
@@ -272,7 +294,7 @@ public class LocalXMLResource extends AbstractEXistResource implements XMLResour
             serializer.setProperties(getProperties());
             saxSerializer = (SAXSerializer) SerializerPool.getInstance().borrowObject(SAXSerializer.class);
 
-            try (final StringWriter writer = new StringWriter()) {
+            try (final StringBuilderWriter writer = new StringBuilderWriter()) {
                 saxSerializer.setOutput(writer, getProperties());
                 serializer.setSAXHandlers(saxSerializer, saxSerializer);
 
@@ -663,7 +685,7 @@ public class LocalXMLResource extends AbstractEXistResource implements XMLResour
         
     private class InternalXMLSerializer extends SAXSerializer {
         public InternalXMLSerializer() {
-            super(new StringWriter(), null);
+            super(new StringBuilderWriter(), null);
         }
 
         @Override

--- a/exist-core/src/main/java/org/exist/xmldb/LocalXMLResource.java
+++ b/exist-core/src/main/java/org/exist/xmldb/LocalXMLResource.java
@@ -327,7 +327,7 @@ public class LocalXMLResource extends AbstractEXistResource implements XMLResour
         } else {
             result = read((document, broker, transaction) -> {
                 if (proxy != null) {
-                    return document.getNode(proxy);
+                    return proxy.getNode();
                 } else {
                     // <frederic.glorieux@ajlsm.com> return a full to get root PI and comments
                     return document;

--- a/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
+++ b/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
@@ -48,6 +48,8 @@ package org.exist.xquery;
 import org.exist.Namespaces;
 import org.exist.dom.QName;
 
+import javax.annotation.Nullable;
+
 /**
  *
  * @author aretter
@@ -295,14 +297,14 @@ public class ErrorCodes {
     public static class ErrorCode {
 
         private final QName errorQName;
-        private final String description;
+        private @Nullable final String description;
 
-        public ErrorCode(String code, String description) {
+        public ErrorCode(final String code, @Nullable final String description) {
             this.errorQName = new QName(code, Namespaces.EXIST_XQUERY_XPATH_ERROR_NS, Namespaces.EXIST_XQUERY_XPATH_ERROR_PREFIX);
             this.description = description;
         }
 
-        public ErrorCode(QName errorQName, String description) {
+        public ErrorCode(final QName errorQName, final String description) {
             this.errorQName = errorQName;
             this.description = description;
         }
@@ -313,10 +315,10 @@ public class ErrorCodes {
 
         @Override
         public String toString() {
-            return "(" + errorQName.getNamespaceURI() + "#" + errorQName.getLocalPart() + "):" + description;
+            return "(" + errorQName.toString() + "): " + description;
         }
 
-        public String getDescription(){
+        public @Nullable String getDescription(){
             return description;
         }
     }
@@ -337,12 +339,21 @@ public class ErrorCodes {
 
     public static class JavaErrorCode extends ErrorCode {
 
-        public JavaErrorCode(final Throwable throwable) {
-            super(new QName(
-                        throwable.getClass().getName(),
-                        Namespaces.EXIST_JAVA_BINDING_NS,
-                        Namespaces.EXIST_JAVA_BINDING_NS_PREFIX),
-                  throwable.getMessage() != null ? throwable.getMessage() : throwable.getCause().getMessage());
+        private JavaErrorCode(final QName errorQName, @Nullable final String description) {
+            super(errorQName, description);
+        }
+
+        public static JavaErrorCode fromThrowable(final Throwable throwable) {
+            final QName errorQName = new QName(throwable.getClass().getName(), Namespaces.EXIST_JAVA_BINDING_NS, Namespaces.EXIST_JAVA_BINDING_NS_PREFIX);
+            @Nullable final String description;
+            if (throwable.getMessage() != null) {
+                description = throwable.getMessage();
+            } else if (throwable.getCause() != null) {
+                description = throwable.getCause().getMessage();
+            } else {
+                description = null;
+            }
+            return new JavaErrorCode(errorQName, description);
         }
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/JavaBinding.java
+++ b/exist-core/src/main/java/org/exist/xquery/JavaBinding.java
@@ -558,7 +558,7 @@ public class JavaBinding extends BasicFunction {
             return XPathUtil.javaObjectToXPath(javaResult, context, true, false, false, this);
 
         } catch (final IllegalAccessException | InvocationTargetException | InstantiationException | IllegalArgumentException e) {
-            throw new XPathException(this, new ErrorCodes.JavaErrorCode(e), e.getMessage());
+            throw new XPathException(this, ErrorCodes.JavaErrorCode.fromThrowable(e), e.getMessage());
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/PerformanceStatsImpl.java
+++ b/exist-core/src/main/java/org/exist/xquery/PerformanceStatsImpl.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -19,18 +43,17 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-
 package org.exist.xquery;
 
 import net.jcip.annotations.NotThreadSafe;
 import net.jcip.annotations.ThreadSafe;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.dom.QName;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.xml.sax.helpers.AttributesImpl;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.io.PrintWriter;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -338,17 +361,14 @@ public class PerformanceStatsImpl implements PerformanceStats {
 
     @Override
     public String toString() {
-        try (final StringWriter sw = new StringWriter();
-            final PrintWriter pw = new PrintWriter(sw)) {
+        try (final StringBuilderWriter sw = new StringBuilderWriter();
+             final PrintWriter pw = new PrintWriter(sw)) {
             final FunctionStats[] stats = sort();
             for (final FunctionStats stat : stats) {
                 pw.format("\n%30s %8.3f %8d", stat.qname, stat.executionTime / 1000.0, stat.callCount);
             }
             pw.flush();
             return sw.toString();
-        } catch (final IOException e) {
-            // no-op
-            return "";
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/TryCatchExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/TryCatchExpression.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -166,7 +190,7 @@ public class TryCatchExpression extends AbstractExpression {
                 }
             } else {
                 // Get errorcode from all other errors and exceptions
-                errorCode = new JavaErrorCode(throwable);
+                errorCode = JavaErrorCode.fromThrowable(throwable);
             }
 
             // We need the qname in the end
@@ -414,7 +438,7 @@ public class TryCatchExpression extends AbstractExpression {
         }
 
         // Fallback, create java error
-        return new ErrorCodes.JavaErrorCode(retVal);
+        return JavaErrorCode.fromThrowable(retVal);
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/TryCatchExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/TryCatchExpression.java
@@ -47,11 +47,11 @@ package org.exist.xquery;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -515,7 +515,7 @@ public class TryCatchExpression extends AbstractExpression {
             return null;
         }
 
-        try(final StringWriter sw = new StringWriter();
+        try (final StringBuilderWriter sw = new StringBuilderWriter();
             final PrintWriter pw = new PrintWriter(sw)) {
 
             t.printStackTrace(pw);

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -21,6 +45,7 @@
  */
 package org.exist.xquery.functions.fn;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.dom.QName;
 import org.exist.dom.memtree.DocumentBuilderReceiver;
 import org.exist.dom.memtree.DocumentImpl;
@@ -35,8 +60,6 @@ import org.exist.xquery.value.*;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Properties;
 
 import static org.exist.Namespaces.XSLT_XQUERY_SERIALIZATION_NS;
@@ -80,7 +103,7 @@ public class FunSerialize extends BasicFunction {
             outputProperties = new Properties();
         }
 
-        try(final StringWriter writer = new StringWriter()) {
+        try (final StringBuilderWriter writer = new StringBuilderWriter()) {
             final XQuerySerializer xqSerializer = new XQuerySerializer(context.getBroker(), outputProperties, writer);
 
             final Sequence input = args[0];
@@ -94,7 +117,7 @@ public class FunSerialize extends BasicFunction {
             }
 
             return new StringValue(this, writer.toString());
-        } catch (final IOException | SAXException e) {
+        } catch (final SAXException e) {
             throw new XPathException(this, FnModule.SENR0001, e.getMessage());
         }
     }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunTrace.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunTrace.java
@@ -45,14 +45,13 @@
  */
 package org.exist.xquery.functions.fn;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.util.serializer.XQuerySerializer;
 import org.exist.xquery.*;
 import org.exist.xquery.value.*;
 import org.xml.sax.SAXException;
 
 import javax.xml.transform.OutputKeys;
-import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Properties;
 
 import static org.exist.util.StringUtil.notNullOrEmptyOrWs;
@@ -134,14 +133,14 @@ public Sequence eval(final Sequence[] args, final Sequence contextSequence) thro
 
                     position++;
 
-                    try (final StringWriter writer = new StringWriter()) {
+                    try (final StringBuilderWriter writer = new StringBuilderWriter()) {
                         final XQuerySerializer xqs = new XQuerySerializer(context.getBroker(), props, writer);
                         xqs.serialize(next.toSequence());
 
                         // Write to log
                         LOG.debug("{} [{}] [{}]: {}", label, position, Type.getTypeName(next.getType()), writer.toString());
 
-                    } catch (final IOException | SAXException e) {
+                    } catch (final SAXException e) {
                         throw new XPathException(this, e.getMessage());
                     }
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunUnparsedText.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunUnparsedText.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -22,6 +46,7 @@
 package org.exist.xquery.functions.fn;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.dom.QName;
 import org.exist.security.PermissionDeniedException;
 import org.exist.source.FileSource;
@@ -149,7 +174,7 @@ public class FunUnparsedText extends BasicFunction {
     private String readContent(final Source source, final String encoding) throws XPathException {
         try {
             final Charset charset = getCharset(encoding, source);
-            final StringWriter output = new StringWriter();
+            final StringBuilderWriter output = new StringBuilderWriter();
             try (final InputStream is = source.getInputStream()) {
                 // InputStream can have value NULL for data retrieved from URL
                 IOUtils.copy(is, output, charset);

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunXmlToJson.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunXmlToJson.java
@@ -46,6 +46,7 @@
 package org.exist.xquery.functions.fn;
 
 import com.fasterxml.jackson.core.*;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
@@ -56,7 +57,6 @@ import org.exist.xquery.value.*;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.io.Writer;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -102,10 +102,11 @@ public class FunXmlToJson extends BasicFunction {
                 throw new XPathException(this, ErrorCodes.FOJS0006, "Invalid XML representation of JSON.");
             }
             final NodeValue nodeValue = (NodeValue) item;
-            final StringWriter stringWriter = new StringWriter();
-            nodeValueToJson(nodeValue, stringWriter);
-            final String jsonString = stringWriter.toString();
-            result.add(new StringValue(this, jsonString));
+            try (final StringBuilderWriter stringWriter = new StringBuilderWriter()) {
+                nodeValueToJson(nodeValue, stringWriter);
+                final String jsonString = stringWriter.toString();
+                result.add(new StringValue(this, jsonString));
+            }
         }
         return result;
     }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/Delivery.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/Delivery.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -19,11 +43,11 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-
 package org.exist.xquery.functions.fn.transform;
 
 import net.sf.saxon.s9api.*;
 import net.sf.saxon.serialize.SerializationProperties;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.dom.memtree.DocumentBuilderReceiver;
 import org.exist.dom.memtree.DocumentImpl;
 import org.exist.dom.memtree.MemTreeBuilder;
@@ -32,7 +56,6 @@ import org.exist.xquery.XQueryContext;
 import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.StringValue;
 
-import java.io.StringWriter;
 import java.util.Objects;
 
 class Delivery {
@@ -47,7 +70,7 @@ class Delivery {
     final Format format;
     final SerializationProperties serializationProperties;
     MemTreeBuilder builder;
-    StringWriter stringWriter;
+    StringBuilderWriter stringWriter;
 
     RawDestination rawDestination;
 
@@ -77,7 +100,7 @@ class Delivery {
                                 serializationProperties);
 
                 serializer.setOutputProperties(combinedProperties);
-                stringWriter = new StringWriter();
+                stringWriter = new StringBuilderWriter();
                 serializer.setOutputWriter(stringWriter);
                 return serializer;
             case RAW:
@@ -93,7 +116,7 @@ class Delivery {
         if (stringWriter == null) {
             return null;
         }
-        return stringWriter.getBuffer().toString();
+        return stringWriter.toString();
     }
 
     private DocumentImpl getDocument() {

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/Eval.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/Eval.java
@@ -34,7 +34,6 @@ package org.exist.xquery.functions.util;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -45,6 +44,7 @@ import java.util.SimpleTimeZone;
 import javax.annotation.Nullable;
 import javax.xml.datatype.Duration;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.Namespaces;
 import org.exist.dom.persistent.BinaryDocument;
 import org.exist.dom.persistent.DocumentImpl;
@@ -396,7 +396,7 @@ public class Eval extends BasicFunction {
                     serializationProperties.putAll(xqueryOutputProperties);
 
                     // serialize the results
-                    try(final StringWriter writer = new StringWriter()) {
+                    try(final StringBuilderWriter writer = new StringBuilderWriter()) {
                         final XQuerySerializer xqSerializer = new XQuerySerializer(
                                 context.getBroker(), serializationProperties, writer);
 
@@ -412,7 +412,7 @@ public class Eval extends BasicFunction {
 
                         return new StringValue(this, writer.toString());
 
-                    } catch (final IOException | SAXException e) {
+                    } catch (final SAXException e) {
                         throw new XPathException(this, FnModule.SENR0001, e.getMessage());
                     }
                 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/LogFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/LogFunction.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -21,6 +45,7 @@
  */
 package org.exist.xquery.functions.util;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
@@ -30,8 +55,6 @@ import org.exist.xquery.value.*;
 import org.xml.sax.SAXException;
 
 import javax.xml.transform.OutputKeys;
-import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Properties;
 
 
@@ -143,12 +166,12 @@ public class LogFunction extends BasicFunction {
 
             } else {
                 // Serialize data
-                try (StringWriter writer = new StringWriter()) {
+                try (final StringBuilderWriter writer = new StringBuilderWriter()) {
                     XQuerySerializer xqs = new XQuerySerializer(context.getBroker(), props, writer);
                     xqs.serialize(next.toSequence());
                     buf.append(writer.toString());
 
-                } catch (IOException | SAXException e) {
+                } catch (final SAXException e) {
                     throw new XPathException(this, e.getMessage());
                 }
             }

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -23,7 +47,6 @@ package org.exist.xquery.functions.validation;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -45,6 +68,7 @@ import javax.xml.transform.stream.StreamSource;
 
 import com.evolvedbinary.j8fu.tuple.Tuple2;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.xerces.xni.parser.XMLEntityResolver;
 import org.exist.Namespaces;
 import org.exist.dom.QName;
@@ -395,7 +419,7 @@ public class Jaxp extends BasicFunction {
 
             final DocumentImpl doc = lockedDocument.getDocument();
 
-            try (final StringWriter stringWriter = new StringWriter()) {
+            try (final StringBuilderWriter stringWriter = new StringBuilderWriter()) {
                 final Properties outputProperties = new Properties();
                 outputProperties.setProperty(OutputKeys.METHOD, "XML");
                 outputProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBStore.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBStore.java
@@ -47,7 +47,6 @@ package org.exist.xquery.functions.xmldb;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -57,6 +56,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Properties;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -220,13 +220,11 @@ public class XMLDBStore extends XMLDBAbstractCollectionManipulator {
                             item.toSAX(context.getBroker(), handler, SERIALIZATION_PROPERTIES);
                             handler.endDocument();
                         } else {
-                            try (final StringWriter writer = new StringWriter()) {
+                            try (final StringBuilderWriter writer = new StringBuilderWriter()) {
                                 final SAXSerializer serializer = new SAXSerializer();
                                 serializer.setOutput(writer, null);
                                 item.toSAX(context.getBroker(), serializer, SERIALIZATION_PROPERTIES);
                                 resource.setContent(writer.toString());
-                            } catch (final IOException e) {
-                                LOGGER.error(e.getMessage(), e);
                             }
                         }
                     } else {

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBXUpdate.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBXUpdate.java
@@ -45,6 +45,7 @@
  */
 package org.exist.xquery.functions.xmldb;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -67,7 +68,6 @@ import org.xmldb.api.modules.XUpdateQueryService;
 
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.TransformerException;
-import java.io.StringWriter;
 import java.util.Properties;
 
 /**
@@ -102,17 +102,17 @@ public class XMLDBXUpdate extends XMLDBAbstractCollectionManipulator
 	public Sequence evalWithCollection(Collection c, Sequence[] args, Sequence contextSequence)
         throws XPathException {
 		final NodeValue data = (NodeValue) args[1].itemAt(0);
-		final StringWriter writer = new StringWriter();
-		final Properties properties = new Properties();
-		properties.setProperty(OutputKeys.INDENT, "yes");
-        final DOMSerializer serializer = new DOMSerializer(writer, properties);
-		try {
+		final String xupdate;
+		try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+			final Properties properties = new Properties();
+			properties.setProperty(OutputKeys.INDENT, "yes");
+			final DOMSerializer serializer = new DOMSerializer(writer, properties);
 			serializer.serialize(data.getNode());
+			xupdate = writer.toString();
 		} catch(final TransformerException e) {
 			logger.debug("Exception while serializing XUpdate document", e);
 			throw new XPathException(this, "Exception while serializing XUpdate document: " + e.getMessage(), e);
 		}
-		final String xupdate = writer.toString();
 
 		long modifications = 0;
 		try {

--- a/exist-core/src/main/java/org/exist/xquery/util/ExpressionDumper.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/ExpressionDumper.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -22,9 +46,9 @@
 package org.exist.xquery.util;
 
 import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.io.Writer;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.xquery.Expression;
 
 /**
@@ -34,13 +58,16 @@ public class ExpressionDumper {
 
     public final static int DEFAULT_INDENT_AMOUNT = 4;
     
-    public static String dump(Expression expr) {
-        if (expr == null)
-            {return "";}
-        final StringWriter writer = new StringWriter();
-        final ExpressionDumper dumper = new ExpressionDumper(writer);
-        expr.dump(dumper);
-        return writer.toString();
+    public static String dump(final Expression expr) {
+        if (expr == null) {
+            return "";
+        }
+
+        try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+            final ExpressionDumper dumper = new ExpressionDumper(writer);
+            expr.dump(dumper);
+            return writer.toString();
+        }
     }
     
     private PrintWriter out;

--- a/exist-core/src/test/java/org/exist/IndexerTest.java
+++ b/exist-core/src/test/java/org/exist/IndexerTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -22,11 +46,11 @@
 package org.exist;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Optional;
 import java.util.Properties;
 import javax.xml.transform.OutputKeys;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.collections.Collection;
 import org.exist.security.AuthenticationException;
 import org.exist.security.PermissionDeniedException;
@@ -193,7 +217,7 @@ public class IndexerTest {
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             final XQuery xquery = pool.getXQueryService();
             final Sequence result = xquery.execute(broker, typeXquery, null);
-            try(final StringWriter out = new StringWriter()) {
+            try(final StringBuilderWriter out = new StringBuilderWriter()) {
 				final Properties props = new Properties();
 				props.setProperty(OutputKeys.INDENT, "yes");
 				final SAXSerializer serializer = new SAXSerializer(out, props);

--- a/exist-core/src/test/java/org/exist/IndexerTest2.java
+++ b/exist-core/src/test/java/org/exist/IndexerTest2.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -22,11 +46,11 @@
 package org.exist;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Optional;
 import java.util.Properties;
 import javax.xml.transform.OutputKeys;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.collections.Collection;
 import org.exist.security.AuthenticationException;
 import org.exist.security.PermissionDeniedException;
@@ -109,7 +133,7 @@ public class IndexerTest2 {
     private String executeQuery() throws EXistException, PermissionDeniedException, SAXException, XPathException, IOException {
         final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
-                final StringWriter out = new StringWriter()) {
+                final StringBuilderWriter out = new StringBuilderWriter()) {
             final XQuery xquery = broker.getBrokerPool().getXQueryService();
             final Sequence result = xquery.execute(broker, XQUERY, null);
             final Properties props = new Properties();

--- a/exist-core/src/test/java/org/exist/IndexerTest3.java
+++ b/exist-core/src/test/java/org/exist/IndexerTest3.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -22,11 +46,11 @@
 package org.exist;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Optional;
 import java.util.Properties;
 import javax.xml.transform.OutputKeys;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.collections.Collection;
 import org.exist.security.AuthenticationException;
 import org.exist.security.PermissionDeniedException;
@@ -350,7 +374,7 @@ public class IndexerTest3 {
         store_suppress_type(type, typeXml);
         final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
-                final StringWriter out = new StringWriter()) {
+                final StringBuilderWriter out = new StringBuilderWriter()) {
             final XQuery xquery = pool.getXQueryService();
             final Sequence result = xquery.execute(broker, typeXquery, null);
             final Properties props = new Properties();

--- a/exist-core/src/test/java/org/exist/dom/memtree/DOMIndexerTest.java
+++ b/exist-core/src/test/java/org/exist/dom/memtree/DOMIndexerTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -22,12 +46,12 @@
 package org.exist.dom.memtree;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Optional;
 import java.util.Properties;
 import javax.xml.transform.OutputKeys;
 
 import com.googlecode.junittoolbox.ParallelRunner;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.EXistException;
 
 import org.exist.collections.Collection;
@@ -120,7 +144,7 @@ public class DOMIndexerTest {
     public void xQuery() throws EXistException, PermissionDeniedException, SAXException, XPathException, IOException {
         final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
-                final StringWriter out = new StringWriter()) {
+                final StringBuilderWriter out = new StringBuilderWriter()) {
             final XQuery xquery = pool.getXQueryService();
             final Sequence result = xquery.execute(broker, XQUERY, null);
             final int count = result.getItemCount();

--- a/exist-core/src/test/java/org/exist/dom/memtree/DOMTest.java
+++ b/exist-core/src/test/java/org/exist/dom/memtree/DOMTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -23,13 +47,13 @@ package org.exist.dom.memtree;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.io.StringWriter;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.TransformerException;
 
 import com.googlecode.junittoolbox.ParallelRunner;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.dom.QName;
 import org.exist.util.ExistSAXParserFactory;
 import org.exist.util.serializer.DOMSerializer;
@@ -71,10 +95,11 @@ public class DOMTest {
         Node node = doc.getFirstChild();
         assertNotNull(node);
 
-        StringWriter writer = new StringWriter();
-        DOMSerializer serializer = new DOMSerializer(writer, null);
-        serializer.serialize(node);
-        writer.toString();
+        try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+            DOMSerializer serializer = new DOMSerializer(writer, null);
+            serializer.serialize(node);
+            writer.toString();
+        }
     }
 
     @Test

--- a/exist-core/src/test/java/org/exist/dom/persistent/PersistentDomTest.java
+++ b/exist-core/src/test/java/org/exist/dom/persistent/PersistentDomTest.java
@@ -46,6 +46,7 @@
 package org.exist.dom.persistent;
 
 import com.evolvedbinary.j8fu.tuple.Tuple2;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.triggers.TriggerException;
@@ -82,7 +83,6 @@ import javax.annotation.Nullable;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Source;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -452,7 +452,7 @@ public class PersistentDomTest {
         // serialize the results to the response output stream
         final Serializer serializer = broker.borrowSerializer();
         SAXSerializer sax = null;
-        try(final StringWriter writer = new StringWriter()) {
+        try(final StringBuilderWriter writer = new StringBuilderWriter()) {
             sax = (SAXSerializer) SerializerPool.getInstance().borrowObject(
                     SAXSerializer.class);
 

--- a/exist-core/src/test/java/org/exist/security/FnDocSecurityTest.java
+++ b/exist-core/src/test/java/org/exist/security/FnDocSecurityTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -21,6 +45,7 @@
  */
 package org.exist.security;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.triggers.TriggerException;
@@ -47,7 +72,6 @@ import org.junit.Test;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -270,7 +294,7 @@ public class FnDocSecurityTest {
     }
 
     private String serialize(final DBBroker broker, final Sequence sequence) throws IOException, XPathException, SAXException {
-        try (final StringWriter writer = new StringWriter()) {
+        try (final StringBuilderWriter writer = new StringBuilderWriter()) {
             final XQuerySerializer serializer = new XQuerySerializer(broker, new Properties(), writer);
             serializer.serialize(sequence);
             return writer.toString();

--- a/exist-core/src/test/java/org/exist/security/XqueryApiTest.java
+++ b/exist-core/src/test/java/org/exist/security/XqueryApiTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -22,6 +46,7 @@
 package org.exist.security;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.EXistException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
@@ -33,8 +58,6 @@ import org.exist.xquery.value.Sequence;
 import org.junit.ClassRule;
 import org.xml.sax.SAXException;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -140,11 +163,11 @@ public class XqueryApiTest extends AbstractApiSecurityTest {
 
     private String serialize(final Sequence sequence) throws ApiException {
         try (final DBBroker broker = server.getBrokerPool().getBroker();
-             final StringWriter writer = new StringWriter()) {
+             final StringBuilderWriter writer = new StringBuilderWriter()) {
             final XQuerySerializer serializer = new XQuerySerializer(broker, new Properties(), writer);
             serializer.serialize(sequence);
             return writer.toString();
-        } catch (final EXistException | IOException | SAXException | XPathException e) {
+        } catch (final EXistException | SAXException | XPathException e) {
             throw new ApiException(e.getMessage(), e);
         }
     }

--- a/exist-core/src/test/java/org/exist/storage/BFileRecoverTest.java
+++ b/exist-core/src/test/java/org/exist/storage/BFileRecoverTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -22,10 +46,9 @@
 package org.exist.storage;
 
 import java.io.IOException;
-import java.io.StringWriter;
-import java.io.Writer;
 import java.util.Optional;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.EXistException;
 import org.exist.storage.btree.BTreeException;
 import org.exist.storage.btree.Value;
@@ -76,9 +99,10 @@ public class BFileRecoverTest {
                 }
                 mgr.commit(txn);
             }
-            
-            Writer writer = new StringWriter();
-            collectionsDb.dump(writer);
+
+            try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+                collectionsDb.dump(writer);
+            }
         }
     }
 
@@ -88,8 +112,9 @@ public class BFileRecoverTest {
         BrokerPool.FORCE_CORRUPTION = false;
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             BFile collectionsDb = (BFile)((NativeBroker)broker).getStorage(NativeBroker.COLLECTIONS_DBX_ID);
-            Writer writer = new StringWriter();
-            collectionsDb.dump(writer);
+            try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+                collectionsDb.dump(writer);
+            }
 
             for (int i = 1; i < 1001; i++) {
                 String key = "test" + i;

--- a/exist-core/src/test/java/org/exist/storage/CollectionTest.java
+++ b/exist-core/src/test/java/org/exist/storage/CollectionTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -22,11 +46,11 @@
 package org.exist.storage;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Iterator;
 import java.util.Optional;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.triggers.TriggerException;
@@ -86,8 +110,9 @@ public class CollectionTest {
     public void read(final BrokerPool pool) throws EXistException, IOException, PermissionDeniedException, BTreeException, DatabaseConfigurationException, LockException {
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             BTree btree = ((NativeBroker)broker).getStorage(NativeBroker.COLLECTIONS_DBX_ID);
-            Writer writer = new StringWriter();
-            btree.dump(writer);
+            try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+                btree.dump(writer);
+            }
 
             Collection test = broker.getCollection(TEST_COLLECTION_URI.append("test2"));
             assertNotNull(test);

--- a/exist-core/src/test/java/org/exist/storage/DOMFileRecoverTest.java
+++ b/exist-core/src/test/java/org/exist/storage/DOMFileRecoverTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -22,12 +46,12 @@
 package org.exist.storage;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.EXistException;
 import org.exist.numbering.NodeId;
 import org.exist.numbering.NodeIdFactory;
@@ -139,8 +163,9 @@ public class DOMFileRecoverTest {
             }
             pool.getJournalManager().get().flush(true, false);
 
-            Writer writer = new StringWriter();
-            domDb.dump(writer);
+            try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+                domDb.dump(writer);
+            }
 	    }
 	}
 
@@ -169,9 +194,10 @@ public class DOMFileRecoverTest {
                 Value value = domDb.get(key);
                 assertNotNull(value);
             }
-            
-            Writer writer = new StringWriter();
-            domDb.dump(writer);
+
+            try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+                domDb.dump(writer);
+            }
 	    }
     }
 }

--- a/exist-core/src/test/java/org/exist/storage/RecoveryTest.java
+++ b/exist-core/src/test/java/org/exist/storage/RecoveryTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -23,10 +47,9 @@ package org.exist.storage;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringWriter;
-import java.io.Writer;
 import java.util.Optional;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.dom.persistent.BinaryDocument;
@@ -207,7 +230,7 @@ public class RecoveryTest {
             
             final DOMFile domDb = ((NativeBroker)broker).getDOMFile();
             assertNotNull(domDb);
-            try(final Writer writer = new StringWriter()) {
+            try (final StringBuilderWriter writer = new StringBuilderWriter()) {
                 domDb.dump(writer);
             }
             

--- a/exist-core/src/test/java/org/exist/storage/RecoveryTest2.java
+++ b/exist-core/src/test/java/org/exist/storage/RecoveryTest2.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -22,13 +46,12 @@
 package org.exist.storage;
 
 import java.io.IOException;
-import java.io.StringWriter;
-import java.io.Writer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.dom.persistent.LockedDocument;
@@ -93,7 +116,7 @@ public class RecoveryTest2 {
 
             DOMFile domDb = ((NativeBroker) broker).getDOMFile();
             assertNotNull(domDb);
-            try(final Writer writer = new StringWriter()) {
+            try (final StringBuilderWriter writer = new StringBuilderWriter()) {
                 domDb.dump(writer);
             }
 

--- a/exist-core/src/test/java/org/exist/storage/XIncludeSerializerTest.java
+++ b/exist-core/src/test/java/org/exist/storage/XIncludeSerializerTest.java
@@ -289,12 +289,13 @@ public class XIncludeSerializerTest {
         connect.setRequestMethod("GET");
         connect.connect();
 
-        final BufferedReader reader = new BufferedReader(new InputStreamReader(connect.getInputStream(), "UTF-8"));
-        String line;
         final StringBuilder out = new StringBuilder();
-        while ((line = reader.readLine()) != null) {
-            out.append(line);
-            out.append("\r\n");
+        try (final BufferedReader reader = new BufferedReader(new InputStreamReader(connect.getInputStream(), "UTF-8"))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                out.append(line);
+                out.append("\r\n");
+            }
         }
         final String responseXML = out.toString();
     }

--- a/exist-core/src/test/java/org/exist/storage/btree/BTreeTest.java
+++ b/exist-core/src/test/java/org/exist/storage/btree/BTreeTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -21,6 +45,7 @@
  */
 package org.exist.storage.btree;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.EXistException;
 import org.exist.storage.BrokerPool;
 import org.exist.test.ExistEmbeddedServer;
@@ -34,7 +59,6 @@ import org.junit.rules.TemporaryFolder;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
@@ -104,7 +128,7 @@ public class BTreeTest {
 
             btree.flush();
 
-            try(final StringWriter writer = new StringWriter()) {
+            try (final StringBuilderWriter writer = new StringBuilderWriter()) {
                 btree.dump(writer);
             }
 

--- a/exist-core/src/test/java/org/exist/util/AbstractXMLReaderSecurityTest.java
+++ b/exist-core/src/test/java/org/exist/util/AbstractXMLReaderSecurityTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -22,6 +46,7 @@
 package org.exist.util;
 
 import com.evolvedbinary.j8fu.tuple.Tuple2;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.triggers.TriggerException;
@@ -41,7 +66,6 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -110,7 +134,7 @@ public abstract class AbstractXMLReaderSecurityTest {
         transformer.setOutputProperty(OutputKeys.INDENT, "no");
         transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
 
-        try(final StringWriter writer = new StringWriter()) {
+        try (final StringBuilderWriter writer = new StringBuilderWriter()) {
             final StreamResult result = new StreamResult(writer);
             final DOMSource source = new DOMSource(doc);
             transformer.transform(source, result);

--- a/exist-core/src/test/java/org/exist/util/DOMSerializerTest.java
+++ b/exist-core/src/test/java/org/exist/util/DOMSerializerTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -23,7 +47,6 @@ package org.exist.util;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringWriter;
 import java.net.URISyntaxException;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -31,6 +54,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.util.serializer.DOMSerializer;
 import org.junit.Test;
 import org.w3c.dom.Document;
@@ -56,7 +80,7 @@ public class DOMSerializerTest {
 		try (final InputStream is = SAMPLES.getBiblioSample()) {
 			Document doc = builder.parse(new InputSource(is));
 			assertNotNull(doc);
-			try (final StringWriter writer = new StringWriter()) {
+			try (final StringBuilderWriter writer = new StringBuilderWriter()) {
 				DOMSerializer serializer = new DOMSerializer(writer, null);
 				serializer.serialize(doc.getDocumentElement());
 			}

--- a/exist-core/src/test/java/org/exist/util/serializer/HTML5WriterTest.java
+++ b/exist-core/src/test/java/org/exist/util/serializer/HTML5WriterTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -21,8 +45,7 @@
  */
 package org.exist.util.serializer;
 
-import java.io.StringWriter;
-
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.dom.QName;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,11 +55,11 @@ import static org.junit.Assert.assertEquals;
 public class HTML5WriterTest {
 
     private HTML5Writer writer;
-    private StringWriter targetWriter;
+    private StringBuilderWriter targetWriter;
     
     @Before
     public void setUp() throws Exception {
-        targetWriter = new StringWriter();
+        targetWriter = new StringBuilderWriter();
         writer = new HTML5Writer(targetWriter);
     }
 

--- a/exist-core/src/test/java/org/exist/util/serializer/json/JSONObjectTest.java
+++ b/exist-core/src/test/java/org/exist/util/serializer/json/JSONObjectTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -22,7 +46,8 @@
 package org.exist.util.serializer.json;
 
 import java.io.IOException;
-import java.io.StringWriter;
+
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
@@ -38,7 +63,7 @@ public class JSONObjectTest {
         node.addObject(new JSONValue("adam"));
         root.addObject(node);
 
-        try(final StringWriter writer = new StringWriter()) {
+        try(final StringBuilderWriter writer = new StringBuilderWriter()) {
             root.serialize(writer, true);
             assertEquals("{\"hello\":\"adam\"}", writer.toString());
         }
@@ -53,7 +78,7 @@ public class JSONObjectTest {
         node.addObject(new JSONValue("adam"));
         root.addObject(node);
 
-        try(final StringWriter writer = new StringWriter()) {
+        try(final StringBuilderWriter writer = new StringBuilderWriter()) {
             root.serialize(writer, true);
             assertEquals("{ \"hello\" : \"adam\" }", writer.toString());
         }
@@ -68,7 +93,7 @@ public class JSONObjectTest {
         node.addObject(literalValue);
         root.addObject(node);
 
-        try(final StringWriter writer = new StringWriter()) {
+        try(final StringBuilderWriter writer = new StringBuilderWriter()) {
             root.serialize(writer, true);
             assertEquals("{\"hello\":1}", writer.toString());
         }
@@ -85,7 +110,7 @@ public class JSONObjectTest {
         node.addObject(literalValue);
         root.addObject(node);
 
-        try(final StringWriter writer = new StringWriter()) {
+        try(final StringBuilderWriter writer = new StringBuilderWriter()) {
             root.serialize(writer, true);
             assertEquals("{ \"hello\" : 1 }", writer.toString());
         }
@@ -103,7 +128,7 @@ public class JSONObjectTest {
         node2.addObject(new JSONValue("wolfgang"));
         root.addObject(node2);
 
-        try(final StringWriter writer = new StringWriter()) {
+        try(final StringBuilderWriter writer = new StringBuilderWriter()) {
             root.serialize(writer, true);
             assertEquals("{\"hello\":[\"adam\",\"wolfgang\"]}", writer.toString());
         }
@@ -124,7 +149,7 @@ public class JSONObjectTest {
         node2.addObject(new JSONValue("wolfgang"));
         root.addObject(node2);
 
-        try(final StringWriter writer = new StringWriter()) {
+        try(final StringBuilderWriter writer = new StringBuilderWriter()) {
             root.serialize(writer, true);
             assertEquals("{ \"hello\" : [\"adam\", \"wolfgang\"] }", writer.toString());
         }
@@ -146,7 +171,7 @@ public class JSONObjectTest {
         node2.addObject(literalValue2);
         root.addObject(node2);
 
-        try(final StringWriter writer = new StringWriter()) {
+        try(final StringBuilderWriter writer = new StringBuilderWriter()) {
             root.serialize(writer, true);
             assertEquals("{\"hello\":[1,2]}", writer.toString());
         }
@@ -171,7 +196,7 @@ public class JSONObjectTest {
         node2.addObject(literalValue2);
         root.addObject(node2);
 
-        try(final StringWriter writer = new StringWriter()) {
+        try(final StringBuilderWriter writer = new StringBuilderWriter()) {
             root.serialize(writer, true);
             assertEquals("{ \"hello\" : [1, 2] }", writer.toString());
         }
@@ -186,7 +211,7 @@ public class JSONObjectTest {
         node.addObject(new JSONValue("adam"));
         root.addObject(node);
 
-        try(final StringWriter writer = new StringWriter()) {
+        try(final StringBuilderWriter writer = new StringBuilderWriter()) {
             root.serialize(writer, true);
             assertEquals("{\"hello\":[\"adam\"]}", writer.toString());
         }
@@ -203,7 +228,7 @@ public class JSONObjectTest {
         node.addObject(new JSONValue("adam"));
         root.addObject(node);
 
-        try(final StringWriter writer = new StringWriter()) {
+        try(final StringBuilderWriter writer = new StringBuilderWriter()) {
             root.serialize(writer, true);
             assertEquals("{ \"hello\" : [\"adam\"] }", writer.toString());
         }
@@ -223,7 +248,7 @@ public class JSONObjectTest {
         node2.addObject(new JSONValue("wolfgang"));
         root.addObject(node2);
 
-        try (final StringWriter writer = new StringWriter()) {
+        try (final StringBuilderWriter writer = new StringBuilderWriter()) {
             root.serialize(writer, true);
             assertEquals("{\"hello\":[\"adam\",\"wolfgang\"]}", writer.toString());
         }
@@ -246,7 +271,7 @@ public class JSONObjectTest {
         node2.addObject(new JSONValue("wolfgang"));
         root.addObject(node2);
 
-        try (final StringWriter writer = new StringWriter()) {
+        try (final StringBuilderWriter writer = new StringBuilderWriter()) {
             root.serialize(writer, true);
             assertEquals("{ \"hello\" : [\"adam\", \"wolfgang\"] }", writer.toString());
         }
@@ -263,7 +288,7 @@ public class JSONObjectTest {
         node.addObject(value);
         root.addObject(node);
 
-        try(final StringWriter writer = new StringWriter()) {
+        try(final StringBuilderWriter writer = new StringBuilderWriter()) {
             root.serialize(writer, true);
             assertEquals("{\"intarray\":[1]}", writer.toString());
         }
@@ -282,7 +307,7 @@ public class JSONObjectTest {
         node.addObject(value);
         root.addObject(node);
 
-        try(final StringWriter writer = new StringWriter()) {
+        try(final StringBuilderWriter writer = new StringBuilderWriter()) {
             root.serialize(writer, true);
             assertEquals("{ \"intarray\" : [1] }", writer.toString());
         }
@@ -297,7 +322,7 @@ public class JSONObjectTest {
         value.setSerializationDataType(JSONNode.SerializationDataType.AS_LITERAL);
         root.addObject(value);
 
-        try(final StringWriter writer = new StringWriter()) {
+        try(final StringBuilderWriter writer = new StringBuilderWriter()) {
             root.serialize(writer, true);
             assertEquals("[1]", writer.toString());
         }
@@ -313,7 +338,7 @@ public class JSONObjectTest {
         value.setSerializationDataType(JSONNode.SerializationDataType.AS_LITERAL);
         root.addObject(value);
 
-        try(final StringWriter writer = new StringWriter()) {
+        try(final StringBuilderWriter writer = new StringBuilderWriter()) {
             root.serialize(writer, true);
             assertEquals("[1]", writer.toString());
         }

--- a/exist-core/src/test/java/org/exist/util/serializer/json/JSONWriterTest.java
+++ b/exist-core/src/test/java/org/exist/util/serializer/json/JSONWriterTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -19,9 +43,9 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-
 package org.exist.util.serializer.json;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
 import org.exist.util.serializer.SAXSerializer;
@@ -38,7 +62,6 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.sax.SAXResult;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringWriter;
 import java.util.Properties;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -75,7 +98,7 @@ public class JSONWriterTest {
         properties.setProperty(OutputKeys.INDENT, "no");
 
         final SAXSerializer serializer = new SAXSerializer();
-        try(final StringWriter writer = new StringWriter()) {
+        try(final StringBuilderWriter writer = new StringBuilderWriter()) {
             serializer.setOutput(writer, properties);
             final Transformer transformer = transformerFactory.newTransformer();
             final SAXResult saxResult = new SAXResult(serializer);
@@ -104,7 +127,7 @@ public class JSONWriterTest {
         properties.setProperty(OutputKeys.INDENT, "no");
 
         final SAXSerializer serializer = new SAXSerializer();
-        try(final StringWriter writer = new StringWriter()) {
+        try(final StringBuilderWriter writer = new StringBuilderWriter()) {
             serializer.setOutput(writer, properties);
             final Transformer transformer = transformerFactory.newTransformer();
             final SAXResult saxResult = new SAXResult(serializer);
@@ -130,7 +153,7 @@ public class JSONWriterTest {
         properties.setProperty(OutputKeys.INDENT, "no");
 
         final SAXSerializer serializer = new SAXSerializer();
-        try(final StringWriter writer = new StringWriter()) {
+        try(final StringBuilderWriter writer = new StringBuilderWriter()) {
             serializer.setOutput(writer, properties);
             final Transformer transformer = transformerFactory.newTransformer();
             final SAXResult saxResult = new SAXResult(serializer);
@@ -156,7 +179,7 @@ public class JSONWriterTest {
         properties.setProperty(OutputKeys.INDENT, "no");
 
         final SAXSerializer serializer = new SAXSerializer();
-        try(final StringWriter writer = new StringWriter()) {
+        try(final StringBuilderWriter writer = new StringBuilderWriter()) {
             serializer.setOutput(writer, properties);
             final Transformer transformer = transformerFactory.newTransformer();
             final SAXResult saxResult = new SAXResult(serializer);

--- a/exist-core/src/test/java/org/exist/w3c/tests/TestCase.java
+++ b/exist-core/src/test/java/org/exist/w3c/tests/TestCase.java
@@ -183,7 +183,7 @@ public abstract class TestCase {
 			for(SequenceIterator i = result.iterate(); i.hasNext(); ) {
 				Resource xmldbResource = getResource(i.nextItem());
 				
-//		        StringWriter writer = new StringWriter();
+//		        StringBuilderWriter writer = new StringBuilderWriter();
 //		        Properties outputProperties = new Properties();
 //		        outputProperties.setProperty("indent", "yes");
 //		        SAXSerializer serializer = new SAXSerializer(writer, outputProperties);

--- a/exist-core/src/test/java/org/exist/xmldb/ContentAsDOMTest.java
+++ b/exist-core/src/test/java/org/exist/xmldb/ContentAsDOMTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -22,6 +46,8 @@
 package org.exist.xmldb;
 
 import javax.xml.transform.TransformerException;
+
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.security.Permission;
 import org.exist.security.Account;
 import org.exist.test.ExistXmldbEmbeddedServer;
@@ -46,7 +72,6 @@ import org.xmldb.api.modules.XMLResource;
 import org.xmldb.api.modules.XQueryService;
 
 import java.io.IOException;
-import java.io.StringWriter;
 
 import static org.exist.TestUtils.*;
 
@@ -86,7 +111,7 @@ public class ContentAsDOMTest {
             t.setOutputProperty(OutputKeys.INDENT, "yes");
             t.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
             DOMSource source = new DOMSource(node);
-            try (final StringWriter writer = new StringWriter()) {
+            try (final StringBuilderWriter writer = new StringBuilderWriter()) {
                 StreamResult output = new StreamResult(writer);
                 t.transform(source, output);
             }

--- a/exist-core/src/test/java/org/exist/xmldb/IndexingTest.java
+++ b/exist-core/src/test/java/org/exist/xmldb/IndexingTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -23,7 +47,6 @@ package org.exist.xmldb;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.Random;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -34,6 +57,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.sax.SAXResult;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.test.ExistXmldbEmbeddedServer;
 import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
 import org.junit.Before;
@@ -299,7 +323,7 @@ public class IndexingTest {
     }
 
     class SAXHandler implements ContentHandler {
-        private final PrintWriter writer = new PrintWriter(new StringWriter());
+        private final PrintWriter writer = new PrintWriter(new StringBuilderWriter());
         SAXHandler() {
         }
 

--- a/exist-core/src/test/java/org/exist/xmldb/ResourceTest.java
+++ b/exist-core/src/test/java/org/exist/xmldb/ResourceTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -33,6 +57,7 @@ import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.OutputKeys;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.custommonkey.xmlunit.exceptions.XpathException;
 import org.exist.dom.QName;
 import org.exist.security.Account;
@@ -102,7 +127,7 @@ public class ResourceTest {
         final XMLResource doc = (XMLResource) testCollection.getResource(resources.get(0));
         assertNotNull(doc);
 
-        try(final StringWriter sout = new StringWriter()) {
+        try(final StringBuilderWriter sout = new StringBuilderWriter()) {
             final Properties outputProperties = new Properties();
             outputProperties.put(OutputKeys.METHOD, "xml");
             outputProperties.put(OutputKeys.ENCODING, "ISO-8859-1");
@@ -130,7 +155,7 @@ public class ResourceTest {
         final Collection testCollection = DatabaseManager.getCollection(XmldbURI.LOCAL_DB + "/" + TEST_COLLECTION);
         assertNotNull(testCollection);
 
-        try(final StringWriter sout = new StringWriter()) {
+        try(final StringBuilderWriter sout = new StringBuilderWriter()) {
             final Properties outputProperties = new Properties();
             outputProperties.put(OutputKeys.METHOD, "xml");
             outputProperties.put(OutputKeys.ENCODING, "UTF-8");
@@ -140,7 +165,7 @@ public class ResourceTest {
             final ContentHandler importHandler = new ImportingContentHandler(sout, outputProperties);
             resource1.getContentAsSAX(importHandler);
 
-            final String result = sout.getBuffer().toString();
+            final String result = sout.toString();
             assertEquals(
                     "<test>" +
                     "<title>Title</title>" +

--- a/exist-core/src/test/java/org/exist/xmldb/TestEXistXMLSerialize.java
+++ b/exist-core/src/test/java/org/exist/xmldb/TestEXistXMLSerialize.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -21,13 +45,13 @@
  */
 package org.exist.xmldb;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.security.Account;
 import org.exist.test.ExistXmldbEmbeddedServer;
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 import org.junit.ClassRule;
 import org.xmldb.api.modules.CollectionManagementService;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Paths;
@@ -174,11 +198,12 @@ public class TestEXistXMLSerialize {
         assertNotNull(resource);
         Node node = resource.getContentAsDOM();
 
-        StringWriter writer = new StringWriter();
-        Properties outputProperties = new Properties();
-        outputProperties.setProperty("indent", "yes");
-        DOMSerializer serializer = new DOMSerializer(writer, outputProperties);
-        serializer.serialize(node);
+        try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+            Properties outputProperties = new Properties();
+            outputProperties.setProperty("indent", "yes");
+            DOMSerializer serializer = new DOMSerializer(writer, outputProperties);
+            serializer.serialize(node);
+        }
     }
 
     @Test
@@ -195,11 +220,12 @@ public class TestEXistXMLSerialize {
         assertNotNull(resource);
         @SuppressWarnings("unused")
                 Node node = resource.getContentAsDOM();
-        StringWriter writer = new StringWriter();
-        Properties outputProperties = new Properties();
-        outputProperties.setProperty("indent", "yes");
-        SAXSerializer serializer = new SAXSerializer(writer, outputProperties);
-        resource.getContentAsSAX(serializer);
+        try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+            Properties outputProperties = new Properties();
+            outputProperties.setProperty("indent", "yes");
+            SAXSerializer serializer = new SAXSerializer(writer, outputProperties);
+            resource.getContentAsSAX(serializer);
+        }
     }
 
     @Test
@@ -218,8 +244,9 @@ public class TestEXistXMLSerialize {
         outputProperties.setProperty("indent", "yes");
         testCollection.setProperty("stylesheet", "test.xsl");
         testCollection.setProperty("stylesheet-param.testparam", "TEST");
-        StringWriter writer = new StringWriter();
-        SAXSerializer serializer = new SAXSerializer(writer, outputProperties);
-        resource.getContentAsSAX(serializer);
+        try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+            SAXSerializer serializer = new SAXSerializer(writer, outputProperties);
+            resource.getContentAsSAX(serializer);
+        }
     }
 }

--- a/exist-core/src/test/java/org/exist/xmldb/TreeLevelOrderTest.java
+++ b/exist-core/src/test/java/org/exist/xmldb/TreeLevelOrderTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -25,6 +49,8 @@ import org.exist.TestUtils;
 import org.exist.test.ExistXmldbEmbeddedServer;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.xmldb.api.base.*;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -32,6 +58,7 @@ import org.xmldb.api.modules.XMLResource;
 import org.xmldb.api.modules.XQueryService;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests the TreeLevelOrder function.
@@ -75,16 +102,18 @@ public class TreeLevelOrderTest {
         store(DOC1, DOC1_NAME);
 
         // read document back from database
-        Node elem = load(DOC1_NAME);
-        assertNotNull(elem);
+        final Node doc = load(DOC1_NAME);
+        assertNotNull(doc);
+        assertTrue(doc instanceof Document);
 
         //get node using DOM
         String strTo = null;
 
-        NodeList rootChildren = elem.getChildNodes();
-        for (int r = 0; r < rootChildren.getLength(); r++) {
-            if (rootChildren.item(r).getLocalName().equals("to")) {
-                Node to = rootChildren.item(r);
+        final Element elem = ((Document) doc).getDocumentElement();
+        final NodeList elemChildNodes = elem.getChildNodes();
+        for (int r = 0; r < elemChildNodes.getLength(); r++) {
+            if (elemChildNodes.item(r).getLocalName().equals("to")) {
+                final Node to = elemChildNodes.item(r);
                 strTo = to.getTextContent();
                 break;
             }

--- a/exist-core/src/test/java/org/exist/xmldb/concurrent/XMLGenerator.java
+++ b/exist-core/src/test/java/org/exist/xmldb/concurrent/XMLGenerator.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -21,8 +45,9 @@
  */
 package org.exist.xmldb.concurrent;
 
+import org.apache.commons.io.output.StringBuilderWriter;
+
 import java.io.IOException;
-import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Random;
 
@@ -58,9 +83,10 @@ public class XMLGenerator {
     }
     
     public String generateElement() throws IOException {
-        StringWriter writer = new StringWriter();
-        writeElement(writer, 0);
-        return writer.toString();
+        try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+            writeElement(writer, 0);
+            return writer.toString();
+        }
     }
     
     protected void writeElement(final Writer writer, final int level) throws IOException {

--- a/exist-core/src/test/java/org/exist/xquery/ConstructedNodesRecoveryTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/ConstructedNodesRecoveryTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -21,6 +45,7 @@
  */
 package org.exist.xquery;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.triggers.TriggerException;
@@ -50,7 +75,6 @@ import org.junit.After;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Optional;
 import java.util.Properties;
 import javax.xml.transform.OutputKeys;
@@ -171,10 +195,10 @@ public class ConstructedNodesRecoveryTest {
         }
 	}
 
-	private String serialize(final DBBroker broker, final DocumentImpl doc) throws IOException, SAXException {
+	private String serialize(final DBBroker broker, final DocumentImpl doc) throws SAXException {
 		final Serializer serializer = broker.borrowSerializer();
 		SAXSerializer sax = null;
-		try (final StringWriter writer = new StringWriter()) {
+		try (final StringBuilderWriter writer = new StringBuilderWriter()) {
 			sax = (SAXSerializer) SerializerPool.getInstance().borrowObject(SAXSerializer.class);
 
 			final Properties outputProperties = new Properties();

--- a/exist-core/src/test/java/org/exist/xquery/ForwardReferenceTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/ForwardReferenceTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -21,6 +45,7 @@
  */
 package org.exist.xquery;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.triggers.TriggerException;
@@ -42,7 +67,6 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -152,11 +176,11 @@ public class ForwardReferenceTest {
 
             final String xqSuiteXmlResult = withCompiledQuery(broker, testXquerySource, compiledQuery -> {
                 final Sequence result = executeQuery(broker, compiledQuery);
-                try (final StringWriter writer = new StringWriter()) {
+                try (final StringBuilderWriter writer = new StringBuilderWriter()) {
                     final XQuerySerializer xquerySerializer = new XQuerySerializer(broker, new Properties(), writer);
                     xquerySerializer.serialize(result);
                     return writer.toString();
-                } catch (final IOException | SAXException e) {
+                } catch (final SAXException e) {
                     throw new XPathException((Expression) null, e);
                 }
             });

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/DocTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/DocTest.java
@@ -65,6 +65,7 @@ import static org.junit.Assert.*;
 
 import org.exist.xmldb.EXistResource;
 import org.exist.xmldb.LocalXMLResource;
+import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
 import org.xml.sax.InputSource;
@@ -152,7 +153,8 @@ public class DocTest {
         LocalXMLResource res = (LocalXMLResource)result.getResource(0);
         assertNotNull(res);
         Node n = res.getContentAsDOM();
-        assertEquals("y", n.getLocalName());
+        assertTrue(n instanceof Document);
+        assertEquals("y", ((Document) n).getDocumentElement().getLocalName());
 
         query = "util:eval(xs:anyURI('/db/test/test1.xq'), false(), ())";
         result = existEmbeddedServer.executeQuery(query);
@@ -160,7 +162,8 @@ public class DocTest {
         res = (LocalXMLResource)result.getResource(0);
         assertNotNull(res);
         n = res.getContentAsDOM();
-        assertEquals("x", n.getLocalName());
+        assertTrue(n instanceof Document);
+        assertEquals("x", ((Document) n).getDocumentElement().getLocalName());
 
         query = "util:eval(xs:anyURI('/db/test/test2.xq'), false(), ())";
         result = existEmbeddedServer.executeQuery(query);
@@ -168,7 +171,8 @@ public class DocTest {
         res = (LocalXMLResource)result.getResource(0);
         assertNotNull(res);
         n = res.getContentAsDOM();
-        assertEquals("x", n.getLocalName());
+        assertTrue(n instanceof Document);
+        assertEquals("x", ((Document) n).getDocumentElement().getLocalName());
     }
 
     @Test

--- a/exist-core/src/test/java/org/exist/xupdate/RemoveAppendTest.java
+++ b/exist-core/src/test/java/org/exist/xupdate/RemoveAppendTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -22,10 +46,10 @@
 package org.exist.xupdate;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Random;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.EXistException;
 import org.exist.TestUtils;
 
@@ -107,27 +131,29 @@ public class RemoveAppendTest {
     }
     
     protected void append(final XUpdateQueryService service, final int id) throws IOException, XMLDBException {
-        StringWriter out = new StringWriter();
-        out.write("<xu:modifications xmlns:xu=\"http://www.xmldb.org/xupdate\" version=\"1.0\">");
-        out.write("<xu:append select=\"/test\">");
-        createItem(id, out);
-        out.write("</xu:append>");
-        out.write("</xu:modifications>");
-        final long mods = service.update(out.toString());
-        assertEquals(mods, 1);
+        try (final StringBuilderWriter out = new StringBuilderWriter()) {
+            out.write("<xu:modifications xmlns:xu=\"http://www.xmldb.org/xupdate\" version=\"1.0\">");
+            out.write("<xu:append select=\"/test\">");
+            createItem(id, out);
+            out.write("</xu:append>");
+            out.write("</xu:modifications>");
+            final long mods = service.update(out.toString());
+            assertEquals(mods, 1);
+        }
     }
     
     protected void insert(final XUpdateQueryService service, final int id) throws IOException, XMLDBException {
-        StringWriter out = new StringWriter();
-        out.write("<xu:modifications xmlns:xu=\"http://www.xmldb.org/xupdate\" version=\"1.0\">");
-        out.write("<xu:insert-before select=\"/test/item[@id='");
-        out.write(Integer.toString(id));
-        out.write("']\">");
-        createItem(5, out);
-        out.write("</xu:insert-before>");
-        out.write("</xu:modifications>");
-         long mods = service.update(out.toString());
-         assertEquals(mods, 1);
+        try (final StringBuilderWriter out = new StringBuilderWriter()) {
+            out.write("<xu:modifications xmlns:xu=\"http://www.xmldb.org/xupdate\" version=\"1.0\">");
+            out.write("<xu:insert-before select=\"/test/item[@id='");
+            out.write(Integer.toString(id));
+            out.write("']\">");
+            createItem(5, out);
+            out.write("</xu:insert-before>");
+            out.write("</xu:modifications>");
+            long mods = service.update(out.toString());
+            assertEquals(mods, 1);
+        }
     }
     
     protected void remove(final XUpdateQueryService service, final int id) throws XMLDBException {

--- a/extensions/debuggee/pom.xml
+++ b/extensions/debuggee/pom.xml
@@ -156,6 +156,7 @@
                                 <include>src/test/resources/log4j2.xml</include>
                                 <include>src/test/resources-filtered/conf.xml</include>
                                 <include>src/test/resources/standalone-webapp/WEB-INF/web.xml</include>
+                                <include>src/main/java/org/exist/debuggee/DebuggeeJointImpl.java</include>
                                 <include>src/test/java/org/exist/debugger/DebuggerTest.java</include>
                             </includes>
                         </licenseSet>
@@ -170,6 +171,7 @@
                                 <exclude>src/test/resources/log4j2.xml</exclude>
                                 <exclude>src/test/resources-filtered/conf.xml</exclude>
                                 <exclude>src/test/resources/standalone-webapp/WEB-INF/web.xml</exclude>
+                                <exclude>src/main/java/org/exist/debuggee/DebuggeeJointImpl.java</exclude>
                                 <exclude>src/test/java/org/exist/debugger/DebuggerTest.java</exclude>
                             </excludes>
                         </licenseSet>

--- a/extensions/debuggee/src/main/java/org/exist/debuggee/DebuggeeJointImpl.java
+++ b/extensions/debuggee/src/main/java/org/exist/debuggee/DebuggeeJointImpl.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -21,10 +45,10 @@
  */
 package org.exist.debuggee;
 
-import java.io.StringWriter;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.Database;
@@ -476,17 +500,18 @@ public class DebuggeeJointImpl implements DebuggeeJoint, Status {
 	        try {
 	            sax = (SAXSerializer) SerializerPool.getInstance().borrowObject(SAXSerializer.class);
 	            Properties outputProps = new Properties();
-	            StringWriter writer = new StringWriter();
-	            sax.setOutput(writer, outputProps);
-	            serializer.setSAXHandlers(sax, sax);
-	            for (SequenceIterator i = resultSequence.iterate(); i.hasNext();) {
-	                Item next = i.nextItem();
-	                if (Type.subTypeOf(next.getType(), Type.NODE))
-	                    serializer.toSAX((NodeValue) next);
-	                else
-	                    writer.write(next.getStringValue());
-	            }
-	            return writer.toString();
+				try (final StringBuilderWriter writer = new StringBuilderWriter()) {
+					sax.setOutput(writer, outputProps);
+					serializer.setSAXHandlers(sax, sax);
+					for (SequenceIterator i = resultSequence.iterate(); i.hasNext(); ) {
+						Item next = i.nextItem();
+						if (Type.subTypeOf(next.getType(), Type.NODE))
+							serializer.toSAX((NodeValue) next);
+						else
+							writer.write(next.getStringValue());
+					}
+					return writer.toString();
+				}
 	        } finally {
 	            if (sax != null) {
 	                SerializerPool.getInstance().returnObject(sax);

--- a/extensions/exquery/restxq/src/test/java/org/exist/extensions/exquery/restxq/impl/xquery/RegistryFunctionsTest.java
+++ b/extensions/exquery/restxq/src/test/java/org/exist/extensions/exquery/restxq/impl/xquery/RegistryFunctionsTest.java
@@ -26,6 +26,7 @@
  */
 package org.exist.extensions.exquery.restxq.impl.xquery;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.exquery.serialization.annotation.MediaTypeAnnotation;
 import org.exquery.serialization.annotation.MethodAnnotation;
@@ -44,7 +45,6 @@ import javax.xml.transform.*;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.io.Writer;
 import java.lang.Override;
 import java.net.URISyntaxException;
@@ -148,7 +148,7 @@ public class RegistryFunctionsTest {
         transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 
-        try(final Writer sw = new StringWriter()) {
+        try(final Writer sw = new StringBuilderWriter()) {
             final Result sr = new StreamResult(sw);
             transformer.transform(new DOMSource(doc), sr);
             return sw.toString();

--- a/extensions/indexes/ngram/pom.xml
+++ b/extensions/indexes/ngram/pom.xml
@@ -147,6 +147,7 @@
                                 <include>pom.xml</include>
                                 <include>src/test/resources-filtered/conf.xml</include>
                                 <include>src/test/resources/log4j2.xml</include>
+                                <include>src/test/java/org/exist/indexing/ngram/CustomIndexTest.java</include>
                                 <include>src/main/java/org/exist/indexing/ngram/NGramIndexWorker.java</include>
                             </includes>
                         </licenseSet>
@@ -160,6 +161,7 @@
                                 <exclude>pom.xml</exclude>
                                 <exclude>src/test/resources-filtered/conf.xml</exclude>
                                 <exclude>src/test/resources/log4j2.xml</exclude>
+                                <exclude>src/test/java/org/exist/indexing/ngram/CustomIndexTest.java</exclude>
                                 <exclude>src/main/java/org/exist/indexing/ngram/NGramIndexWorker.java</exclude>
                             </excludes>
                         </licenseSet>

--- a/extensions/modules/cache/pom.xml
+++ b/extensions/modules/cache/pom.xml
@@ -144,6 +144,7 @@
                             </multi>
                             <includes>
                                 <include>pom.xml</include>
+                                <include>src/main/java/org/exist/xquery/modules/cache/CacheFunctions.java</include>
                                 <include>src/test/java/org/exist/xquery/modules/cache/LazyCacheTest.java</include>
                                 <include>src/test/java/org/exist/xquery/modules/cache/NonLazyCacheTest.java</include>
                                 <include>src/test/resources-filtered/conf.xml</include>
@@ -160,6 +161,7 @@
                             <header>${project.parent.relativePath}/../../exist-parent/existdb-LGPL-21-license.template.txt</header>
                             <excludes>
                                 <exclude>pom.xml</exclude>
+                                <exclude>src/main/java/org/exist/xquery/modules/cache/CacheFunctions.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/modules/cache/LazyCacheTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/modules/cache/NonLazyCacheTest.java</exclude>
                                 <exclude>src/test/resources-filtered/conf.xml</exclude>

--- a/extensions/modules/compression/pom.xml
+++ b/extensions/modules/compression/pom.xml
@@ -162,6 +162,7 @@
                                 <include>pom.xml</include>
                                 <include>src/test/resources-filtered/conf.xml</include>
                                 <include>src/test/resources/log4j2.xml</include>
+                                <include>src/main/java/org/exist/xquery/modules/compression/AbstractCompressFunction.java</include>
                                 <include>src/main/java/org/exist/xquery/modules/compression/EntryFunctions.java</include>
                             </includes>
                         </licenseSet>
@@ -175,6 +176,7 @@
                                 <exclude>pom.xml</exclude>
                                 <exclude>src/test/resources-filtered/conf.xml</exclude>
                                 <exclude>src/test/resources/log4j2.xml</exclude>
+                                <exclude>src/main/java/org/exist/xquery/modules/compression/AbstractCompressFunction.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/modules/compression/EntryFunctions.java</exclude>
                             </excludes>
                         </licenseSet>

--- a/extensions/modules/compression/pom.xml
+++ b/extensions/modules/compression/pom.xml
@@ -162,8 +162,14 @@
                                 <include>pom.xml</include>
                                 <include>src/test/resources-filtered/conf.xml</include>
                                 <include>src/test/resources/log4j2.xml</include>
+                                <include>src/test/xquery/modules/compression/unzip-tests.xql</include>
                                 <include>src/main/java/org/exist/xquery/modules/compression/AbstractCompressFunction.java</include>
+                                <include>src/main/java/org/exist/xquery/modules/compression/AbstractExtractFunction.java</include>
+                                <include>src/main/java/org/exist/xquery/modules/compression/CompressionModule.java</include>
                                 <include>src/main/java/org/exist/xquery/modules/compression/EntryFunctions.java</include>
+                                <include>src/main/java/org/exist/xquery/modules/compression/UnTarFunction.java</include>
+                                <include>src/main/java/org/exist/xquery/modules/compression/UnZipFunction.java</include>
+
                             </includes>
                         </licenseSet>
 
@@ -176,9 +182,15 @@
                                 <exclude>pom.xml</exclude>
                                 <exclude>src/test/resources-filtered/conf.xml</exclude>
                                 <exclude>src/test/resources/log4j2.xml</exclude>
+                                <exclude>src/test/xquery/modules/compression/unzip-tests.xql</exclude>
+                                <exclude>src/test/xquery/modules/compression/zip-tests.xql</exclude>
                                 <exclude>src/test/xquery/modules/compression/zip-unzip-tests.xqm</exclude>
                                 <exclude>src/main/java/org/exist/xquery/modules/compression/AbstractCompressFunction.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/modules/compression/AbstractExtractFunction.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/modules/compression/CompressionModule.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/modules/compression/EntryFunctions.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/modules/compression/UnTarFunction.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/modules/compression/UnZipFunction.java</exclude>
                             </excludes>
                         </licenseSet>
 

--- a/extensions/modules/compression/pom.xml
+++ b/extensions/modules/compression/pom.xml
@@ -176,6 +176,7 @@
                                 <exclude>pom.xml</exclude>
                                 <exclude>src/test/resources-filtered/conf.xml</exclude>
                                 <exclude>src/test/resources/log4j2.xml</exclude>
+                                <exclude>src/test/xquery/modules/compression/zip-unzip-tests.xqm</exclude>
                                 <exclude>src/main/java/org/exist/xquery/modules/compression/AbstractCompressFunction.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/modules/compression/EntryFunctions.java</exclude>
                             </excludes>

--- a/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/AbstractCompressFunction.java
+++ b/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/AbstractCompressFunction.java
@@ -104,6 +104,11 @@ public abstract class AbstractCompressFunction extends BasicFunction
     protected final static SequenceType STRIP_PREFIX_PARAM = new FunctionParameterSequenceType("strip-prefix", Type.STRING, Cardinality.EXACTLY_ONE, "This prefix is stripped from the Entrys name");
     protected final static SequenceType ENCODING_PARAM = new FunctionParameterSequenceType("encoding", Type.STRING, Cardinality.EXACTLY_ONE, "This encoding to be used for filenames inside the compressed file");
 
+    private enum ZipMethod {
+        DEFLATE,
+        STORE
+    }
+
 
     public AbstractCompressFunction(final XQueryContext context, final FunctionSignature signature) {
         super(context, signature);
@@ -159,7 +164,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
                     if (item instanceof Element element) {
                         compressElement(os, element, useHierarchy, stripOffset, sbWriter);
                     } else {
-                        compressFromUri(os, ((AnyURIValue) item).toURI(), useHierarchy, stripOffset, "", null, sbWriter);
+                        compressFromUri(os, ((AnyURIValue) item).toURI(), useHierarchy, stripOffset, ZipMethod.DEFLATE, null, sbWriter);
                     }
                 }
 
@@ -176,7 +181,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
 		}
 	}
 
-    private void compressFromUri(final OutputStream os, final URI uri, final boolean useHierarchy, final String stripOffset, final String method, final String resourceName, final StringBuilderWriter sbWriter) throws XPathException
+    private void compressFromUri(final OutputStream os, final URI uri, final boolean useHierarchy, final String stripOffset, final ZipMethod method, final String resourceName, final StringBuilderWriter sbWriter) throws XPathException
         {
             try {
                 if ("file".equals(uri.getScheme())) {
@@ -198,7 +203,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
                     // try for a collection
                     try (final Collection collection = context.getBroker().openCollection(xmldburi, LockMode.READ_LOCK)) {
                         if(collection != null) {
-                            compressCollection(os, collection, useHierarchy, stripOffset, sbWriter);
+                            compressCollection(os, collection, useHierarchy, stripOffset, method, sbWriter);
                             return;
                         }
                     } catch (final PermissionDeniedException | LockException | SAXException | IOException pde) {
@@ -245,7 +250,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
      * @param method the Zip method.
      * @param name the name of the entry.
      */
-    private void compressFile(final OutputStream os, final Path file, final boolean useHierarchy, final String stripOffset, final String method, final String name) throws IOException {
+    private void compressFile(final OutputStream os, final Path file, final boolean useHierarchy, final String stripOffset, final ZipMethod method, final String name) throws IOException {
 
         if (!Files.isDirectory(file)) {
 
@@ -262,9 +267,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
             final byte[] value = Files.readAllBytes(file);
 
             // close the entry
-            final CRC32 chksum = new CRC32();
-            if (entry instanceof ZipEntry &&
-                    "store".equals(method)) {
+            if (entry instanceof ZipEntry && method == ZipMethod.STORE) {
                 ((ZipEntry) entry).setMethod(ZipOutputStream.STORED);
                 chksum.update(value);
                 ((ZipEntry) entry).setCrc(chksum.getValue());
@@ -311,13 +314,19 @@ public abstract class AbstractCompressFunction extends BasicFunction
 //                throw new XPathException(this, "Entry must have name attribute.");
 
         final String type = element.getAttribute("type");
+        ZipMethod method;
+        try {
+            method = ZipMethod.valueOf(element.getAttribute("method").toUpperCase());
+        } catch (final IllegalArgumentException e) {
+            method = ZipMethod.DEFLATE;
+        }
 
         if ("uri".equals(type)) {
             @Nullable final String uri = element.getFirstChild().getNodeValue();
             if (isNullOrEmpty(uri)) {
                 throw new XPathException(this, "Entry with type uri must contain a URI.");
             }
-            compressFromUri(os, URI.create(uri), useHierarchy, stripOffset, element.getAttribute("method"), name, sbWriter);
+            compressFromUri(os, URI.create(uri), useHierarchy, stripOffset, method, name, sbWriter);
             return;
         }
 
@@ -368,8 +377,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
                     }
                 }
 
-                if (entry instanceof ZipEntry &&
-                    "store".equals(element.getAttribute("method"))) {
+                if (entry instanceof ZipEntry && method == ZipMethod.STORE) {
                     ((ZipEntry) entry).setMethod(ZipOutputStream.STORED);
                     chksum.update(value);
                     ((ZipEntry) entry).setCrc(chksum.getValue());
@@ -415,7 +423,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
 	 * @param name the name of the entry.
 	 * @param sbWriter a StringBuilderWriter to reuse
 	 */
-	private void compressResource(final OutputStream os, final DocumentImpl doc, final boolean useHierarchy, final String stripOffset, final String method, final String name, final StringBuilderWriter sbWriter) throws IOException, SAXException {
+	private void compressResource(final OutputStream os, final DocumentImpl doc, final boolean useHierarchy, final String stripOffset, final ZipMethod method, final String name, final StringBuilderWriter sbWriter) throws IOException, SAXException {
 		// create an entry in the Tar for the document
         final Object entry;
         if (name != null) {
@@ -456,8 +464,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
 
 		// close the entry
         final CRC32 chksum = new CRC32();
-        if (entry instanceof ZipEntry &&
-            "store".equals(method)) {
+        if (entry instanceof ZipEntry && method == ZipMethod.STORE) {
             ((ZipEntry) entry).setMethod(ZipOutputStream.STORED);
             chksum.update(value);
             ((ZipEntry) entry).setCrc(chksum.getValue());
@@ -476,18 +483,19 @@ public abstract class AbstractCompressFunction extends BasicFunction
 	 * @param col The Collection to add to the archive.
 	 * @param useHierarchy Whether to use a folder hierarchy in the archive file that reflects the collection hierarchy.
 	 * @param stripOffset a string that should be stripped from the start of the entry name.
+	 * @param method the Zip method.
 	 * @param sbWriter a StringBuilderWriter to reuse
 	 */
-	private void compressCollection(final OutputStream os, final Collection col, final boolean useHierarchy, final String stripOffset, final StringBuilderWriter sbWriter) throws IOException, SAXException, LockException, PermissionDeniedException {
+	private void compressCollection(final OutputStream os, final Collection col, final boolean useHierarchy, final String stripOffset, final ZipMethod method, final StringBuilderWriter sbWriter) throws IOException, SAXException, LockException, PermissionDeniedException {
 		// iterate over child documents
         final DBBroker broker = context.getBroker();
         final LockManager lockManager = broker.getBrokerPool().getLockManager();
         final MutableDocumentSet childDocs = new DefaultDocumentSet();
 		col.getDocuments(broker, childDocs);
 		for (final Iterator<DocumentImpl> itChildDocs = childDocs.getDocumentIterator(); itChildDocs.hasNext();) {
-            final DocumentImpl childDoc = itChildDocs.next();
+			final DocumentImpl childDoc = itChildDocs.next();
 			try (final ManagedDocumentLock updateLock = lockManager.acquireDocumentReadLock(childDoc.getURI())) {
-				compressResource(os, childDoc, useHierarchy, stripOffset, "", null, sbWriter);
+				compressResource(os, childDoc, useHierarchy, stripOffset, method, null, sbWriter);
 			}
 		}
 		// iterate over child collections
@@ -496,7 +504,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
             final XmldbURI childColURI = itChildCols.next();
             final Collection childCol = broker.getCollection(col.getURI().append(childColURI));
 			// recurse
-			compressCollection(os, childCol, useHierarchy, stripOffset, sbWriter);
+			compressCollection(os, childCol, useHierarchy, stripOffset, method, sbWriter);
 		}
 	}
 	

--- a/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/AbstractCompressFunction.java
+++ b/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/AbstractCompressFunction.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -22,6 +46,7 @@
 package org.exist.xquery.modules.compression;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.collections.Collection;
@@ -120,17 +145,18 @@ public abstract class AbstractCompressFunction extends BasicFunction
                 encoding = StandardCharsets.UTF_8;
             }
 
-            try(final UnsynchronizedByteArrayOutputStream baos = new UnsynchronizedByteArrayOutputStream();
-                    OutputStream os = stream(baos, encoding)) {
+            try (final UnsynchronizedByteArrayOutputStream baos = new UnsynchronizedByteArrayOutputStream();
+                 final OutputStream os = stream(baos, encoding);
+                 final StringBuilderWriter sbWriter = new StringBuilderWriter()) {
 
                 // iterate through the argument sequence
                 for (SequenceIterator i = args[0].iterate(); i.hasNext(); ) {
                     Item item = i.nextItem();
 
                     if (item instanceof Element element) {
-                        compressElement(os, element, useHierarchy, stripOffset);
+                        compressElement(os, element, useHierarchy, stripOffset, sbWriter);
                     } else {
-                        compressFromUri(os, ((AnyURIValue) item).toURI(), useHierarchy, stripOffset, "", null);
+                        compressFromUri(os, ((AnyURIValue) item).toURI(), useHierarchy, stripOffset, "", null, sbWriter);
                     }
                 }
 
@@ -147,7 +173,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
 		}
 	}
 
-    private void compressFromUri(OutputStream os, URI uri, boolean useHierarchy, String stripOffset, String method, String resourceName) throws XPathException
+    private void compressFromUri(final OutputStream os, final URI uri, final boolean useHierarchy, final String stripOffset, final String method, final String resourceName, final StringBuilderWriter sbWriter) throws XPathException
         {
             try {
                 if ("file".equals(uri.getScheme())) {
@@ -169,7 +195,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
                     // try for a collection
                     try(final Collection collection = context.getBroker().openCollection(xmldburi, LockMode.READ_LOCK)) {
                         if(collection != null) {
-                            compressCollection(os, collection, useHierarchy, stripOffset);
+                            compressCollection(os, collection, useHierarchy, stripOffset, sbWriter);
                             return;
                         }
                     } catch(final PermissionDeniedException | LockException | SAXException | IOException pde) {
@@ -192,7 +218,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
                                 throw new XPathException(this, "Invalid URI: " + uri.toString());
                             }
 
-                            compressResource(os, doc.getDocument(), useHierarchy, stripOffset, method, resourceName);
+                            compressResource(os, doc.getDocument(), useHierarchy, stripOffset, method, resourceName, sbWriter);
                             return;
                         }
                     } catch(final PermissionDeniedException | LockException | SAXException | IOException pde) {
@@ -267,9 +293,11 @@ public abstract class AbstractCompressFunction extends BasicFunction
 	 * @param useHierarchy
 	 *            Whether to use a folder hierarchy in the archive file that
 	 *            reflects the collection hierarchy
+     *
+     * @param sbWriter a StringBuilderWriter to reuse
 	 */
 	private void compressElement(final OutputStream os, final Element element, final boolean useHierarchy,
-            final String stripOffset) throws XPathException {
+            final String stripOffset, final StringBuilderWriter sbWriter) throws XPathException {
 
         final String ns = element.getNamespaceURI();
         if(!(element.getNodeName().equals("entry") || (ns != null && !ns.isEmpty()))) {
@@ -287,7 +315,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
         final String type = element.getAttribute("type");
 
         if("uri".equals(type)) {
-            compressFromUri(os, URI.create(element.getFirstChild().getNodeValue()), useHierarchy, stripOffset, element.getAttribute("method"), name);
+            compressFromUri(os, URI.create(element.getFirstChild().getNodeValue()), useHierarchy, stripOffset, element.getAttribute("method"), name, sbWriter);
             return;
         }
 
@@ -329,7 +357,9 @@ public abstract class AbstractCompressFunction extends BasicFunction
                             serializer.setUser(context.getSubject());
                             serializer.setProperty("omit-xml-declaration", "no");
                             getDynamicSerializerOptions(serializer);
-                            value = serializer.serialize((NodeValue) content).getBytes();
+                            sbWriter.getBuilder().setLength(0);
+                            serializer.serialize((NodeValue) content, sbWriter);
+                            value = sbWriter.toString().getBytes(StandardCharsets.UTF_8);
                         } finally {
                             context.getBroker().returnSerializer(serializer);
                         }
@@ -382,8 +412,9 @@ public abstract class AbstractCompressFunction extends BasicFunction
 	 * @param useHierarchy
 	 *            Whether to use a folder hierarchy in the archive file that
 	 *            reflects the collection hierarchy
+     * @param sbWriter a StringBuilderWriter to reuse
 	 */
-	private void compressResource(OutputStream os, DocumentImpl doc, boolean useHierarchy, String stripOffset, String method, String name) throws IOException, SAXException {
+	private void compressResource(final OutputStream os, final DocumentImpl doc, final boolean useHierarchy, final String stripOffset, final String method, final String name, final StringBuilderWriter sbWriter) throws IOException, SAXException {
 		// create an entry in the Tar for the document
         final Object entry;
         if(name != null) {
@@ -404,7 +435,9 @@ public abstract class AbstractCompressFunction extends BasicFunction
                 serializer.setUser(context.getSubject());
                 serializer.setProperty("omit-xml-declaration", "no");
                 getDynamicSerializerOptions(serializer);
-                String strDoc = serializer.serialize(doc);
+                sbWriter.getBuilder().setLength(0);
+                serializer.serialize(doc, sbWriter);
+                String strDoc = sbWriter.toString();
                 value = strDoc.getBytes();
             } finally {
                 context.getBroker().returnSerializer(serializer);
@@ -447,7 +480,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
 	 *            Whether to use a folder hierarchy in the archive file that
 	 *            reflects the collection hierarchy
 	 */
-	private void compressCollection(OutputStream os, Collection col, boolean useHierarchy, String stripOffset) throws IOException, SAXException, LockException, PermissionDeniedException {
+	private void compressCollection(final OutputStream os, final Collection col, final boolean useHierarchy, final String stripOffset, final StringBuilderWriter sbWriter) throws IOException, SAXException, LockException, PermissionDeniedException {
 		// iterate over child documents
         final DBBroker broker = context.getBroker();
         final LockManager lockManager = broker.getBrokerPool().getLockManager();
@@ -456,7 +489,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
 		for (final Iterator<DocumentImpl> itChildDocs = childDocs.getDocumentIterator(); itChildDocs.hasNext();) {
 			DocumentImpl childDoc = itChildDocs.next();
 			try(final ManagedDocumentLock updateLock = lockManager.acquireDocumentReadLock(childDoc.getURI())) {
-				compressResource(os, childDoc, useHierarchy, stripOffset, "", null);
+				compressResource(os, childDoc, useHierarchy, stripOffset, "", null, sbWriter);
 			}
 		}
 		// iterate over child collections
@@ -465,7 +498,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
 			XmldbURI childColURI = itChildCols.next();
 			Collection childCol = broker.getCollection(col.getURI().append(childColURI));
 			// recurse
-			compressCollection(os, childCol, useHierarchy, stripOffset);
+			compressCollection(os, childCol, useHierarchy, stripOffset, sbWriter);
 		}
 	}
 	

--- a/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/AbstractCompressFunction.java
+++ b/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/AbstractCompressFunction.java
@@ -88,10 +88,10 @@ import static org.exist.util.StringUtil.isNullOrEmpty;
 
 /**
  * Compresses a sequence of resources and/or collections
- * 
- * @author <a href="mailto:adam@exist-db.org">Adam Retter</a>
+ *
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  * @author <a href="mailto:ljo@exist-db.org">Leif-Jöran Olsson</a>
- * @version 1.0
+ * @version 2.0
  */
 public abstract class AbstractCompressFunction extends BasicFunction
 {
@@ -226,7 +226,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
                             collection.close();
 
                             if (doc == null) {
-                                throw new XPathException(this, "Invalid URI: " + uri.toString());
+                                throw new XPathException(this, "No document available at URI: " + uri.toString());
                             }
 
                             compressResource(os, doc.getDocument(), useHierarchy, stripOffset, method, resourceName, sbWriter, chksum);

--- a/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/CompressionModule.java
+++ b/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/CompressionModule.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -33,7 +57,7 @@ import static org.exist.xquery.FunctionDSL.functionDefs;
 /**
  * XQuery Extension module for compression and de-compression functions
  * 
- * @author <a href="mailto:adam@exist-db.org">Adam Retter</a>
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  * @author ljo
  */
 public class CompressionModule extends AbstractInternalModule {
@@ -53,7 +77,8 @@ public class CompressionModule extends AbstractInternalModule {
             functionDefs(UnZipFunction.class,
                     UnZipFunction.FS_UNZIP[0],
                     UnZipFunction.FS_UNZIP[1],
-                    UnZipFunction.FS_UNZIP[2]
+                    UnZipFunction.FS_UNZIP[2],
+                    UnZipFunction.FS_UNZIP[3]
             ),
             functionDefs(GZipFunction.class,
                     GZipFunction.signatures[0]
@@ -77,7 +102,8 @@ public class CompressionModule extends AbstractInternalModule {
             functionDefs(UnTarFunction.class,
                     UnTarFunction.FS_UNTAR[0],
                     UnTarFunction.FS_UNTAR[1],
-                    UnTarFunction.FS_UNTAR[2]
+                    UnTarFunction.FS_UNTAR[2],
+                    UnTarFunction.FS_UNTAR[3]
             ),
             functionDefs(EntryFunctions.class,
                     EntryFunctions.FS_NO_FILTER[0],

--- a/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/EntryFunctions.java
+++ b/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/EntryFunctions.java
@@ -50,8 +50,12 @@ import org.apache.logging.log4j.Logger;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.triggers.TriggerException;
+import org.exist.dom.persistent.DocumentImpl;
+import org.exist.dom.persistent.NodeImpl;
+import org.exist.dom.persistent.NodeProxy;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionException;
 import org.exist.storage.txn.Txn;
 import org.exist.util.BinaryValueInputSource;
@@ -61,11 +65,12 @@ import org.exist.util.MimeType;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.*;
 import org.exist.xquery.value.*;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
 
-import java.io.BufferedOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
+import javax.annotation.Nullable;
+import java.io.*;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -246,8 +251,31 @@ public class EntryFunctions extends BasicFunction {
                     if(data.isPresent()) {
                         // store the resource
                         try (final OutputStream os = new BufferedOutputStream(Files.newOutputStream(destPath, StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING))) {
-                            ((BinaryValue)data.get()).streamBinaryTo(os);
-                        } catch (final IOException e) {
+                            if (data.get() instanceof BinaryValue) {
+                                // binary
+                                ((BinaryValue)data.get()).streamBinaryTo(os);
+                            } else {
+                                // XML
+                                final Serializer serializer = context.getBroker().borrowSerializer();
+                                try {
+                                    serializer.setUser(context.getSubject());
+                                    serializer.setProperty("omit-xml-declaration", "no");
+
+                                    final NodeValue nodeValue;
+                                    if (data.get() instanceof NodeValue || data.get() instanceof NodeProxy) {
+                                        nodeValue = (NodeValue) data.get();
+                                    } else {
+                                        final NodeImpl n = (NodeImpl) data.get();
+                                        nodeValue = new NodeProxy(n instanceof DocumentImpl ? (DocumentImpl)n : (DocumentImpl)n.getOwnerDocument(), n.getNodeId());
+                                    }
+                                    try (final Writer writer = new OutputStreamWriter(os)) {
+                                        serializer.serialize(nodeValue, writer);
+                                    }
+                                } finally {
+                                    context.getBroker().returnSerializer(serializer);
+                                }
+                            }
+                        } catch (final IOException | SAXException e) {
                             throw new XPathException(this, "Cannot serialize file. A problem occurred while serializing the binary data: " + e.getMessage(), e);
                         }
                     }
@@ -300,9 +328,16 @@ public class EntryFunctions extends BasicFunction {
                         try (final Txn transaction = context.getBroker().getBrokerPool().getTransactionManager().beginTransaction()) {
 
                             try (final Collection collection = context.getBroker().openCollection(destPath.removeLastSegment(), Lock.LockMode.WRITE_LOCK)) {
-                                final BinaryValue binaryValue = (BinaryValue) data.get();
                                 final MimeType mimeType = MimeTable.getInstance().getContentTypeFor(destPath.lastSegment());
-                                context.getBroker().storeDocument(transaction, destPath.lastSegment(), new BinaryValueInputSource(binaryValue), mimeType, collection);
+
+                                if (data.get() instanceof BinaryValue) {
+                                    // binary
+                                    final BinaryValue binaryValue = (BinaryValue) data.get();
+                                    context.getBroker().storeDocument(transaction, destPath.lastSegment(), new BinaryValueInputSource(binaryValue), mimeType, collection);
+                                } else {
+                                    // XML
+                                    context.getBroker().storeDocument(transaction, destPath.lastSegment(), (Node)data.get(), mimeType, collection);
+                                }
                             }
                             transaction.commit();
                         } catch (final IOException | PermissionDeniedException | EXistException | LockException | SAXException e) {

--- a/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/UnTarFunction.java
+++ b/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/UnTarFunction.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -35,7 +59,6 @@ import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.Type;
 import org.exist.xquery.value.ValueSequence;
-import org.xmldb.api.base.XMLDBException;
 
 import static org.exist.xquery.FunctionDSL.*;
 import static org.exist.xquery.modules.compression.CompressionModule.functionSignatures;
@@ -43,47 +66,44 @@ import static org.exist.xquery.modules.compression.CompressionModule.functionSig
 /**
  * Extracts files and folders from a Tar file
  * 
- * @author <a href="mailto:adam@exist-db.org">Adam Retter</a>
- * @version 1.0
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ * @version 2.0
  */
 public class UnTarFunction extends AbstractExtractFunction {
 
-    private static final FunctionParameterSequenceType FS_PARAM_TAR_DATA = param("tar-data", Type.BASE64_BINARY, "The tar file data");
+    private static final FunctionParameterSequenceType FS_PARAM_TAR_DATA = param("tar-data", Type.BASE64_BINARY, "The Tar file data");
     private static final FunctionParameterSequenceType FS_PARAM_ENTRY_FILTER = param("entry-filter", Type.FUNCTION,
-            "A user defined function for filtering resources from the tar file. The function takes 2 parameters e.g. "
-            + "user:untar-entry-filter($path as xs:string, $data-type as xs:string) as xs:boolean. "
-            + "$data-type may be 'resource' or 'folder'. If the return type is true() it indicates the entry "
-            + "should be processed and passed to the entry-data function, else the resource is skipped. "
-            + "If you wish to extract all resources you can use the provided compression:no-filter#2 function."
-    );
+        "A function for filtering resources from the Tar file. The function takes 2 parameters e.g. " +
+            "user:untar-entry-filter($path as xs:string, $data-type as xs:string) as xs:boolean. " +
+            "The provided value of $data-type will be either 'resource' or 'folder'. " +
+            "If the return type is true() it indicates the entry " +
+            "should be processed and passed to the $entry-data function, else the resource is skipped. " +
+            "If you wish to extract all resources you can use the provided compression:no-filter#2 function.");
     private static final FunctionParameterSequenceType FS_PARAM_ENTRY_FILTER_WITH_PARAMS = param("entry-filter", Type.FUNCTION,
-            "A user defined function for filtering resources from the tar file. The function takes 3 parameters e.g. "
-            + "user:untar-entry-filter($path as xs:string, $data-type as xs:string, $param as item()*) as xs:boolean. "
-            + "$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters, "
-            + "for example a list of extracted files. If the return type is true() it indicates the entry "
-            + "should be processed and passed to the entry-data function, else the resource is skipped. "
-            + "If you wish to extract all resources you can use the provided compression:no-filter#3 function."
-    );
+        "A function for filtering resources from the Tar file. The function takes 3 parameters e.g. " +
+            "user:untar-entry-filter($path as xs:string, $data-type as xs:string, $param as item()*) as xs:boolean. " +
+            "The provided value of $data-type will be either 'resource' or 'folder'. " +
+            "$param is a sequence with any additional parameters, for example a list of extracted files. " +
+            "If the return type is true() it indicates the entry " +
+            "should be processed and passed to the $entry-data function, else the resource is skipped. " +
+            "If you wish to extract all resources you can use the provided compression:no-filter#3 function.");
     private static final FunctionParameterSequenceType FS_PARAM_ENTRY_FILTER_PARAM = optManyParam("entry-filter-param", Type.ANY_TYPE, "A sequence with an additional parameters for filtering function.");
     private static final FunctionParameterSequenceType FS_PARAM_ENTRY_DATA = param("entry-data", Type.FUNCTION,
-            "A user defined function for storing an extracted resource from the tar file. The function takes 3 parameters e.g. "
-            + "user:untar-entry-data($path as xs:string, $data-type as xs:string, $data as item()?). "
-            + "Or a user defined function which returns a db path for storing an extracted resource from the tar file. "
-            + "The function takes 3 parameters e.g. user:entry-path($path as xs:string, $data-type as xs:string, "
-            + "$param as item()*) as xs:anyURI. $data-type may be 'resource' or 'folder'. "
-            + "Functions for storing the entries to a folder on the filesystem or a collection in the database "
-            + "provided by compression:fs-store-entry3($dest) and compression:db-store-entry3($dest).");
+        "A function for working with the entry from the Tar file. You must supply one of two different types of functions, either: " +
+            "(1) A function that receives the data of the Tar entry, it must have a signature like: user:entry-data($path as xs:string, $data-type as xs:string, $data as item()?) as item()*, " +
+            "or (2) a function that receives details of the entry and returns a database path to store the file at, it must have a signature like: user:entry-path($path as xs:string, $data-type as xs:string) as xs:anyURI. " +
+            "For convenience we provide the built-in functions: " +
+            "(1) compression:fs-store-entry3($folder-path) for storing the entries to a folder on the filesystem, " +
+            "and (2) compression:db-store-entry3($collection-uri) for storing entries to a collection in the database.");
     private static final FunctionParameterSequenceType FS_PARAM_ENTRY_DATA_WITH_PARAMS = param("entry-data", Type.FUNCTION,
-            "A user defined function for storing an extracted resource from the tar file. The function takes 4 parameters e.g. "
-            + "user:untar-entry-data($path as xs:string, $data-type as xs:string, $data as item()?, $param as item()*). "
-            + "Or a user defined function which returns a db path for storing an extracted resource from the tar file. The function takes 3 parameters e.g. "
-            + "user:entry-path($path as xs:string, $data-type as xs:string, $param as item()*) as xs:anyURI. "
-            + "$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters"
-            + "Functions for storing the entries to a folder on the filesystem or a collection in the database "
-            + "provided by compression:fs-store-entry4($dest) and compression:db-store-entry4($dest)."
-    );
+        "A function for working with the entry from the Tar file. You must supply one of two different types of functions, either: " +
+            "(1) A function that receives the data of the Tar entry, it must have a signature like: user:entry-data($path as xs:string, $data-type as xs:string, $data as item()?, $param as item()*) as item()*, " +
+            "or (2) a function that receives details of the entry and returns a database path to store the file at, it must have a signature like: user:entry-path($path as xs:string, $data-type as xs:string, $param as item()*) as xs:anyURI. " +
+            "For convenience we provide the built-in functions: " +
+            "(1) compression:fs-store-entry4($folder-path) for storing the entries to a folder on the filesystem, " +
+            "and (2) compression:db-store-entry4($collection-uri) for storing entries to a collection in the database.");
     private static final FunctionParameterSequenceType FS_PARAM_ENTRY_DATA_PARAM = optManyParam("entry-data-param", Type.ANY_TYPE, "A sequence with an additional parameters for storing function.");
-
+    private static final FunctionParameterSequenceType FS_PARAM_ENCODING = param("encoding", Type.STRING, "The encoding to be used during uncompressing eg: UTF8 or Cp437 from https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html");
 
     private static final String FS_UNTAR_NAME = "untar";
     static final FunctionSignature[] FS_UNTAR = functionSignatures(
@@ -98,6 +118,12 @@ public class UnTarFunction extends AbstractExtractFunction {
                 ),
                 arity(
                     FS_PARAM_TAR_DATA,
+                    FS_PARAM_ENTRY_FILTER,
+                    FS_PARAM_ENTRY_DATA,
+                    FS_PARAM_ENCODING
+                ),
+                arity(
+                    FS_PARAM_TAR_DATA,
                     FS_PARAM_ENTRY_FILTER_WITH_PARAMS,
                     FS_PARAM_ENTRY_FILTER_PARAM,
                     FS_PARAM_ENTRY_DATA_WITH_PARAMS,
@@ -109,7 +135,7 @@ public class UnTarFunction extends AbstractExtractFunction {
                     FS_PARAM_ENTRY_FILTER_PARAM,
                     FS_PARAM_ENTRY_DATA_WITH_PARAMS,
                     FS_PARAM_ENTRY_DATA_PARAM,
-                    param("encoding", Type.STRING, "The encoding to be used during uncompressing eg: UTF8 or Cp437 from https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html")
+                    FS_PARAM_ENCODING
                 )
             )
     );
@@ -119,7 +145,7 @@ public class UnTarFunction extends AbstractExtractFunction {
     }
 	
     @Override
-    protected Sequence processCompressedData(final BinaryValue compressedData, final Charset encoding) throws XPathException, XMLDBException {
+    protected Sequence processCompressedData(final BinaryValue compressedData, final Charset encoding) throws XPathException {
         try(final TarArchiveInputStream tis = new TarArchiveInputStream(compressedData.getInputStream(), encoding.name())) {
 
             TarArchiveEntry entry = null;
@@ -127,7 +153,7 @@ public class UnTarFunction extends AbstractExtractFunction {
             final Sequence results = new ValueSequence();
 
             while((entry = tis.getNextTarEntry()) != null) {
-                final Sequence processCompressedEntryResults = processCompressedEntry(entry.getName(), entry.isDirectory(), tis, filterParam, storeParam);
+                final Sequence processCompressedEntryResults = processCompressedEntry(entry.getName(), entry.isDirectory(), tis);
                 results.addAll(processCompressedEntryResults);
             }
 

--- a/extensions/modules/compression/src/test/xquery/modules/compression/unzip-tests.xql
+++ b/extensions/modules/compression/src/test/xquery/modules/compression/unzip-tests.xql
@@ -1,4 +1,28 @@
 (:
+ : Elemental
+ : Copyright (C) 2024, Evolved Binary Ltd
+ :
+ : admin@evolvedbinary.com
+ : https://www.evolvedbinary.com | https://www.elemental.xyz
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; version 2.1.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :
+ : NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ :       The original license header is included below.
+ :
+ : =====================================================================
+ :
  : eXist-db Open Source Native XML Database
  : Copyright (C) 2001 The eXist-db Authors
  :
@@ -21,30 +45,30 @@
  :)
 xquery version "3.0";
 
-module namespace uz="http://exist-db.org/testsuite/unzips";
+module namespace ut = "http://exist-db.org/xquery/cache/test/unzip";
 
+import module namespace compression = "http://exist-db.org/xquery/compression";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
 declare namespace util = "http://exist-db.org/xquery/util";
 
-import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
-import module namespace compression="http://exist-db.org/xquery/compression";
+
+declare variable $ut:collection-name := "unzip-test";
+declare variable $ut:collection := "/db/" || $ut:collection-name;
 
 
-declare variable $uz:collection-name := "unzip-test";
-declare variable $uz:collection := "/db/" || $uz:collection-name;
-
-
-declare variable $uz:myFile-name := "!#$%()*+,-.:;=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_abcdefghijklmnopqrstuvwxyz{}~ ÇüéâäàåçêëèïîìÄÅÉæÆôöòûùÿÖÜ¢£¥₧ƒáíóúñÑªº¿αßΓπΣσµτΦΘΩδ∞φε.xml";
-declare variable $uz:myFile-serialized := "<file/>";
+declare variable $ut:myFile-name := "!#$%()*+,-.:;=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_abcdefghijklmnopqrstuvwxyz{}~ ÇüéâäàåçêëèïîìÄÅÉæÆôöòûùÿÖÜ¢£¥₧ƒáíóúñÑªº¿αßΓπΣσµτΦΘΩδ∞φε.xml";
+declare variable $ut:myFile-serialized := "<file/>";
 
 (: declare UTF8 encoded binary :)
-declare variable $uz:myStaticUTF8ContentBase64 := xs:base64Binary("UEsDBBQACAgIAOBYl0UAAAAAAAAAAAAAAADCAAAAISMkJSgpKissLS46Oz0/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW11eX2FiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e31+IMOHw7zDqcOiw6TDoMOlw6fDqsOrw6jDr8Ouw6zDhMOFw4nDpsOGw7TDtsOyw7vDucO/w5bDnMKiwqPCpeKCp8aSw6HDrcOzw7rDscORwqrCusK/zrHDn86Tz4DOo8+DwrXPhM6mzpjOqc604oiez4bOtS54bWyzsa/IzVEoSy0qzszPs1Uy1DNQUkjNS85PycxLt1UKDXHTtVCyt+OyScvMSdW3AwBQSwcIwWbL3zAAAAAuAAAAUEsBAhQAFAAICAgA4FiXRcFmy98wAAAALgAAAMIAAAAAAAAAAAAAAAAAAAAAACEjJCUoKSorLC0uOjs9P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltdXl9hYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ent9fiDDh8O8w6nDosOkw6DDpcOnw6rDq8Oow6/DrsOsw4TDhcOJw6bDhsO0w7bDssO7w7nDv8OWw5zCosKjwqXigqfGksOhw63Ds8O6w7HDkcKqwrrCv86xw5/Ok8+AzqPPg8K1z4TOps6YzqnOtOKIns+GzrUueG1sUEsFBgAAAAABAAEA8AAAACABAAAAAA==");
+declare variable $ut:myStaticUTF8ContentBase64 := xs:base64Binary("UEsDBBQACAgIAOBYl0UAAAAAAAAAAAAAAADCAAAAISMkJSgpKissLS46Oz0/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW11eX2FiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e31+IMOHw7zDqcOiw6TDoMOlw6fDqsOrw6jDr8Ouw6zDhMOFw4nDpsOGw7TDtsOyw7vDucO/w5bDnMKiwqPCpeKCp8aSw6HDrcOzw7rDscORwqrCusK/zrHDn86Tz4DOo8+DwrXPhM6mzpjOqc604oiez4bOtS54bWyzsa/IzVEoSy0qzszPs1Uy1DNQUkjNS85PycxLt1UKDXHTtVCyt+OyScvMSdW3AwBQSwcIwWbL3zAAAAAuAAAAUEsBAhQAFAAICAgA4FiXRcFmy98wAAAALgAAAMIAAAAAAAAAAAAAAAAAAAAAACEjJCUoKSorLC0uOjs9P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltdXl9hYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ent9fiDDh8O8w6nDosOkw6DDpcOnw6rDq8Oow6/DrsOsw4TDhcOJw6bDhsO0w7bDssO7w7nDv8OWw5zCosKjwqXigqfGksOhw63Ds8O6w7HDkcKqwrrCv86xw5/Ok8+AzqPPg8K1z4TOps6YzqnOtOKIns+GzrUueG1sUEsFBgAAAAABAAEA8AAAACABAAAAAA==");
 
 (: declare cp437 encoded binary :)
-declare variable $uz:myStaticCP437ContentBase64 := xs:base64Binary("UEsDBBQACAAIAOBYl0UAAAAAAAAAAAAAAACIAAAAISMkJSgpKissLS46Oz0/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW11eX2FiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e31+IICBgoOEhYaHiImKi4yNjo+QkZKTlJWWl5iZmpucnZ6foKGio6Slpqeo4OHi4+Tl5ufo6err7O3uLnhtbLOxr8jNUShLLSrOzM+zVTLUM1BSSM1Lzk/JzEu3VQoNcdO1ULK347JJy8xJ1bcDAFBLBwjBZsvfMAAAAC4AAABQSwECFAAUAAgACADgWJdFwWbL3zAAAAAuAAAAiAAAAAAAAAAAAAAAAAAAAAAAISMkJSgpKissLS46Oz0/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW11eX2FiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e31+IICBgoOEhYaHiImKi4yNjo+QkZKTlJWWl5iZmpucnZ6foKGio6Slpqeo4OHi4+Tl5ufo6err7O3uLnhtbFBLBQYAAAAAAQABALYAAADmAAAAAAA=");
+declare variable $ut:myStaticCP437ContentBase64 := xs:base64Binary("UEsDBBQACAAIAOBYl0UAAAAAAAAAAAAAAACIAAAAISMkJSgpKissLS46Oz0/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW11eX2FiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e31+IICBgoOEhYaHiImKi4yNjo+QkZKTlJWWl5iZmpucnZ6foKGio6Slpqeo4OHi4+Tl5ufo6err7O3uLnhtbLOxr8jNUShLLSrOzM+zVTLUM1BSSM1Lzk/JzEu3VQoNcdO1ULK347JJy8xJ1bcDAFBLBwjBZsvfMAAAAC4AAABQSwECFAAUAAgACADgWJdFwWbL3zAAAAAuAAAAiAAAAAAAAAAAAAAAAAAAAAAAISMkJSgpKissLS46Oz0/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW11eX2FiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e31+IICBgoOEhYaHiImKi4yNjo+QkZKTlJWWl5iZmpucnZ6foKGio6Slpqeo4OHi4+Tl5ufo6err7O3uLnhtbFBLBQYAAAAAAQABALYAAADmAAAAAAA=");
 
 
 (: declare helper functions :)
-declare function local:entry-data($path as xs:anyURI, $type as xs:string, $data as item()?, $param as item()*) as item()?
+declare function local:entry-data($path as xs:string, $type as xs:string, $data as item()?, $param as item()*) as item()?
 {
     <entry>
         <path>{$path}</path>
@@ -54,7 +78,7 @@ declare function local:entry-data($path as xs:anyURI, $type as xs:string, $data 
 };
 
 (: Process every Zip Collections and Resources  :)
-declare function local:entry-filter($path as xs:anyURI, $type as xs:string, $param as item()*) as xs:boolean
+declare function local:entry-filter($path as xs:string, $type as xs:string, $param as item()*) as xs:boolean
 {
     true()
 };
@@ -62,29 +86,29 @@ declare function local:entry-filter($path as xs:anyURI, $type as xs:string, $par
 declare
     %test:user("guest", "guest")
 	%test:assertEquals("<entry><path>!#$%()*+,-.:;=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_abcdefghijklmnopqrstuvwxyz{}~ ÇüéâäàåçêëèïîìÄÅÉæÆôöòûùÿÖÜ¢£¥₧ƒáíóúñÑªº¿αßΓπΣσµτΦΘΩδ∞φε.xml</path><type>resource</type><data><file/></data></entry>")
-function uz:fnUzipUtf8Content() {
-    compression:unzip($uz:myStaticUTF8ContentBase64, util:function(xs:QName("local:entry-filter"), 3), (), util:function(xs:QName("local:entry-data"), 4), (), "UTF8")
+function ut:fnUzipUtf8Content() {
+    compression:unzip($ut:myStaticUTF8ContentBase64, local:entry-filter#3, (), local:entry-data#4, (), "UTF8")
 };
 
 declare
     %test:user("guest", "guest")
 	%test:assertEquals("<entry><path>!#$%()*+,-.:;=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_abcdefghijklmnopqrstuvwxyz{}~ ÇüéâäàåçêëèïîìÄÅÉæÆôöòûùÿÖÜ¢£¥₧ƒáíóúñÑªº¿αßΓπΣσµτΦΘΩδ∞φε.xml</path><type>resource</type><data><file/></data></entry>")
-function uz:fnUzipCp437Content() {
-    compression:unzip($uz:myStaticCP437ContentBase64, util:function(xs:QName("local:entry-filter"), 3), (), util:function(xs:QName("local:entry-data"), 4), (), "Cp437")
+function ut:fnUzipCp437Content() {
+    compression:unzip($ut:myStaticCP437ContentBase64, local:entry-filter#3, (), local:entry-data#4, (), "Cp437")
 };
 
 declare
     %test:user("guest", "guest")
 	%test:assertEquals("<entry><path>!#$%()*+,-.:;=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_abcdefghijklmnopqrstuvwxyz{}~ ÇüéâäàåçêëèïîìÄÅÉæÆôöòûùÿÖÜ¢£¥₧ƒáíóúñÑªº¿αßΓπΣσµτΦΘΩδ∞φε.xml</path><type>resource</type><data><file/></data></entry>")
-function uz:fnUzipUtf8ContentWrongEncoding() {
+function ut:fnUzipUtf8ContentWrongEncoding() {
     (: This case is working due to the selected cp437 character in the filename :)
-    compression:unzip($uz:myStaticUTF8ContentBase64, util:function(xs:QName("local:entry-filter"), 3), (), util:function(xs:QName("local:entry-data"), 4), (), "Cp437")
+    compression:unzip($ut:myStaticUTF8ContentBase64, local:entry-filter#3, (), local:entry-data#4, (), "Cp437")
 };
 
 declare
     %test:user("guest", "guest")
 	%test:assertError("(?:MALFORMED)|(?:malformed)")
-function uz:fnUzipCp437ContentWrongEncoding() {
+function ut:fnUzipCp437ContentWrongEncoding() {
     (: This case is not working because the Unicode extended filename table is not present in non unicode encoded Zip :)
-    compression:unzip($uz:myStaticCP437ContentBase64, util:function(xs:QName("local:entry-filter"), 3), (), util:function(xs:QName("local:entry-data"), 4), (), "UTF8")
+    compression:unzip($ut:myStaticCP437ContentBase64, local:entry-filter#3, (), local:entry-data#4, (), "UTF8")
 };

--- a/extensions/modules/compression/src/test/xquery/modules/compression/zip-tests.xql
+++ b/extensions/modules/compression/src/test/xquery/modules/compression/zip-tests.xql
@@ -1,14 +1,13 @@
 (:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2001 The eXist-db Authors
+ : Elemental
+ : Copyright (C) 2024, Evolved Binary Ltd
  :
- : info@exist-db.org
- : http://www.exist-db.org
+ : admin@evolvedbinary.com
+ : https://www.evolvedbinary.com | https://www.elemental.xyz
  :
  : This library is free software; you can redistribute it and/or
  : modify it under the terms of the GNU Lesser General Public
- : License as published by the Free Software Foundation; either
- : version 2.1 of the License, or (at your option) any later version.
+ : License as published by the Free Software Foundation; version 2.1.
  :
  : This library is distributed in the hope that it will be useful,
  : but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -21,38 +20,113 @@
  :)
 xquery version "3.0";
 
-module namespace z="http://exist-db.org/testsuite/zips";
+module namespace zt = "http://exist-db.org/xquery/cache/test/zip";
 
+import module namespace compression = "http://exist-db.org/xquery/compression";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
 declare namespace util = "http://exist-db.org/xquery/util";
+declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
 
-import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
-import module namespace compression="http://exist-db.org/xquery/compression";
+declare variable $zt:TEST_COLLECTION_NAME := "zip-test";
+declare variable $zt:TEST_COLLECTION_PATH := "/db/" || $zt:TEST_COLLECTION_NAME;
 
+declare variable $zt:DOC_1_NAME := "doc-1.xml";
+declare variable $zt:DOC_1_PATH := $zt:TEST_COLLECTION_PATH || "/" || $zt:DOC_1_NAME;
+declare variable $zt:DOC_1 := document { <test>123</test> };
 
-declare variable $z:collection-name := "unzip-test";
-declare variable $z:collection := "/db/" || $z:collection-name;
+declare variable $zt:DOC_2_NAME := "doc-2.xml";
+declare variable $zt:DOC_2_PATH := $zt:TEST_COLLECTION_PATH || "/" || $zt:DOC_2_NAME;
+declare variable $zt:DOC_2 := document { <test>abc</test> };
 
-
-declare variable $z:myFile-name := "!#$%()*+,-.:;=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_abcdefghijklmnopqrstuvwxyz{}~ ÇüéâäàåçêëèïîìÄÅÉæÆôöòûùÿÖÜ¢£¥₧ƒáíóúñÑªº¿αßΓπΣσµτΦΘΩδ∞φε.xml";
-declare variable $z:myFile-serialized := "<file/>";
-
-(: declare UTF8 encoded binary :)
-declare variable $z:myStaticUTF8ContentBase64 := xs:base64Binary("UEsDBBQACAgIAOBYl0UAAAAAAAAAAAAAAADCAAAAISMkJSgpKissLS46Oz0/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW11eX2FiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e31+IMOHw7zDqcOiw6TDoMOlw6fDqsOrw6jDr8Ouw6zDhMOFw4nDpsOGw7TDtsOyw7vDucO/w5bDnMKiwqPCpeKCp8aSw6HDrcOzw7rDscORwqrCusK/zrHDn86Tz4DOo8+DwrXPhM6mzpjOqc604oiez4bOtS54bWyzsa/IzVEoSy0qzszPs1Uy1DNQUkjNS85PycxLt1UKDXHTtVCyt+OyScvMSdW3AwBQSwcIwWbL3zAAAAAuAAAAUEsBAhQAFAAICAgA4FiXRcFmy98wAAAALgAAAMIAAAAAAAAAAAAAAAAAAAAAACEjJCUoKSorLC0uOjs9P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltdXl9hYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ent9fiDDh8O8w6nDosOkw6DDpcOnw6rDq8Oow6/DrsOsw4TDhcOJw6bDhsO0w7bDssO7w7nDv8OWw5zCosKjwqXigqfGksOhw63Ds8O6w7HDkcKqwrrCv86xw5/Ok8+AzqPPg8K1z4TOps6YzqnOtOKIns+GzrUueG1sUEsFBgAAAAABAAEA8AAAACABAAAAAA==");
-
-
-
-(: Verify zero byte sized resource :)
 declare
-	%test:assertEquals("")
-function z:zeroByteBinResource() {
-    let $collection-uri :="/db/"
-    let $resource-name :="empty.txt"
-    let $contents :=""
-
-    let $empty-file := xmldb:store-as-binary($collection-uri, $resource-name, $contents)
-
-    let $zip := compression:zip(<entry type="uri" name="{$collection-uri}">{$collection-uri||$resource-name}</entry>, true())
-
-    return util:binary-to-string(util:binary-doc($collection-uri||$resource-name))
+    %test:setUp
+function zt:setup() {
+    xmldb:create-collection("/db", $zt:TEST_COLLECTION_NAME),
+    xmldb:store($zt:TEST_COLLECTION_PATH, $zt:DOC_1_NAME, $zt:DOC_1),
+    xmldb:store($zt:TEST_COLLECTION_PATH, $zt:DOC_2_NAME, $zt:DOC_2)
 };
 
+declare
+	%test:assertExists
+function zt:zip-xml-entries() {
+    let $entries := (
+        <entry type="xml" name="{$zt:DOC_1_NAME}">{doc($zt:DOC_1_PATH)}</entry>,
+        <entry type="xml" name="{$zt:DOC_2_NAME}">{doc($zt:DOC_2_PATH)}</entry>
+    ) return
+        compression:zip($entries, true())
+};
+
+declare
+	%test:assertExists
+function zt:zip-uri-entries() {
+    let $entries := (
+        <entry type="xml" name="{$zt:DOC_1_NAME}">{$zt:DOC_1_PATH}</entry>,
+        <entry type="xml" name="{$zt:DOC_2_NAME}">{$zt:DOC_2_PATH}</entry>
+    ) return
+        compression:zip($entries, true())
+};
+
+declare
+	%test:assertExists
+function zt:zip-uris() {
+    let $entries := (
+        xs:anyURI("xmldb:exist://" || $zt:DOC_1_PATH),
+        xs:anyURI("xmldb:exist://" || $zt:DOC_2_PATH)
+    ) return
+        compression:zip($entries, true())
+};
+
+declare
+	%test:assertExists
+function zt:zip-collection-entry-with-hierarchy() {
+    let $entries := (
+        <entry type="collection" name="{$zt:TEST_COLLECTION_NAME}">{$zt:TEST_COLLECTION_PATH}</entry>
+    ) return
+        compression:zip($entries, true())
+};
+
+declare
+	%test:assertExists
+function zt:zip-collection-entry-without-hierarchy() {
+    let $entries := (
+        <entry type="collection" name="{$zt:TEST_COLLECTION_NAME}">{$zt:TEST_COLLECTION_PATH}</entry>
+    ) return
+        compression:zip($entries, false())
+};
+
+declare
+	%test:assertExists
+function zt:zip-collection-entry-with-hierarchy-strip-prefix() {
+    let $entries := (
+        <entry type="collection" name="{$zt:TEST_COLLECTION_NAME}">{$zt:TEST_COLLECTION_PATH}</entry>
+    ) return
+        compression:zip($entries, true(), "/db")
+};
+
+declare
+	%test:assertExists
+function zt:zip-collection-entry-without-hierarchy-strip-prefix() {
+    let $entries := (
+        <entry type="collection" name="{$zt:TEST_COLLECTION_NAME}">{$zt:TEST_COLLECTION_PATH}</entry>
+    ) return
+        compression:zip($entries, false(), "/db")
+};
+
+declare
+	%test:assertExists
+function zt:zip-collection-entry-with-hierarchy-strip-prefix-encoding-ascii() {
+    let $entries := (
+        <entry type="collection" name="{$zt:TEST_COLLECTION_NAME}">{$zt:TEST_COLLECTION_PATH}</entry>
+    ) return
+        compression:zip($entries, true(), "/db", "ASCII")
+};
+
+declare
+	%test:assertExists
+function zt:zip-collection-entry-with-hierarchy-strip-prefix-encoding-utf8() {
+    let $entries := (
+        <entry type="collection" name="{$zt:TEST_COLLECTION_NAME}">{$zt:TEST_COLLECTION_PATH}</entry>
+    ) return
+        compression:zip($entries, true(), "/db", "UTF-8")
+};

--- a/extensions/modules/compression/src/test/xquery/modules/compression/zip-unzip-tests.xqm
+++ b/extensions/modules/compression/src/test/xquery/modules/compression/zip-unzip-tests.xqm
@@ -1,0 +1,83 @@
+(:
+ : Elemental
+ : Copyright (C) 2024, Evolved Binary Ltd
+ :
+ : admin@evolvedbinary.com
+ : https://www.evolvedbinary.com | https://www.elemental.xyz
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; version 2.1.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.0";
+
+module namespace zut = "http://exist-db.org/xquery/cache/test/zip-unzip";
+
+import module namespace compression = "http://exist-db.org/xquery/compression";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+declare namespace util = "http://exist-db.org/xquery/util";
+declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
+
+declare variable $zut:TEST_COLLECTION_NAME := "zip-unzip-test";
+declare variable $zut:TEST_COLLECTION_PATH := "/db/" || $zut:TEST_COLLECTION_NAME;
+
+declare variable $zut:DOC_WITH_PIS_1_NAME := "doc-with-pis-1.xml";
+declare variable $zut:DOC_WITH_PIS_1_PATH := $zut:TEST_COLLECTION_PATH || "/" || $zut:DOC_WITH_PIS_1_NAME;
+declare variable $zut:DOC_WITH_PIS_1 := document {
+    <?xml-model href="http://docbook.org/xml/5.0/rng/docbook.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>,
+    <?xml-model href="http://docbook.org/xml/5.0/rng/docbook.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>,
+    <article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0">
+      <info>
+        <title>Integration Testing</title>
+        <date>2Q19</date>
+        <keywordset>
+          <keyword>application-development</keyword>
+          <keyword>testing</keyword>
+        </keywordset>
+      </info>
+    </article>
+};
+
+declare
+    %test:setUp
+function zut:setup() {
+    xmldb:create-collection("/db", $zut:TEST_COLLECTION_NAME),
+    xmldb:store($zut:TEST_COLLECTION_PATH, $zut:DOC_WITH_PIS_1_NAME, $zut:DOC_WITH_PIS_1)
+};
+
+declare
+	%test:assertEquals(3)
+function zut:entry-of-doc-with-pis() {
+    let $entries := <entry type="xml" name="{$zut:DOC_WITH_PIS_1_NAME}">{doc($zut:DOC_WITH_PIS_1_PATH)}</entry>
+    return
+        let $zip-data := compression:zip($entries, true())
+        return
+            let $output-collection-path := $zut:TEST_COLLECTION_PATH || "/entry-of-doc-with-pis-output"
+            let $_ := compression:unzip($zip-data, compression:no-filter#2, compression:db-store-entry3($output-collection-path))
+            return
+                count(doc($output-collection-path || "/" || $zut:DOC_WITH_PIS_1_NAME)/node())
+};
+
+declare
+	%test:assertEquals(3)
+function zut:entry-of-doc-child-nodes-including-pis() {
+    let $entries := <entry type="xml" name="{$zut:DOC_WITH_PIS_1_NAME}">{doc($zut:DOC_WITH_PIS_1_PATH)/node()}</entry>
+    return
+        let $zip-data := compression:zip($entries, true())
+        return
+            let $output-collection-path := $zut:TEST_COLLECTION_PATH || "/entry-of-doc-child-nodes-including-pis"
+            let $_ := compression:unzip($zip-data, compression:no-filter#2, compression:db-store-entry3($output-collection-path))
+            return
+                count(doc($output-collection-path || "/" || $zut:DOC_WITH_PIS_1_NAME)/node())
+};
+

--- a/extensions/modules/compression/src/test/xquery/modules/compression/zip-unzip-tests.xqm
+++ b/extensions/modules/compression/src/test/xquery/modules/compression/zip-unzip-tests.xqm
@@ -81,3 +81,62 @@ function zut:entry-of-doc-child-nodes-including-pis() {
                 count(doc($output-collection-path || "/" || $zut:DOC_WITH_PIS_1_NAME)/node())
 };
 
+declare
+	%test:assertEquals("<test>123</test>", "<test>abc</test>")
+function zut:round-trip-no-filter2-db-store-entry-3-without-encoding() {
+    let $entries := (
+        <entry type="xml" name="test1.xml"><test>123</test></entry>,
+        <entry type="xml" name="test2.xml"><test>abc</test></entry>
+    ) return
+        let $zip-data := compression:zip($entries, true())
+        return
+            let $output-collection-path := $zut:TEST_COLLECTION_PATH || "/round-trip-no-filter2-db-store-entry-3-without-encoding"
+            let $_ := compression:unzip($zip-data, compression:no-filter#2, compression:db-store-entry3($output-collection-path))
+            return
+                collection($output-collection-path)
+};
+
+declare
+	%test:assertEquals("<test>123</test>", "<test>abc</test>")
+function zut:round-trip-no-filter2-db-store-entry-3-utf8-encoding() {
+    let $entries := (
+        <entry type="xml" name="test1.xml"><test>123</test></entry>,
+        <entry type="xml" name="test2.xml"><test>abc</test></entry>
+    ) return
+        let $zip-data := compression:zip($entries, true())
+        return
+            let $output-collection-path := $zut:TEST_COLLECTION_PATH || "/round-trip-no-filter2-db-store-entry-3-utf8-encoding"
+            let $_ := compression:unzip($zip-data, compression:no-filter#2, compression:db-store-entry3($output-collection-path), "UTF-8")
+            return
+                collection($output-collection-path)
+};
+
+declare
+	%test:assertEquals("<test>123</test>", "<test>abc</test>")
+function zut:round-trip-no-filter3-db-store-entry-4-without-encoding() {
+    let $entries := (
+        <entry type="xml" name="test1.xml"><test>123</test></entry>,
+        <entry type="xml" name="test2.xml"><test>abc</test></entry>
+    ) return
+        let $zip-data := compression:zip($entries, true())
+        return
+            let $output-collection-path := $zut:TEST_COLLECTION_PATH || "/round-trip-no-filter3-db-store-entry-4-without-encoding"
+            let $_ := compression:unzip($zip-data, compression:no-filter#3, <params/>, compression:db-store-entry4($output-collection-path), <params/>)
+            return
+                collection($output-collection-path)
+};
+
+declare
+	%test:assertEquals("<test>123</test>", "<test>abc</test>")
+function zut:round-trip-no-filter3-db-store-entry-4-utf8-encoding() {
+    let $entries := (
+        <entry type="xml" name="test1.xml"><test>123</test></entry>,
+        <entry type="xml" name="test2.xml"><test>abc</test></entry>
+    ) return
+        let $zip-data := compression:zip($entries, true())
+        return
+            let $output-collection-path := $zut:TEST_COLLECTION_PATH || "/round-trip-no-filter3-db-store-entry-4-utf8-encoding"
+            let $_ := compression:unzip($zip-data, compression:no-filter#3, <params/>, compression:db-store-entry4($output-collection-path), <params/>, "UTF-8")
+            return
+                collection($output-collection-path)
+};

--- a/extensions/modules/exi/pom.xml
+++ b/extensions/modules/exi/pom.xml
@@ -139,9 +139,9 @@
                             -->
                             <header>${project.parent.relativePath}/../../elemental-parent/elemental-LGPL-21-ONLY-license.template.txt</header>
                             <excludes>
+                                <exclude>exi-functions-demo.xql</exclude>
                                 <exclude>pom.xml</exclude>
                                 <exclude>src/**</exclude>
-                                <exclude>exi-functions-demo.xql</exclude>
                             </excludes>
                         </licenseSet>
 
@@ -160,6 +160,8 @@
                             </multi>
                             <includes>
                                 <include>pom.xml</include>
+                                <include>src/main/java/org/exist/xquery/modules/exi/DecodeExiFunction.java</include>
+                                <include>src/main/java/org/exist/xquery/modules/exi/EncodeExiFunction.java</include>
                             </includes>
                         </licenseSet>
 
@@ -170,6 +172,8 @@
                             <header>${project.parent.relativePath}/../../exist-parent/existdb-LGPL-21-license.template.txt</header>
                             <excludes>
                                 <exclude>pom.xml</exclude>
+                                <exclude>src/main/java/org/exist/xquery/modules/exi/DecodeExiFunction.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/modules/exi/EncodeExiFunction.java</exclude>
                             </excludes>
                         </licenseSet>
 

--- a/extensions/modules/exi/src/main/java/org/exist/xquery/modules/exi/DecodeExiFunction.java
+++ b/extensions/modules/exi/src/main/java/org/exist/xquery/modules/exi/DecodeExiFunction.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -125,8 +149,8 @@ public class DecodeExiFunction extends BasicFunction {
 				context.popDocumentContext();
 			}
 		}
-		catch(EXIException | SAXException | IOException exie) {
-			throw new XPathException(this, new JavaErrorCode(exie.getCause()), exie.getMessage());
+		catch(final EXIException | SAXException | IOException exie) {
+			throw new XPathException(this, JavaErrorCode.fromThrowable(exie.getCause()), exie.getMessage());
 		}
 	}
 

--- a/extensions/modules/exi/src/main/java/org/exist/xquery/modules/exi/EncodeExiFunction.java
+++ b/extensions/modules/exi/src/main/java/org/exist/xquery/modules/exi/EncodeExiFunction.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -114,8 +138,8 @@ public class EncodeExiFunction extends BasicFunction {
 			// TODO - test!
 			throw new XPathException(this, ErrorCodes.FODC0002, ioex.getMessage());
 		}
-		catch(EXIException | SAXException exie) {
-			throw new XPathException(this, new JavaErrorCode(exie.getCause()), exie.getMessage());
+		catch(final EXIException | SAXException exie) {
+			throw new XPathException(this, JavaErrorCode.fromThrowable(exie.getCause()), exie.getMessage());
 		}
 	}
 	

--- a/extensions/modules/file/pom.xml
+++ b/extensions/modules/file/pom.xml
@@ -94,7 +94,6 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -218,6 +217,7 @@
                                 <include>src/test/resources/log4j2.xml</include>
                                 <include>src/test/resources/standalone-webapp/WEB-INF/web.xml</include>
                                 <include>src/main/java/org/exist/xquery/modules/file/FileModuleHelper.java</include>
+                                <include>src/main/java/org/exist/xquery/modules/file/FileReadUnicode.java</include>
                                 <include>src/main/java/org/exist/xquery/modules/file/Sync.java</include>
                             </includes>
                         </licenseSet>
@@ -233,6 +233,7 @@
                                 <exclude>src/test/resources/log4j2.xml</exclude>
                                 <exclude>src/test/resources/standalone-webapp/WEB-INF/web.xml</exclude>
                                 <exclude>src/main/java/org/exist/xquery/modules/file/FileModuleHelper.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/modules/file/FileReadUnicode.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/modules/file/Sync.java</exclude>
                             </excludes>
                         </licenseSet>

--- a/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/FileReadUnicode.java
+++ b/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/FileReadUnicode.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -22,12 +46,12 @@
 package org.exist.xquery.modules.file;
 
 import java.io.IOException;
-import java.io.StringWriter;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -102,7 +126,7 @@ public class FileReadUnicode extends BasicFunction {
 		}
 		
 		try(final UnicodeReader reader = new UnicodeReader(Files.newInputStream(file), encoding.name());
-				final StringWriter sw  = new StringWriter()) {
+				final StringBuilderWriter sw  = new StringBuilderWriter()) {
 
 			char[] buf = new char[1024];
 			int len;

--- a/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/SendEmailFunction.java
+++ b/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/SendEmailFunction.java
@@ -46,6 +46,7 @@
 package org.exist.xquery.modules.mail;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.Version;
@@ -701,7 +702,7 @@ public class SendEmailFunction extends BasicFunction {
                                         //Convert everything inside <xhtml></xhtml> to text
                                         final Transformer transformer = TRANSFORMER_FACTORY.newTransformer();
                                         final DOMSource source = new DOMSource(bodyPart.getFirstChild());
-                                        try (final StringWriter strWriter = new StringWriter()) {
+                                        try (final StringBuilderWriter strWriter = new StringBuilderWriter()) {
                                             final StreamResult result = new StreamResult(strWriter);
                                             transformer.transform(source, result);
                                             mail.setXHTML(strWriter.toString());
@@ -840,7 +841,7 @@ public class SendEmailFunction extends BasicFunction {
                                             //Convert everything inside <xhtml></xhtml> to text
                                             final Transformer transformer = TRANSFORMER_FACTORY.newTransformer();
                                             final DOMSource source = new DOMSource(bodyPart.getFirstChild());
-                                            try (final StringWriter strWriter = new StringWriter()) {
+                                            try (final StringBuilderWriter strWriter = new StringBuilderWriter()) {
                                                 final StreamResult result = new StreamResult(strWriter);
                                                 transformer.transform(source, result);
                                                 content = strWriter.toString();
@@ -907,7 +908,7 @@ public class SendEmailFunction extends BasicFunction {
                                     if (Node.ELEMENT_NODE == attachChild.getNodeType()) {
                                         final Transformer transformer = TRANSFORMER_FACTORY.newTransformer();
                                         final DOMSource source = new DOMSource(attachChild);
-                                        try (final StringWriter strWriter = new StringWriter()) {
+                                        try (final StringBuilderWriter strWriter = new StringBuilderWriter()) {
                                             final StreamResult result = new StreamResult(strWriter);
                                             transformer.transform(source, result);
                                             content.append(strWriter);

--- a/extensions/modules/mail/src/test/java/org/exist/xquery/modules/mail/WriteMessageTest.java
+++ b/extensions/modules/mail/src/test/java/org/exist/xquery/modules/mail/WriteMessageTest.java
@@ -34,12 +34,12 @@ package org.exist.xquery.modules.mail;
 
 import com.evolvedbinary.j8fu.tuple.Tuple2;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.exist.util.UUIDGenerator;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -588,7 +588,7 @@ public class WriteMessageTest {
 
     private String[] writeMessage(final SendEmailFunction.Mail mail) throws IOException {
         final String[] lines;
-        try (final StringWriter writer = new StringWriter();
+        try (final StringBuilderWriter writer = new StringBuilderWriter();
              final PrintWriter printWriter = new PrintWriter(writer)) {
             SendEmailFunction.writeMessage(printWriter, mail, true, CHARSET);
 


### PR DESCRIPTION
Previously code inherited from eXist-db was not correctly returning all child nodes of a document node. This caused corruption when Exporting EXPath Apps from eXide.

Closes https://github.com/evolvedbinary/elemental/issues/4
Closes https://github.com/evolvedbinary/elemental/issues/7
Closes https://github.com/evolvedbinary/elemental/issues/8