### PR TITLE
[7.x.x] Correct a syntax error in the log4j2 config used for testing the XSL:FO module

### DIFF
--- a/extensions/modules/xslfo/src/test/resources/log4j2.xml
+++ b/extensions/modules/xslfo/src/test/resources/log4j2.xml
@@ -111,6 +111,7 @@
             </Policies>
             <DefaultRolloverStrategy max="${rollover.max}"/>
             <PatternLayout pattern="${elemental.file.pattern}"/>
+        </RollingRandomAccessFile>
         
         <RollingRandomAccessFile name="elemental.restxq" filePattern="${logs}/restxq.${rollover.file.pattern}.log.gz" fileName="${logs}/restxq.log">
             <Policies>


### PR DESCRIPTION
The log4j2 XML config file that is used for testing the XSL:FO extension module previously contained a syntax error. This was harmless, it just meant that messages were not logged correctly when running the test suite.