### PR TITLE
[6.x.x] Raise error FOJS0007 on all elements passed to fn:xmj-to-json that are missing Fn namespace

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunXmlToJson.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunXmlToJson.java
@@ -143,6 +143,7 @@ public class FunXmlToJson extends BasicFunction {
                 status = reader.next();
                 switch (status) {
                     case XMLStreamReader.START_ELEMENT:
+                        checkNamespace(reader.getNamespaceURI());
                         tempStringBuilder.setLength(0);
                         final String elementAttributeEscapedValue = reader.getAttributeValue(null, "escaped");
                         elementValueIsEscaped = "true".equals(elementAttributeEscapedValue);
@@ -167,11 +168,9 @@ public class FunXmlToJson extends BasicFunction {
                         }
                         switch (reader.getLocalName()) {
                             case "array":
-                                checkNamespace(reader.getNamespaceURI());
                                 jsonGenerator.writeStartArray();
                                 break;
                             case "map":
-                                checkNamespace(reader.getNamespaceURI());
                                 mapkeyArrayList.add(stackSeparator);
                                 jsonGenerator.writeStartObject();
                                 break;
@@ -187,7 +186,6 @@ public class FunXmlToJson extends BasicFunction {
                         final String tempString = tempStringBuilder.toString();
                         switch (reader.getLocalName()) {
                             case "array":
-                                checkNamespace(reader.getNamespaceURI());
                                 jsonGenerator.writeEndArray();
                                 break;
                             case "boolean":
@@ -195,7 +193,6 @@ public class FunXmlToJson extends BasicFunction {
                                 jsonGenerator.writeBoolean(tempBoolean);
                                 break;
                             case "map":
-                                checkNamespace(reader.getNamespaceURI());
                                 while (!mapkeyArrayList.isEmpty() && mapkeyArrayList.remove(mapkeyArrayList.size() - 1) != stackSeparator) {
                                 }
                                 jsonGenerator.writeEndObject();


### PR DESCRIPTION
Backport of https://github.com/evolvedbinary/elemental/pull/29

Improves upon 04c0e9d which seems to have only partially fixed the issue previously.
Closes https://github.com/eXist-db/exist/issues/5543