### PR TITLE
[7.x.x] Coalesce namespaces with different prefixes when serializing XML

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -975,6 +975,7 @@
                                 <include>src/main/java/org/exist/util/serializer/DOMStreamer.java</include>
                                 <include>src/main/java/org/exist/util/serializer/EXISerializer.java</include>
                                 <include>src/test/java/org/exist/util/serializer/HTML5WriterTest.java</include>
+                                <include>src/main/java/org/exist/util/serializer/SAXSerializer.java</include>
                                 <include>src/main/java/org/exist/util/serializer/SerializerObjectFactory.java</include>
                                 <include>src/main/java/org/exist/util/serializer/json/JSONObject.java</include>
                                 <include>src/test/java/org/exist/util/serializer/json/JSONObjectTest.java</include>
@@ -1388,6 +1389,7 @@
                                 <exclude>src/main/java/org/exist/util/serializer/DOMStreamer.java</exclude>
                                 <exclude>src/main/java/org/exist/util/serializer/EXISerializer.java</exclude>
                                 <exclude>src/test/java/org/exist/util/serializer/HTML5WriterTest.java</exclude>
+                                <exclude>src/main/java/org/exist/util/serializer/SAXSerializer.java</exclude>
                                 <exclude>src/main/java/org/exist/util/serializer/SerializerObjectFactory.java</exclude>
                                 <exclude>src/main/java/org/exist/util/serializer/json/JSONObject.java</exclude>
                                 <exclude>src/test/java/org/exist/util/serializer/json/JSONObjectTest.java</exclude>

--- a/exist-core/src/main/java/org/exist/util/StringUtil.java
+++ b/exist-core/src/main/java/org/exist/util/StringUtil.java
@@ -293,4 +293,24 @@ public class StringUtil {
 
         return string.substring(0, idx);
     }
+
+    /**
+     * Test if two strings are equal whilst handling null references.
+     *
+     * @param s1 the first string.
+     * @param s2 the second string.
+     *
+     * @return true of the strings are equal or both are null, false otherwise.
+     */
+    public static boolean equals(@Nullable final String s1, @Nullable final String s2) {
+        if (s1 == s2) {
+            return true;
+        }
+
+        if (s1 == null) {
+            return false;
+        }
+
+        return s1.equals(s2);
+    }
 }

--- a/exist-core/src/main/java/org/exist/util/serializer/SAXSerializer.java
+++ b/exist-core/src/main/java/org/exist/util/serializer/SAXSerializer.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -25,6 +49,7 @@ import org.exist.Namespaces;
 import org.exist.dom.INodeHandle;
 import org.exist.dom.QName;
 import org.exist.storage.serializers.EXistOutputKeys;
+import org.exist.util.StringUtil;
 import org.exist.util.XMLString;
 import org.w3c.dom.Document;
 import org.xml.sax.Attributes;
@@ -138,16 +163,13 @@ public class SAXSerializer extends AbstractSerializer implements ContentHandler,
     }
 
     @Override
-    public void startElement(String namespaceURI, final String localName, final String qname, final Attributes attribs) throws SAXException {
+    public void startElement(String namespaceURI, final String localName, String qname, final Attributes attribs) throws SAXException {
         try {
             namespaceDecls.clear();
             nsSupport.pushContext();
-            receiver.startElement(namespaceURI, localName, qname);
-            String elemPrefix = XMLConstants.DEFAULT_NS_PREFIX;
-            int p = qname.indexOf(':');
-            if (p > 0) {
-                elemPrefix = qname.substring(0, p);
-            }
+
+            // calculate namespaces
+            final String elemPrefix = getQNamePrefix(qname);
             if (namespaceURI == null) {
                 namespaceURI = XMLConstants.NULL_NS_URI;
             }
@@ -159,14 +181,12 @@ public class SAXSerializer extends AbstractSerializer implements ContentHandler,
                 nsSupport.declarePrefix(elemPrefix, namespaceURI);
             }
             // check attributes for required namespace declarations
-            String attrName;
-            String uri;
-            if(attribs != null) {
+            if (attribs != null) {
                 for (int i = 0; i < attribs.getLength(); i++) {
-                    attrName = attribs.getQName(i);
+                    final String attrName = attribs.getQName(i);
                     if (XMLConstants.XMLNS_ATTRIBUTE.equals(attrName)) {
                         if (nsSupport.getURI(XMLConstants.DEFAULT_NS_PREFIX) == null) {
-                            uri = attribs.getValue(i);
+                            String uri = attribs.getValue(i);
                             if (enforceXHTML && !Namespaces.XHTML_NS.equals(uri)) {
                                 uri = Namespaces.XHTML_NS;
                             }
@@ -174,34 +194,54 @@ public class SAXSerializer extends AbstractSerializer implements ContentHandler,
                             nsSupport.declarePrefix(XMLConstants.DEFAULT_NS_PREFIX, uri);
                         }
                     } else if (attrName.startsWith(XMLConstants.XMLNS_ATTRIBUTE + ":")) {
-                        final String prefix = attrName.substring(6);
-                        if (nsSupport.getURI(prefix) == null) {
-                            uri = attribs.getValue(i);
-                            namespaceDecls.put(prefix, uri);
-                            nsSupport.declarePrefix(prefix, uri);
+                        final String attrPrefix = attrName.substring(6);
+                        if (nsSupport.getURI(attrPrefix) == null) {
+                            final String uri = attribs.getValue(i);
+                            namespaceDecls.put(attrPrefix, uri);
+                            nsSupport.declarePrefix(attrPrefix, uri);
                         }
-                    } else if ((p = attrName.indexOf(':')) > 0) {
-                        final String prefix = attrName.substring(0, p);
-                        uri = attribs.getURI(i);
-                        if (nsSupport.getURI(prefix) == null) {
-                            namespaceDecls.put(prefix, uri);
-                            nsSupport.declarePrefix(prefix, uri);
+                    } else {
+                        final int p = attrName.indexOf(':');
+                        if (p > 0) {
+                            final String attrPrefix = attrName.substring(0, p);
+                            final String uri = attribs.getURI(i);
+                            if (nsSupport.getURI(attrPrefix) == null) {
+                                namespaceDecls.put(attrPrefix, uri);
+                                nsSupport.declarePrefix(attrPrefix, uri);
+                            }
                         }
                     }
                 }
             }
             for (final Map.Entry<String, String> nsEntry : optionalNamespaceDecls.entrySet()) {
                 final String prefix = nsEntry.getKey();
-                uri = nsEntry.getValue(); 
-                receiver.namespace(prefix, uri);
-                nsSupport.declarePrefix(prefix, uri); //nsSupport.declarePrefix(prefix, namespaceURI);
+                final String uri = nsEntry.getValue();
+                nsSupport.declarePrefix(prefix, uri);
             }
+
+            // output the start of the element itself
+            final boolean elemPrefixedNsIsDefaultNs = (!localName.equals(qname)) && StringUtil.equals(nsSupport.getURI(XMLConstants.DEFAULT_NS_PREFIX), nsSupport.getURI(elemPrefix));
+            if (elemPrefixedNsIsDefaultNs) {
+                // NOTE(AR) remove qname namespace prefix if the prefix points to the same namespace as the default namespace - see: https://github.com/eXist-db/exist/issues/5790
+                qname = localName;
+            }
+            receiver.startElement(namespaceURI, localName, qname);
+
             // output all namespace declarations
+            for (final Map.Entry<String, String> nsEntry : optionalNamespaceDecls.entrySet()) {
+                final String prefix = nsEntry.getKey();
+                final String uri = nsEntry.getValue();
+                if (!(elemPrefixedNsIsDefaultNs && uri.equals(namespaceURI) && elemPrefix.equals(prefix))) {
+                    receiver.namespace(prefix, uri);
+                }
+            }
             for (final Map.Entry<String, String> nsEntry : namespaceDecls.entrySet()) {
                 final String prefix = nsEntry.getKey();
-                uri = nsEntry.getValue(); 
+                final String uri = nsEntry.getValue();
                 if(!optionalNamespaceDecls.containsKey(prefix)) {
-                    receiver.namespace(prefix, uri);
+                    if (!(elemPrefixedNsIsDefaultNs && uri.equals(namespaceURI) && elemPrefix.equals(prefix))) {
+                        receiver.namespace(prefix, uri);
+                    }
                 }
             }
             //cancels current xmlns if relevant
@@ -210,6 +250,7 @@ public class SAXSerializer extends AbstractSerializer implements ContentHandler,
                 nsSupport.declarePrefix(XMLConstants.DEFAULT_NS_PREFIX, namespaceURI);
             }
             optionalNamespaceDecls.clear();
+
             // output attributes
             if(attribs != null) {
                 for (int i = 0; i < attribs.getLength(); i++) {
@@ -228,33 +269,30 @@ public class SAXSerializer extends AbstractSerializer implements ContentHandler,
         try {
             namespaceDecls.clear();
             nsSupport.pushContext();
-            String prefix = qname.getPrefix();
-            String namespaceURI = qname.getNamespaceURI();
-            if(prefix == null) {
-                prefix = XMLConstants.DEFAULT_NS_PREFIX;
+
+            // calculate namespaces
+            String elemPrefix = qname.getPrefix();
+            if (elemPrefix == null) {
+                elemPrefix = XMLConstants.DEFAULT_NS_PREFIX;
             }
+            String namespaceURI = qname.getNamespaceURI();
             if(namespaceURI == null) {
                 namespaceURI = XMLConstants.NULL_NS_URI;
             }
-            if(enforceXHTML && prefix.isEmpty() && namespaceURI.isEmpty()) {
+            if(enforceXHTML && elemPrefix.isEmpty() && namespaceURI.isEmpty()) {
                 namespaceURI = Namespaces.XHTML_NS;
-                receiver.startElement(new QName(qname.getLocalPart(), namespaceURI, qname.getPrefix()));
-            } else {
-                receiver.startElement(qname);
             }
-            if (nsSupport.getURI(prefix) == null) {
-                namespaceDecls.put(prefix, namespaceURI);
-                nsSupport.declarePrefix(prefix, namespaceURI);
+            if (nsSupport.getURI(elemPrefix) == null) {
+                namespaceDecls.put(elemPrefix, namespaceURI);
+                nsSupport.declarePrefix(elemPrefix, namespaceURI);
             }
             // check attributes for required namespace declarations
-            QName attrQName;
-            String uri;
-            if(attribs != null) {
+            if (attribs != null) {
                 for (int i = 0; i < attribs.getLength(); i++) {
-                    attrQName = attribs.getQName(i);
+                    final QName attrQName = attribs.getQName(i);
                     if (XMLConstants.XMLNS_ATTRIBUTE.equals(attrQName.getLocalPart())) {
                         if (nsSupport.getURI(XMLConstants.DEFAULT_NS_PREFIX) == null) {
-                            uri = attribs.getValue(i);
+                            String uri = attribs.getValue(i);
                             if (enforceXHTML && !Namespaces.XHTML_NS.equals(uri)) {
                                 uri = Namespaces.XHTML_NS;
                             }
@@ -262,41 +300,58 @@ public class SAXSerializer extends AbstractSerializer implements ContentHandler,
                             nsSupport.declarePrefix(XMLConstants.DEFAULT_NS_PREFIX, uri);
                         }
                     } else if (attrQName.getPrefix() != null && !attrQName.getPrefix().isEmpty()) {
-                        prefix = attrQName.getPrefix();
-                        if (nsSupport.getURI(prefix) == null) {
-                            uri = attrQName.getNamespaceURI();
-                            namespaceDecls.put(prefix, uri);
-                            nsSupport.declarePrefix(prefix, uri);
+                        final String attrPrefix = attrQName.getPrefix();
+                        if (nsSupport.getURI(attrPrefix) == null) {
+                            final String uri = attrQName.getNamespaceURI();
+                            namespaceDecls.put(attrPrefix, uri);
+                            nsSupport.declarePrefix(attrPrefix, uri);
                         }
                     }
                 }
             }
-            String optPrefix;
             for (final Map.Entry<String, String> nsEntry : optionalNamespaceDecls.entrySet()) {
-                optPrefix = nsEntry.getKey();
-                uri = nsEntry.getValue(); 
-                receiver.namespace(optPrefix, uri);
-                nsSupport.declarePrefix(optPrefix, uri);
+                final String prefix = nsEntry.getKey();
+                final String uri = nsEntry.getValue();
+                nsSupport.declarePrefix(prefix, uri);
             }
+
+            // output the start of the element itself
+            final boolean elemPrefixedNsIsDefaultNs = StringUtil.equals(nsSupport.getURI(XMLConstants.DEFAULT_NS_PREFIX), nsSupport.getURI(elemPrefix));
+            if (elemPrefixedNsIsDefaultNs) {
+                // NOTE(AR) remove qname namespace prefix if the prefix points to the same namespace as the default namespace - see: https://github.com/eXist-db/exist/issues/5790
+                elemPrefix = XMLConstants.DEFAULT_NS_PREFIX;
+            }
+            receiver.startElement(new QName(qname.getLocalPart(), namespaceURI, elemPrefix));
+
             // output all namespace declarations
+            for (final Map.Entry<String, String> nsEntry : optionalNamespaceDecls.entrySet()) {
+                final String prefix = nsEntry.getKey();
+                final String uri = nsEntry.getValue();
+                if (!(elemPrefixedNsIsDefaultNs && uri.equals(namespaceURI) && elemPrefix.equals(prefix))) {
+                    receiver.namespace(prefix, uri);
+                }
+            }
             for (final Map.Entry<String, String> nsEntry : namespaceDecls.entrySet()) {
-                optPrefix = nsEntry.getKey();
-                if (XMLConstants.XMLNS_ATTRIBUTE.equals(optPrefix)) {
+                final String prefix = nsEntry.getKey();
+                if (XMLConstants.XMLNS_ATTRIBUTE.equals(prefix)) {
                     continue;
                 }
-                uri = nsEntry.getValue(); 
-                if(!optionalNamespaceDecls.containsKey(optPrefix)) {
-                    receiver.namespace(optPrefix, uri);
+                final String uri = nsEntry.getValue();
+                if(!optionalNamespaceDecls.containsKey(prefix)) {
+                    if (!(elemPrefixedNsIsDefaultNs && uri.equals(namespaceURI) && elemPrefix.equals(prefix))) {
+                        receiver.namespace(prefix, uri);
+                    }
                 }
             }
-            optionalNamespaceDecls.clear();
             //cancels current xmlns if relevant
-            if (XMLConstants.DEFAULT_NS_PREFIX.equals(prefix) && !namespaceURI.equals(receiver.getDefaultNamespace())) {
+            if (XMLConstants.DEFAULT_NS_PREFIX.equals(elemPrefix) && !namespaceURI.equals(receiver.getDefaultNamespace())) {
                 receiver.namespace(XMLConstants.DEFAULT_NS_PREFIX, namespaceURI);
                 nsSupport.declarePrefix(XMLConstants.DEFAULT_NS_PREFIX, namespaceURI);
             }
+            optionalNamespaceDecls.clear();
+
+            // output attributes
             if(attribs != null) {
-                // output attributes
                 for (int i = 0; i < attribs.getLength(); i++) {
                     if (!attribs.getQName(i).getLocalPart().startsWith(XMLConstants.XMLNS_ATTRIBUTE)) {
                         receiver.attribute(attribs.getQName(i), attribs.getValue(i));
@@ -309,10 +364,22 @@ public class SAXSerializer extends AbstractSerializer implements ContentHandler,
     }
 
     @Override
-    public void endElement(final String namespaceURI, final String localName, final String qname) throws SAXException {
+    public void endElement(String namespaceURI, final String localName, String qname) throws SAXException {
         try {
+            final String elemPrefix = getQNamePrefix(qname);
+            if ((!localName.equals(qname)) && StringUtil.equals(nsSupport.getURI(XMLConstants.DEFAULT_NS_PREFIX), nsSupport.getURI(elemPrefix))) {
+                // NOTE(AR) remove qname namespace prefix if the prefix points to the same namespace as the default namespace - see: https://github.com/eXist-db/exist/issues/5790
+                qname = localName;
+            }
+
             nsSupport.popContext();
+
+            // output the end of the element itself
+            if (enforceXHTML && qname.indexOf(':') == -1 && namespaceURI.isEmpty()) {
+                namespaceURI = Namespaces.XHTML_NS;
+            }
             receiver.endElement(namespaceURI, localName, qname);
+
             receiver.setDefaultNamespace(nsSupport.getURI(XMLConstants.DEFAULT_NS_PREFIX));
         } catch (final TransformerException e) {
             throw new SAXException(e.getMessage(), e);
@@ -322,27 +389,42 @@ public class SAXSerializer extends AbstractSerializer implements ContentHandler,
     @Override
     public void endElement(final QName qname) throws SAXException {
         try {
-            nsSupport.popContext();
-            String prefix = qname.getPrefix();
-            String namespaceURI = qname.getNamespaceURI();
-            if(prefix == null) {
-                prefix = XMLConstants.DEFAULT_NS_PREFIX;
+            String elemPrefix = qname.getPrefix();
+            if (elemPrefix == null) {
+                elemPrefix = XMLConstants.DEFAULT_NS_PREFIX;
             }
-            
+
+            String namespaceURI = qname.getNamespaceURI();
             if(namespaceURI == null) {
                 namespaceURI = XMLConstants.NULL_NS_URI;
             }
-            
-            if(enforceXHTML && prefix.isEmpty() && namespaceURI.isEmpty()) {
-                namespaceURI = Namespaces.XHTML_NS;
-                receiver.endElement(new QName(qname.getLocalPart(), namespaceURI, qname.getPrefix()));
-            } else {
-                receiver.endElement(qname);
+
+            if (StringUtil.equals(nsSupport.getURI(XMLConstants.DEFAULT_NS_PREFIX), nsSupport.getURI(elemPrefix))) {
+                // NOTE(AR) remove qname namespace prefix if the prefix points to the same namespace as the default namespace - see: https://github.com/eXist-db/exist/issues/5790
+                elemPrefix = XMLConstants.DEFAULT_NS_PREFIX;
             }
+
+            nsSupport.popContext();
+
+            // output the end of the element itself
+            if (enforceXHTML && elemPrefix.isEmpty() && namespaceURI.isEmpty()) {
+                namespaceURI = Namespaces.XHTML_NS;
+            }
+            receiver.endElement(new QName(qname.getLocalPart(), namespaceURI, qname.getPrefix()));
+
             receiver.setDefaultNamespace(nsSupport.getURI(XMLConstants.DEFAULT_NS_PREFIX));
         } catch (final TransformerException e) {
             throw new SAXException(e.getMessage(), e);
         }
+    }
+
+    private String getQNamePrefix(final String qname) {
+        String elemPrefix = XMLConstants.DEFAULT_NS_PREFIX;
+        final int p = qname.indexOf(':');
+        if (p > 0) {
+            elemPrefix = qname.substring(0, p);
+        }
+        return elemPrefix;
     }
 
     @Override

--- a/exist-core/src/test/java/org/exist/xmldb/SerializationTest.java
+++ b/exist-core/src/test/java/org/exist/xmldb/SerializationTest.java
@@ -101,10 +101,10 @@ public class SerializationTest {
 
 	private static final String XML_EXPECTED2 =
 		"<exist:result xmlns:exist=\"" + Namespaces.EXIST_NS + "\" hitCount=\"1\">" + EOL +
-		"    <c:Site xmlns:c=\"urn:content\" xmlns=\"urn:content\">" + EOL +
+		"    <Site xmlns=\"urn:content\">" + EOL +
         "        <config xmlns=\"urn:config\">123</config>" + EOL +
         "        <serverconfig xmlns=\"urn:config\">123</serverconfig>" + EOL +
-		"    </c:Site>" + EOL +
+		"    </Site>" + EOL +
 		"</exist:result>";
 
 	private static final String XML_UPDATED_EXPECTED =

--- a/exist-core/src/test/java/org/exist/xquery/XQueryTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryTest.java
@@ -915,12 +915,12 @@ public class XQueryTest {
         result = service.query(query);
         assertEquals("XQuery: " + query,
                 "<result xmlns=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +
-                "    <rdf:Description xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" id=\"3\">\n" +
+                "    <Description id=\"3\">\n" +
                 "        <dc:title xmlns:dc=\"http://purl.org/dc/elements/1.1/\">title</dc:title>\n" +
                 "        <dc:creator xmlns:dc=\"http://purl.org/dc/elements/1.1/\">creator</dc:creator>\n" +
                 "        <x:place xmlns:x=\"http://exist.sourceforge.net/dc-ext\">place</x:place>\n" +
                 "        <x:edition xmlns:x=\"http://exist.sourceforge.net/dc-ext\">place</x:edition>\n" +
-                "    </rdf:Description>\n" +
+                "    </Description>\n" +
                 "</result>",
                 result.getResource(0).getContent());
 

--- a/exist-core/src/test/xquery/xquery3/parse-xml.xqm
+++ b/exist-core/src/test/xquery/xquery3/parse-xml.xqm
@@ -46,9 +46,43 @@
 xquery version "3.0";
 
 (:~ Additional tests for the fn:parse-xml and fn:parse-xml-fragment functions :)
-module namespace px="http://exist-db.org/xquery/test/parse-xml";
+module namespace px ="http://exist-db.org/xquery/test/parse-xml";
 
-declare namespace test="http://exist-db.org/xquery/xqsuite";
+declare namespace tei = "http://www.tei-c.org/ns/1.0";
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
+
+
+declare %private variable $px:test-collection-name := "test-parse-xml";
+declare %private variable $px:test-collection-uri := "/db/" || $px:test-collection-name;
+
+declare %private variable $px:example1-doc := document {
+    <notes xmlns="http://www.tei-c.org/ns/1.0">
+        <note><hi>Adam</hi></note>
+    </notes>
+};
+
+declare %private variable $px:example1-inmemory-inserter := function($note) as document-node(element(tei:listPerson)) {
+    document {
+        <notes xmlns="http://www.tei-c.org/ns/1.0">
+            <note><hi>Adam</hi></note>
+            {$note}
+        </notes>
+    }
+};
+
+
+declare
+    %test:setUp
+function px:setup() {
+    xmldb:create-collection("/db", $px:test-collection-name)
+};
+
+declare
+    %test:tearDown
+function px:teardown() {
+    xmldb:remove("/db/" || $px:test-collection-name)
+};
 
 declare
     %test:assertEmpty
@@ -144,4 +178,337 @@ declare
     %test:assertError("FODC0006")
 function px:fragment-xml-decl-encoding-standalone-no() {
     fn:parse-xml-fragment('<?xml version="1.0" encoding="utf8" standalone="no"?><a/>')
+};
+
+declare
+    %test:assertTrue
+function px:insert-document-parse-xml-no-ns-into-persistent-dom() {
+    let $expected-serialized := fn:serialize(document {<notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi xmlns="">insert-document-parse-xml-no-ns-into-persistent-dom</hi></note></notes> })
+
+    let $note-content := parse-xml("<hi>insert-document-parse-xml-no-ns-into-persistent-dom</hi>")
+    let $notes := px:insert-document-into-persistent-dom("insert-document-parse-xml-no-ns-into-persistent-dom.xml", $note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-element-parse-xml-no-ns-into-persistent-dom() {
+    let $expected-serialized := fn:serialize(document {<notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi xmlns="">insert-element-parse-xml-no-ns-into-persistent-dom</hi></note></notes> })
+
+    let $note-content := parse-xml("<hi>insert-element-parse-xml-no-ns-into-persistent-dom</hi>")
+    let $notes := px:insert-element-into-persistent-dom("insert-element-parse-xml-no-ns-into-persistent-dom.xml", $note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-document-parse-xml-no-ns-into-inmemory-dom() {
+    let $expected-serialized := fn:serialize(document {<notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi xmlns="">insert-document-parse-xml-no-ns-into-inmemory-dom</hi></note></notes> })
+
+    let $note-content := parse-xml("<hi>insert-document-parse-xml-no-ns-into-inmemory-dom</hi>")
+    let $notes := px:insert-document-into-inmemory-dom($note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-element-parse-xml-no-ns-into-inmemory-dom() {
+    let $expected-serialized := fn:serialize(document {<notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi xmlns="">insert-element-parse-xml-no-ns-into-inmemory-dom</hi></note></notes> })
+
+    let $note-content := parse-xml("<hi>insert-element-parse-xml-no-ns-into-inmemory-dom</hi>")
+    let $notes := px:insert-element-into-inmemory-dom($note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-document-parse-xml-ns-into-persistent-dom() {
+    let $expected-serialized := fn:serialize(document { <notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi>insert-document-parse-xml-ns-into-persistent-dom</hi></note></notes> })
+
+    let $note-content := parse-xml("<hi xmlns='http://www.tei-c.org/ns/1.0'>insert-document-parse-xml-ns-into-persistent-dom</hi>")
+    let $notes := px:insert-document-into-persistent-dom("insert-document-parse-xml-ns-into-persistent-dom.xml", $note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-element-parse-xml-ns-into-persistent-dom() {
+    let $expected-serialized := fn:serialize(document { <notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi>insert-element-parse-xml-ns-into-persistent-dom</hi></note></notes> })
+
+    let $note-content := parse-xml("<hi xmlns='http://www.tei-c.org/ns/1.0'>insert-element-parse-xml-ns-into-persistent-dom</hi>")
+    let $notes := px:insert-element-into-persistent-dom("insert-element-parse-xml-ns-into-persistent-dom.xml", $note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-document-parse-xml-ns-into-inmemory-dom() {
+    let $expected-serialized := fn:serialize(document {<notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi>insert-document-parse-xml-ns-into-inmemory-dom</hi></note></notes> })
+
+    let $note-content := parse-xml("<hi xmlns='http://www.tei-c.org/ns/1.0'>insert-document-parse-xml-ns-into-inmemory-dom</hi>")
+    let $notes := px:insert-document-into-inmemory-dom($note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-element-parse-xml-ns-into-inmemory-dom() {
+    let $expected-serialized := fn:serialize(document {<notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi>insert-element-parse-xml-ns-into-inmemory-dom</hi></note></notes> })
+
+    let $note-content := parse-xml("<hi xmlns='http://www.tei-c.org/ns/1.0'>insert-element-parse-xml-ns-into-inmemory-dom</hi>")
+    let $notes := px:insert-element-into-inmemory-dom($note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-document-parse-xml-prefix-into-persistent-dom() {
+    let $expected-serialized := fn:serialize(document { <notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi>insert-document-parse-xml-prefix-into-persistent-dom</hi></note></notes> })
+
+    let $note-content := parse-xml("<tei:hi xmlns:tei='http://www.tei-c.org/ns/1.0'>insert-document-parse-xml-prefix-into-persistent-dom</tei:hi>")
+    let $notes := px:insert-document-into-persistent-dom("insert-document-parse-xml-prefix-into-persistent-dom.xml", $note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-element-parse-xml-prefix-into-persistent-dom() {
+    let $expected-serialized := fn:serialize(document { <notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi>insert-element-parse-xml-prefix-into-persistent-dom</hi></note></notes> })
+
+    let $note-content := parse-xml("<tei:hi xmlns:tei='http://www.tei-c.org/ns/1.0'>insert-element-parse-xml-prefix-into-persistent-dom</tei:hi>")
+    let $notes := px:insert-element-into-persistent-dom("insert-element-parse-xml-prefix-into-persistent-dom.xml", $note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-document-parse-xml-prefix-into-inmemory-dom() {
+    let $expected-serialized := fn:serialize(document { <notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi>insert-document-parse-xml-prefix-into-inmemory-dom</hi></note></notes> })
+
+    let $note-content := parse-xml("<tei:hi xmlns:tei='http://www.tei-c.org/ns/1.0'>insert-document-parse-xml-prefix-into-inmemory-dom</tei:hi>")
+    let $notes := px:insert-document-into-inmemory-dom($note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-element-parse-xml-prefix-into-inmemory-dom() {
+    let $expected-serialized := fn:serialize(document { <notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi>insert-element-parse-xml-prefix-into-inmemory-dom</hi></note></notes> })
+
+    let $note-content := parse-xml("<tei:hi xmlns:tei='http://www.tei-c.org/ns/1.0'>insert-element-parse-xml-prefix-into-inmemory-dom</tei:hi>")
+    let $notes := px:insert-element-into-inmemory-dom($note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-document-parse-xml-fragment-no-ns-into-persistent-dom() {
+    let $expected-serialized := fn:serialize(document {<notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi xmlns="">insert-document-parse-xml-fragment-no-ns-into-persistent-dom</hi></note></notes> })
+
+    let $note-content := parse-xml-fragment("<hi>insert-document-parse-xml-fragment-no-ns-into-persistent-dom</hi>")
+    let $notes := px:insert-document-into-persistent-dom("insert-document-parse-xml-fragment-no-ns-into-persistent-dom.xml", $note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-element-parse-xml-fragment-no-ns-into-persistent-dom() {
+    let $expected-serialized := fn:serialize(document {<notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi xmlns="">insert-element-parse-xml-fragment-no-ns-into-persistent-dom</hi></note></notes> })
+
+    let $note-content := parse-xml-fragment("<hi>insert-element-parse-xml-fragment-no-ns-into-persistent-dom</hi>")
+    let $notes := px:insert-element-into-persistent-dom("insert-element-parse-xml-fragment-no-ns-into-persistent-dom.xml", $note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-document-parse-xml-fragment-no-ns-into-inmemory-dom() {
+    let $expected-serialized := fn:serialize(document {<notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi xmlns="">insert-document-parse-xml-fragment-no-ns-into-inmemory-dom</hi></note></notes> })
+
+    let $note-content := parse-xml-fragment("<hi>insert-document-parse-xml-fragment-no-ns-into-inmemory-dom</hi>")
+    let $notes := px:insert-document-into-inmemory-dom($note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-element-parse-xml-fragment-no-ns-into-inmemory-dom() {
+    let $expected-serialized := fn:serialize(document {<notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi xmlns="">insert-element-parse-xml-fragment-no-ns-into-inmemory-dom</hi></note></notes> })
+
+    let $note-content := parse-xml-fragment("<hi>insert-element-parse-xml-fragment-no-ns-into-inmemory-dom</hi>")
+    let $notes := px:insert-element-into-inmemory-dom($note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-document-parse-xml-fragment-ns-into-persistent-dom() {
+    let $expected-serialized := fn:serialize(document { <notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi>insert-document-parse-xml-fragment-ns-into-persistent-dom</hi></note></notes> })
+
+    let $note-content := parse-xml-fragment("<hi xmlns='http://www.tei-c.org/ns/1.0'>insert-document-parse-xml-fragment-ns-into-persistent-dom</hi>")
+    let $notes := px:insert-document-into-persistent-dom("insert-document-parse-xml-fragment-ns-into-persistent-dom.xml", $note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-element-parse-xml-fragment-ns-into-persistent-dom() {
+    let $expected-serialized := fn:serialize(document { <notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi>insert-element-parse-xml-fragment-ns-into-persistent-dom</hi></note></notes> })
+
+    let $note-content := parse-xml-fragment("<hi xmlns='http://www.tei-c.org/ns/1.0'>insert-element-parse-xml-fragment-ns-into-persistent-dom</hi>")
+    let $notes := px:insert-element-into-persistent-dom("insert-element-parse-xml-fragment-ns-into-persistent-dom.xml", $note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-document-parse-xml-fragment-ns-into-inmemory-dom() {
+    let $expected-serialized := fn:serialize(document {<notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi>insert-document-parse-xml-fragment-ns-into-inmemory-dom</hi></note></notes> })
+
+    let $note-content := parse-xml-fragment("<hi xmlns='http://www.tei-c.org/ns/1.0'>insert-document-parse-xml-fragment-ns-into-inmemory-dom</hi>")
+    let $notes := px:insert-document-into-inmemory-dom($note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-element-parse-xml-fragment-ns-into-inmemory-dom() {
+    let $expected-serialized := fn:serialize(document {<notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi>insert-element-parse-xml-fragment-ns-into-inmemory-dom</hi></note></notes> })
+
+    let $note-content := parse-xml-fragment("<hi xmlns='http://www.tei-c.org/ns/1.0'>insert-element-parse-xml-fragment-ns-into-inmemory-dom</hi>")
+    let $notes := px:insert-element-into-inmemory-dom($note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-document-parse-xml-fragment-prefix-into-persistent-dom() {
+    let $expected-serialized := fn:serialize(document { <notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi>insert-document-parse-xml-fragment-prefix-into-persistent-dom</hi></note></notes> })
+
+    let $note-content := parse-xml-fragment("<tei:hi xmlns:tei='http://www.tei-c.org/ns/1.0'>insert-document-parse-xml-fragment-prefix-into-persistent-dom</tei:hi>")
+    let $notes := px:insert-document-into-persistent-dom("insert-document-parse-xml-fragment-prefix-into-persistent-dom.xml", $note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-element-parse-xml-fragment-prefix-into-persistent-dom() {
+    let $expected-serialized := fn:serialize(document { <notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi>insert-element-parse-xml-fragment-prefix-into-persistent-dom</hi></note></notes> })
+
+    let $note-content := parse-xml-fragment("<tei:hi xmlns:tei='http://www.tei-c.org/ns/1.0'>insert-element-parse-xml-fragment-prefix-into-persistent-dom</tei:hi>")
+    let $notes := px:insert-element-into-persistent-dom("insert-element-parse-xml-fragment-prefix-into-persistent-dom.xml", $note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-document-parse-xml-fragment-prefix-into-inmemory-dom() {
+    let $expected-serialized := fn:serialize(document { <notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi>insert-document-parse-xml-fragment-prefix-into-inmemory-dom</hi></note></notes> })
+
+    let $note-content := parse-xml-fragment("<tei:hi xmlns:tei='http://www.tei-c.org/ns/1.0'>insert-document-parse-xml-fragment-prefix-into-inmemory-dom</tei:hi>")
+    let $notes := px:insert-document-into-inmemory-dom($note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %test:assertTrue
+function px:insert-element-parse-xml-fragment-prefix-into-inmemory-dom() {
+    let $expected-serialized := fn:serialize(document { <notes xmlns="http://www.tei-c.org/ns/1.0"><note><hi>Adam</hi></note><note><hi>insert-element-parse-xml-fragment-prefix-into-inmemory-dom</hi></note></notes> })
+
+    let $note-content := parse-xml-fragment("<tei:hi xmlns:tei='http://www.tei-c.org/ns/1.0'>insert-element-parse-xml-fragment-prefix-into-inmemory-dom</tei:hi>")
+    let $notes := px:insert-element-into-inmemory-dom($note-content)
+    let $actual := fn:serialize($notes)
+    return
+        $expected-serialized eq $actual
+};
+
+declare
+    %private
+function px:insert-document-into-persistent-dom($test-doc-name as xs:string, $note-content) as document-node(element(tei:listPerson)) {
+    let $test-doc-uri := xmldb:store($px:test-collection-uri, $test-doc-name, $px:example1-doc)
+
+    let $note := document {
+        <note xmlns="http://www.tei-c.org/ns/1.0">{$note-content}</note>
+    }
+    let $notes := doc($test-doc-uri)/tei:notes
+    let $_ := update insert $note into $notes
+    return
+        doc($test-doc-uri)
+};
+
+declare
+    %private
+function px:insert-element-into-persistent-dom($test-doc-name as xs:string, $note-content) as document-node(element(tei:listPerson)) {
+    let $test-doc-uri := xmldb:store($px:test-collection-uri, $test-doc-name, $px:example1-doc)
+
+    let $note := <note xmlns="http://www.tei-c.org/ns/1.0">{$note-content}</note>
+
+    let $notes := doc($test-doc-uri)/tei:notes
+    let $_ := update insert $note into $notes
+    return
+        doc($test-doc-uri)
+};
+
+declare
+    %private
+function px:insert-document-into-inmemory-dom($note-content) as document-node(element(tei:listPerson)) {
+    let $note := document {
+        <note xmlns="http://www.tei-c.org/ns/1.0">{$note-content}</note>
+    }
+    return
+        $px:example1-inmemory-inserter($note)
+};
+
+declare
+    %private
+function px:insert-element-into-inmemory-dom($note-content) as document-node(element(tei:listPerson)) {
+    let $note := <note xmlns="http://www.tei-c.org/ns/1.0">{$note-content}</note>
+    return
+        $px:example1-inmemory-inserter($note)
 };


### PR DESCRIPTION
When serializing XML, if the prefix points to the same namespace as the default namespace, the namespace declarations can be coalesced. We achieve this by removing the qname namespace prefix from the next element which is in the same same namespace.

Closes https://github.com/eXist-db/exist/issues/5790