### PR TITLE
[bugfix] #4958 & #4810

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/GeneralComparison.java
+++ b/exist-core/src/main/java/org/exist/xquery/GeneralComparison.java
@@ -648,6 +648,9 @@ public class GeneralComparison extends BinaryOp implements Optimizable, IndexUse
                     }
                 }
             }
+            if (result.isEmpty()) {
+                return BooleanValue.FALSE;
+            }
         }
 
         if( context.getProfiler().traceFunctions() ) {

--- a/exist-core/src/main/java/org/exist/xquery/Predicate.java
+++ b/exist-core/src/main/java/org/exist/xquery/Predicate.java
@@ -36,6 +36,7 @@ import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.SequenceIterator;
 import org.exist.xquery.value.Type;
 import org.exist.xquery.value.ValueSequence;
+import org.exist.xquery.value.BooleanValue;
 
 import javax.annotation.Nullable;
 import java.util.Set;
@@ -377,10 +378,13 @@ public class Predicate extends PathExpr {
         final NodeSet contextSet = contextSequence.toNodeSet();
         final boolean contextIsVirtual = contextSet instanceof VirtualNodeSet;
         contextSet.setTrackMatches(false);
-        final Sequence x = super.eval(contextSet, null);
-        if(!(x instanceof NodeSet))
-            return x;
-        final NodeSet nodes = result.toNodeSet();
+        final Sequence res = super.eval(contextSet, null);
+        if(!(res instanceof NodeSet)) {
+            if(res == BooleanValue.FALSE)
+                return NodeSet.EMPTY_SET;
+            return res;
+        }
+        final NodeSet nodes = res.toNodeSet();
 
         /*
          * if the predicate expression returns results from the cache we can

--- a/exist-core/src/main/java/org/exist/xquery/Predicate.java
+++ b/exist-core/src/main/java/org/exist/xquery/Predicate.java
@@ -377,7 +377,11 @@ public class Predicate extends PathExpr {
         final NodeSet contextSet = contextSequence.toNodeSet();
         final boolean contextIsVirtual = contextSet instanceof VirtualNodeSet;
         contextSet.setTrackMatches(false);
-        final NodeSet nodes = super.eval(contextSet, null).toNodeSet();
+        final Sequence x = super.eval(contextSet, null);
+        if(!(x instanceof NodeSet))
+            return x;
+        final NodeSet nodes = result.toNodeSet();
+
         /*
          * if the predicate expression returns results from the cache we can
          * also return the cached result.

--- a/exist-core/src/test/xquery/emptySeq.xq
+++ b/exist-core/src/test/xquery/emptySeq.xq
@@ -1,0 +1,38 @@
+xquery version "3.1";
+
+module namespace t="http://exist-db.org/xquery/test";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $t:XML := document {
+    <F id="1"/>
+};
+
+declare
+    %test:setUp
+function t:setup() {
+    xmldb:create-collection("/db", "test"),
+    xmldb:store("/db/test", "test.xml", $t:XML)
+};
+
+declare
+    %test:tearDown
+function t:tearDown() {
+    xmldb:remove("/db/test")
+};
+
+declare
+    %test:assertTrue
+function t:test-db() {
+    exists(
+        doc("/db/test/test.xml")//F[boolean(count(@id >= 2))]
+    )
+};
+
+declare
+    %test:assertTrue
+function t:test-mem() {
+    exists(
+        $t:XML//F[boolean(count(@id >= 2))]
+    )
+};

--- a/exist-core/src/test/xquery/startWithComp.xq
+++ b/exist-core/src/test/xquery/startWithComp.xq
@@ -1,0 +1,32 @@
+xquery version "3.1";
+
+module namespace t="http://exist-db.org/xquery/test";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $t:XML := document {
+    <Y1 id="1">
+        <H1 id="2" a2="2">true</H1>
+    </Y1>
+};
+
+declare
+    %test:setUp
+function t:setup() {
+    let $testCol := xmldb:create-collection("/db", "test")
+    return
+        xmldb:store("/db/test", "test.xml", $t:XML)
+};
+
+declare
+    %test:tearDown
+function t:tearDown() {
+    xmldb:remove("/db/test")
+};
+
+declare
+    %test:assertTrue
+function t:test() {
+    doc("/db/test/test.xml")//*[starts-with(@a2, "1") = false()]
+    => exists()
+};


### PR DESCRIPTION
### Description:

**Issues**: 
Closes https://github.com/eXist-db/exist/issues/4958
Closes https://github.com/eXist-db/exist/issues/4810

**What was wrong**

The general comparisons engine only returns a node set for a comparison if the comparison is not empty.
If it is empty, it doesn’t return false, which is fine in most cases but can lead to issues like the ones I’ve fixed in this PR.

What I’ve done is: whenever an empty node set would be returned, I simply return false instead. This works in most cases, but not with the predicate engine. That’s because when general comparison is used, the context sequence indicates that the execution mode for the predicate engine must be set to "node" — i.e., it expects a node set instead of a boolean. I’ve made the necessary changes to handle that as well. I’m aware this might not be the ideal solution, but any alternative could would require significant changes across many functions.

### Reference:
XPath 3.1 is explicit: a general comparison must return true or false, never a node sequence. See: 3.7.2 [General comparison](https://www.w3.org/TR/xpath-31/#id-general-comparisons)

### Tests:
Added test cases for the same