### PR TITLE
[7.x.x] Make sure that underlying type check errors are exposed for deferred function calls

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -780,6 +780,7 @@
                                 <include>src/test/resources/log4j2.xml</include>
                                 <include>src/test/resources-filtered/conf.xml</include>
                                 <include>src/test/resources/standalone-webapp/WEB-INF/web.xml</include>
+                                <include>src/test/xquery/tail-recursion.xml</include>
                                 <include>src/test/xquery/maps/maps.xqm</include>
                                 <include>src/test/xquery/util/util.xml</include>
                                 <include>src/test/xquery/xquery3/parse-xml.xqm</include>
@@ -965,6 +966,8 @@
                                 <include>src/main/java/org/exist/xqj/Marshaller.java</include>
                                 <include>src/test/java/org/exist/xqj/MarshallerTest.java</include>
                                 <include>src/test/java/org/exist/xquery/ConstructedNodesRecoveryTest.java</include>
+                                <include>src/main/java/org/exist/xquery/DeferredFunctionCall.java</include>
+                                <include>src/main/java/org/exist/xquery/DynamicCardinalityCheck.java</include>
                                 <include>src/main/java/org/exist/xquery/DynamicTypeCheck.java</include>
                                 <include>src/main/java/org/exist/xquery/ErrorCodes.java</include>
                                 <include>src/test/java/org/exist/xquery/ForwardReferenceTest.java</include>
@@ -1055,6 +1058,7 @@
                                 <exclude>src/test/xquery/instance-of.xqm</exclude>
                                 <exclude>src/test/xquery/operator-mapping.xqm</exclude>
                                 <exclude>src/test/xquery/order.xqm</exclude>
+                                <exclude>src/test/xquery/tail-recursion.xml</exclude>
                                 <exclude>src/test/xquery/type-promotion.xqm</exclude>
                                 <exclude>src/test/xquery/maps/maps.xqm</exclude>
                                 <exclude>src/test/xquery/securitymanager/acl.xqm</exclude>
@@ -1320,6 +1324,8 @@
                                 <exclude>src/main/java/org/exist/xquery/Cardinality.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/CastExpressionTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/ConstructedNodesRecoveryTest.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/DeferredFunctionCall.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/DynamicCardinalityCheck.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/DynamicTypeCheck.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/ErrorCodes.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/ForwardReferenceTest.java</exclude>

--- a/exist-core/src/main/java/org/exist/xquery/DeferredFunctionCall.java
+++ b/exist-core/src/main/java/org/exist/xquery/DeferredFunctionCall.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -44,7 +68,7 @@ public abstract class DeferredFunctionCall implements Sequence {
     
     private FunctionSignature signature;
     private Sequence sequence = null;
-    private XPathException caughtException = null;
+    private @Nullable XPathException caughtException = null;
 
     protected DeferredFunctionCall(FunctionSignature signature) {
         this.signature = signature;
@@ -57,6 +81,15 @@ public abstract class DeferredFunctionCall implements Sequence {
         if (sequence == null) {
             sequence = execute();
         }
+    }
+
+    /**
+     * Get any exception that has been caught.
+     *
+     * @return an XPathException or null if there is no caught exception.
+     */
+    public @Nullable XPathException getCaughtException() {
+        return caughtException;
     }
     
     protected FunctionSignature getSignature() {

--- a/exist-core/src/main/java/org/exist/xquery/DynamicCardinalityCheck.java
+++ b/exist-core/src/main/java/org/exist/xquery/DynamicCardinalityCheck.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -27,6 +51,8 @@ import org.exist.xquery.util.ExpressionDumper;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.Sequence;
 
+import javax.annotation.Nullable;
+
 /**
  * Runtime-check for the cardinality of a function parameter.
  * 
@@ -47,52 +73,71 @@ public class DynamicCardinalityCheck extends AbstractExpression {
         setLocation(expression.getLine(), expression.getColumn());
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Expression#analyze(org.exist.xquery.Expression)
-     */
-    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+    @Override
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
         contextInfo.setParent(this);
         expression.analyze(contextInfo);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Expression#eval(org.exist.xquery.StaticContext, org.exist.dom.persistent.DocumentSet, org.exist.xquery.value.Sequence, org.exist.xquery.value.Item)
-     */
-    public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
+    @Override
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
         if (context.getProfiler().isEnabled()) {
             context.getProfiler().start(this);
-            context.getProfiler().message(this, Profiler.DEPENDENCIES,
-                "DEPENDENCIES", Dependency.getDependenciesName(this.getDependencies()));
-            if (contextSequence != null)
-                {context.getProfiler().message(this, Profiler.START_SEQUENCES,
-                "CONTEXT SEQUENCE", contextSequence);}
-            if (contextItem != null)
-                {context.getProfiler().message(this, Profiler.START_SEQUENCES,
-                "CONTEXT ITEM", contextItem.toSequence());}
+            context.getProfiler().message(this, Profiler.DEPENDENCIES, "DEPENDENCIES", Dependency.getDependenciesName(this.getDependencies()));
+            if (contextSequence != null) {
+                context.getProfiler().message(this, Profiler.START_SEQUENCES, "CONTEXT SEQUENCE", contextSequence);
+            }
+            if (contextItem != null) {
+                context.getProfiler().message(this, Profiler.START_SEQUENCES, "CONTEXT ITEM", contextItem.toSequence());
+            }
         }
+
         final Sequence seq = expression.eval(contextSequence, contextItem);
-        Cardinality actualCardinality;
-        if (seq.isEmpty())
-            {actualCardinality = Cardinality.EMPTY_SEQUENCE;}
-        else if (seq.hasMany())
-            {actualCardinality = Cardinality._MANY;}
-        else
-            {actualCardinality = Cardinality.EXACTLY_ONE;}
+
+        final Cardinality actualCardinality;
+        if (isEmpty(seq)) {
+            actualCardinality = Cardinality.EMPTY_SEQUENCE;
+        } else if (hasMany(seq)) {
+            actualCardinality = Cardinality._MANY;
+        } else {
+            actualCardinality = Cardinality.EXACTLY_ONE;
+        }
+
         if (!requiredCardinality.isSuperCardinalityOrEqualOf(actualCardinality)) {
-            error.addArgs(ExpressionDumper.dump(expression),
-                requiredCardinality.getHumanDescription(),
-                    seq.getItemCount());
+            error.addArgs(ExpressionDumper.dump(expression), requiredCardinality.getHumanDescription(), seq.getItemCount());
             throw new XPathException(this, error.toString());
         }
-        if (context.getProfiler().isEnabled())
-            {context.getProfiler().end(this, "", seq);}
+
+        if (context.getProfiler().isEnabled()) {
+            context.getProfiler().end(this, "", seq);
+        }
+
         return seq;
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Expression#dump(org.exist.xquery.util.ExpressionDumper)
-     */
-    public void dump(ExpressionDumper dumper) {
+    private boolean isEmpty(final Sequence sequence) throws XPathException {
+        final boolean empty = sequence.isEmpty();
+        throwIfDeferredFunctionCallAndHasException(sequence);
+        return empty;
+    }
+
+    private boolean hasMany(final Sequence sequence) throws XPathException {
+        final boolean hasMany = sequence.hasMany();
+        throwIfDeferredFunctionCallAndHasException(sequence);
+        return hasMany;
+    }
+
+    private void throwIfDeferredFunctionCallAndHasException(final Sequence sequence) throws XPathException {
+        if (sequence instanceof DeferredFunctionCall) {
+            @Nullable final XPathException caughtException = ((DeferredFunctionCall) sequence).getCaughtException();
+            if (caughtException != null) {
+                throw caughtException;
+            }
+        }
+    }
+
+    @Override
+    public void dump(final ExpressionDumper dumper) {
         if(dumper.verbosity() > 1) {
             dumper.display("dynamic-cardinality-check"); 
             dumper.display("("); 
@@ -108,44 +153,42 @@ public class DynamicCardinalityCheck extends AbstractExpression {
         return expression.toString();
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Expression#returnsType()
-     */
+    @Override
     public int returnsType() {
         return expression.returnsType();
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.AbstractExpression#getDependencies()
-     */
+    @Override
     public int getDependencies() {
         return expression.getDependencies();
     }
 
-    public void setContextDocSet(DocumentSet contextSet) {
+    public void setContextDocSet(final DocumentSet contextSet) {
         super.setContextDocSet(contextSet);
         expression.setContextDocSet(contextSet);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.AbstractExpression#resetState()
-     */
-    public void resetState(boolean postOptimization) {
+    @Override
+    public void resetState(final boolean postOptimization) {
         super.resetState(postOptimization);
         expression.resetState(postOptimization);
     }
 
-    public void accept(ExpressionVisitor visitor) {
+    @Override
+    public void accept(final ExpressionVisitor visitor) {
         expression.accept(visitor);
     }
 
+    @Override
     public int getSubExpressionCount() {
         return 1;
     }
-    
-    public Expression getSubExpression(int index) {
-        if (index == 0)
-            {return expression;}
-        throw new IndexOutOfBoundsException("Index: " + index + ", Size: "+getSubExpressionCount());
+
+    @Override
+    public Expression getSubExpression(final int index) {
+        if (index == 0) {
+            return expression;
+        }
+        throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + getSubExpressionCount());
     }
 }

--- a/exist-core/src/test/xquery/tail-recursion.xml
+++ b/exist-core/src/test/xquery/tail-recursion.xml
@@ -1,6 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Elemental
+    Copyright (C) 2024, Evolved Binary Ltd
+
+    admin@evolvedbinary.com
+    https://www.evolvedbinary.com | https://www.elemental.xyz
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; version 2.1.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+    NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+          The original license header is included below.
+
+    =====================================================================
+
     eXist-db Open Source Native XML Database
     Copyright (C) 2001 The eXist-db Authors
 
@@ -29,6 +53,7 @@
         <author>LordGeoffrey</author>
     </description>
     <setup>
+        <create-collection parent="/db" name="test-correct-error"/>
     </setup>
     <!-- 
     <test output="text">
@@ -55,5 +80,39 @@ declare function local:plus($x, $total) {
 local:plus(1000, 0)
 </code>
         <expected>500500</expected>
+    </test>
+    <test output="text">
+        <!-- See: https://github.com/eXist-db/exist/issues/5139 -->
+        <task>correct-error</task>
+        <code><![CDATA[
+        xquery version "3.1";
+
+declare function local:parent-collection($collection-path as xs:string) as xs:string? {
+   let $parent-collection-path := replace($collection-path, "(/.+)/.*", "$1")
+   return
+       if ($parent-collection-path eq $collection-path or not(starts-with($parent-collection-path, "/db")))
+       then
+           ()
+       else
+           $parent-collection-path
+};
+
+declare %private function local:ascend($collection-path as xs:string, $group-name as xs:string, $collection-permission as xs:string) as empty-sequence() {
+    if (not(starts-with($collection-path, "/db")))
+    then
+       ()
+    else
+       let $_ := sm:add-group-ace(xs:anyURI($collection-path), $group-name, true(), $collection-permission)
+       return
+            local:ascend(local:parent-collection($collection-path), $group-name, $collection-permission)
+};
+
+try {
+    local:ascend("/db/test-correct-error", "guest", "r-x")
+} catch * {
+    substring-before($err:description, ", source:")
+}
+        ]]></code>
+        <expected>exerr:ERROR XPTY0004: The actual cardinality for parameter 1 does not match the cardinality declared in the function's signature: local:ascend($collection-path as xs:string, $group-name as xs:string, $collection-permission as xs:string) empty-sequence(). Expected cardinality: exactly one, got 0. [at line 21, column 26</expected>
     </test>
 </TestSet>


### PR DESCRIPTION
Previously type check errors were not correctly surfaced when checking the types of arguments supplied to deferred function calls. This is now corrected.

Closes https://github.com/eXist-db/exist/issues/5139