### PR TITLE
[6.x.x] Include the version in the name of the deployment created on Maven Central Staging Portal

### DIFF
--- a/elemental-parent/pom.xml
+++ b/elemental-parent/pom.xml
@@ -629,7 +629,7 @@
                         <artifactId>central-publishing-maven-plugin</artifactId>
                         <configuration>
                             <publishingServerId>central</publishingServerId>
-                            <deploymentName>${project.artifactId}</deploymentName>
+                            <deploymentName>${project.artifactId}-${project.version}</deploymentName>
                             <failOnBuildFailure>true</failOnBuildFailure>
                             <waitUntil>validated</waitUntil>
                         </configuration>


### PR DESCRIPTION
Backport of https://github.com/evolvedbinary/elemental/pull/25

Previously the deployment name did not include a version number. This just makes it easier for the Release Manager to disambiguate the deployments on the Maven Central Staging Portal.