### PR TITLE
[6.x.x] Remove disclaimer from JAC startup

### DIFF
--- a/exist-core/src/main/java/org/exist/client/InteractiveClient.java
+++ b/exist-core/src/main/java/org/exist/client/InteractiveClient.java
@@ -2557,12 +2557,6 @@ public class InteractiveClient {
         builder.append(Calendar.getInstance().get(Calendar.YEAR));
         builder.append(" Evolved Binary Ltd");
         builder.append(EOL);
-        builder.append("Elemental comes with ABSOLUTELY NO WARRANTY.");
-        builder.append(EOL);
-        builder.append("This is free software, and you are welcome to redistribute it");
-        builder.append(EOL);
-        builder.append("under certain conditions; for details read the license file.");
-        builder.append(EOL);
         return builder.toString();
     }
 


### PR DESCRIPTION
Backport of https://github.com/evolvedbinary/elemental/pull/26

The disclaimer printed when the JAC (Java Admin Client) starts is redundant as this is already covered in the license terms.