### PR TITLE
[6.x.x] Avoid an NPE when in ext-test-error-function

### DIFF
--- a/exist-core/src/main/java/org/exist/test/runner/ExtTestErrorFunction.java
+++ b/exist-core/src/main/java/org/exist/test/runner/ExtTestErrorFunction.java
@@ -105,12 +105,11 @@ public class ExtTestErrorFunction extends JUnitIntegrationFunction {
 
         final XPathException xpe = new XPathException(lineNumber, columnNumber, errorCode, description);
 
-        final Sequence seqJavaStackTrace = errorMap.get(new StringValue(this, "java-stack-trace"));
+        @Nullable final Sequence seqJavaStackTrace = errorMap.get(new StringValue(this, "java-stack-trace"));
         if (seqJavaStackTrace != null && !seqJavaStackTrace.isEmpty()) {
-            try {
-                xpe.setStackTrace(convertStackTraceElements(seqJavaStackTrace));
-            } catch (final NullPointerException e) {
-                e.printStackTrace();
+            @Nullable final StackTraceElement[] stackTraceElements = convertStackTraceElements(seqJavaStackTrace);
+            if (stackTraceElements != null) {
+                xpe.setStackTrace(stackTraceElements);
             }
         }
 


### PR DESCRIPTION
Backport of https://github.com/evolvedbinary/elemental/pull/28

Previously under certain circumstances it was possible for an NPE to occur in the ext-test-error-function of the XSuite test executor.