### PR TITLE
[7.x.x] Remove disclaimer from JAC startup

### DIFF
--- a/exist-core/src/main/java/org/exist/client/InteractiveClient.java
+++ b/exist-core/src/main/java/org/exist/client/InteractiveClient.java
@@ -2494,12 +2494,6 @@ public class InteractiveClient {
         builder.append(Calendar.getInstance().get(Calendar.YEAR));
         builder.append(" Evolved Binary Ltd");
         builder.append(EOL);
-        builder.append("Elemental comes with ABSOLUTELY NO WARRANTY.");
-        builder.append(EOL);
-        builder.append("This is free software, and you are welcome to redistribute it");
-        builder.append(EOL);
-        builder.append("under certain conditions; for details read the license file.");
-        builder.append(EOL);
         return builder.toString();
     }
 

--- a/exist-core/src/test/java/org/exist/client/InteractiveClientTest.java
+++ b/exist-core/src/test/java/org/exist/client/InteractiveClientTest.java
@@ -233,10 +233,7 @@ class InteractiveClientTest {
         replay(collection, mgtService, perm, resource, clientFrame, account, group, propertyAction);
 
         String expected = "Elemental version testVersion (gitCommitId), Copyright (C) 2024-" +
-                Calendar.getInstance().get(Calendar.YEAR) + " Evolved Binary Ltd" + EOL +
-                "Elemental comes with ABSOLUTELY NO WARRANTY." + EOL +
-                "This is free software, and you are welcome to redistribute it" + EOL +
-                "under certain conditions; for details read the license file." + EOL;
+                Calendar.getInstance().get(Calendar.YEAR) + " Evolved Binary Ltd" + EOL;
         assertThat(client.getNotice(propertyAction)).isNotNull().isEqualTo(expected);
     }
 


### PR DESCRIPTION
The disclaimer printed when the JAC (Java Admin Client) starts is redundant as this is already covered in the license terms.