### PR TITLE
[6.x.x] Fix issues with Lucene Index optimisations and Matches

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -917,8 +917,10 @@
                                 <include>src/main/java/org/exist/xquery/DynamicCardinalityCheck.java</include>
                                 <include>src/main/java/org/exist/xquery/DynamicTypeCheck.java</include>
                                 <include>src/main/java/org/exist/xquery/ErrorCodes.java</include>
+                                <include>src/main/java/org/exist/xquery/FilteredExpression.java</include>
                                 <include>src/test/java/org/exist/xquery/ForwardReferenceTest.java</include>
                                 <include>src/main/java/org/exist/xquery/FunctionFactory.java</include>
+                                <include>src/main/java/org/exist/xquery/LocationStep.java</include>
                                 <include>src/main/java/org/exist/xquery/Optimizer.java</include>
                                 <include>src/main/java/org/exist/xquery/PerformanceStats.java</include>
                                 <include>src/main/java/org/exist/xquery/TryCatchExpression.java</include>
@@ -962,6 +964,7 @@
                                 <include>src/main/java/org/exist/xquery/functions/xmldb/XMLDBStore.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/xmldb/XMLDBXUpdate.java</include>
                                 <include>src/main/antlr/org/exist/xquery/parser/XQueryTree.g</include>
+                                <include>src/main/java/org/exist/xquery/pragmas/Optimize.java</include>
                                 <include>src/test/java/org/exist/xquery/update/UpdateReplaceTest.java</include>
                                 <include>src/main/java/org/exist/xquery/util/ExpressionDumper.java</include>
                                 <include>src/main/java/org/exist/xquery/util/SerializerUtils.java</include>
@@ -1257,8 +1260,10 @@
                                 <include>src/main/java/org/exist/xquery/DynamicCardinalityCheck.java</include>
                                 <exclude>src/main/java/org/exist/xquery/DynamicTypeCheck.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/ErrorCodes.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/FilteredExpression.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/ForwardReferenceTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/FunctionFactory.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/LocationStep.java</exclude>
                                 <exclude>src/test/resources-filtered/org/exist/xquery/import-from-pkg-test.conf.xml</exclude>
                                 <exclude>src/test/java/org/exist/xquery/ImportFromPkgTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/ImportModuleTest.java</exclude>
@@ -1326,6 +1331,7 @@
                                 <exclude>src/main/java/org/exist/xquery/functions/xmldb/XMLDBXUpdate.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/xquery3/SerializeTest.java</exclude>
                                 <exclude>src/main/antlr/org/exist/xquery/parser/XQueryTree.g</exclude>
+                                <exclude>src/main/java/org/exist/xquery/pragmas/Optimize.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/pragmas/TimePragma.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/update/UpdateReplaceTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/util/ExpressionDumper.java</exclude>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -796,6 +796,8 @@
                                 <include>src/main/java/org/exist/dom/persistent/DocumentImpl.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/DocumentSet.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/ElementImpl.java</include>
+                                <include>src/main/java/org/exist/dom/persistent/Match.java</include>
+                                <include>src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/NodeProxy.java</include>
                                 <include>src/test/java/org/exist/dom/persistent/NodeTest.java</include>
                                 <include>src/test/java/org/exist/dom/persistent/PersistentDomTest.java</include>
@@ -1080,6 +1082,8 @@
                                 <exclude>src/main/java/org/exist/dom/persistent/DocumentImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/DocumentSet.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/ElementImpl.java</exclude>
+                                <exclude>src/main/java/org/exist/dom/persistent/Match.java</exclude>
+                                <exclude>src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/NodeProxy.java</exclude>
                                 <exclude>src/test/java/org/exist/dom/persistent/NodeTest.java</exclude>
                                 <exclude>src/test/java/org/exist/dom/persistent/PersistentDomTest.java</exclude>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -912,6 +912,7 @@
                                 <include>src/main/java/org/exist/xmlrpc/RpcConnection.java</include>
                                 <include>src/main/java/org/exist/xqj/Marshaller.java</include>
                                 <include>src/test/java/org/exist/xqj/MarshallerTest.java</include>
+                                <include>src/main/java/org/exist/xquery/CombiningExpression.java</include>
                                 <include>src/test/java/org/exist/xquery/ConstructedNodesRecoveryTest.java</include>
                                 <include>src/main/java/org/exist/xquery/DeferredFunctionCall.java</include>
                                 <include>src/main/java/org/exist/xquery/DynamicCardinalityCheck.java</include>
@@ -1255,6 +1256,7 @@
                                 <exclude>src/main/java/org/exist/xqj/Marshaller.java</exclude>
                                 <exclude>src/test/java/org/exist/xqj/MarshallerTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/Cardinality.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/CombiningExpression.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/ConstructedNodesRecoveryTest.java</exclude>
                                 <include>src/main/java/org/exist/xquery/DeferredFunctionCall.java</include>
                                 <include>src/main/java/org/exist/xquery/DynamicCardinalityCheck.java</include>

--- a/exist-core/src/main/java/org/exist/dom/persistent/Match.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/Match.java
@@ -23,6 +23,7 @@ package org.exist.dom.persistent;
 
 import org.exist.numbering.NodeId;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -78,20 +79,20 @@ public abstract class Match implements Comparable<Match> {
     }
 
     private final int context;
-    protected final NodeId nodeId;
-    private final String matchTerm;
+    private final NodeId nodeId;
+    private @Nullable final String matchTerm;
     private int[] offsets;
     private int[] lengths;
 
     private int currentOffset = 0;
 
-    protected Match nextMatch = null;
+    private @Nullable Match nextMatch = null;
 
-    protected Match(final int contextId, final NodeId nodeId, final String matchTerm) {
+    protected Match(final int contextId, final NodeId nodeId, @Nullable final String matchTerm) {
         this(contextId, nodeId, matchTerm, 1);
     }
 
-    protected Match(final int contextId, final NodeId nodeId, final String matchTerm, final int frequency) {
+    protected Match(final int contextId, final NodeId nodeId, @Nullable final String matchTerm, final int frequency) {
         this.context = contextId;
         this.nodeId = nodeId;
         this.matchTerm = matchTerm;
@@ -120,16 +121,24 @@ public abstract class Match implements Comparable<Match> {
         return context;
     }
 
-    public abstract Match createInstance(final int contextId, final NodeId nodeId, final String matchTerm);
+    public @Nullable Match getNextMatch() {
+        return nextMatch;
+    }
+
+    public void setNextMatch(@Nullable final Match nextMatch) {
+        this.nextMatch = nextMatch;
+    }
+
+    public abstract Match createInstance(final int contextId, final NodeId nodeId, @Nullable final String matchTerm);
     public abstract Match newCopy();
     public abstract String getIndexId();
 
     public void addOffset(final int offset, final int length) {
-        if(currentOffset == offsets.length) {
-            final int noffsets[] = new int[currentOffset + 1];
+        if (currentOffset == offsets.length) {
+            final int[] noffsets = new int[currentOffset + 1];
             System.arraycopy(offsets, 0, noffsets, 0, currentOffset);
             offsets = noffsets;
-            final int nlengths[] = new int[currentOffset + 1];
+            final int[] nlengths = new int[currentOffset + 1];
             System.arraycopy(lengths, 0, nlengths, 0, currentOffset);
             lengths = nlengths;
         }
@@ -151,7 +160,7 @@ public abstract class Match implements Comparable<Match> {
 
     public List<Offset> getOffsets() {
         final List<Offset> result = new ArrayList<>(currentOffset);
-        for(int i = 0; i < currentOffset; i++) {
+        for (int i = 0; i < currentOffset; i++) {
             result.add(getOffset(i));
         }
         return result;
@@ -178,24 +187,24 @@ public abstract class Match implements Comparable<Match> {
      * the other match in the specified distance range if such
      * a match exists or null if no such match found
      */
-    public Match followedBy(final Match other, final int minDistance, final int maxDistance) {
+    public @Nullable Match followedBy(final Match other, final int minDistance, final int maxDistance) {
         final List<Offset> newMatchOffsets = new LinkedList<>();
-        for(int i = 0; i < currentOffset; i++) {
-            for(int j = 0; j < other.currentOffset; j++) {
+        for (int i = 0; i < currentOffset; i++) {
+            for (int j = 0; j < other.currentOffset; j++) {
                 final int distance = other.offsets[j] - (offsets[i] + lengths[i]);
-                if(distance >= minDistance && distance <= maxDistance) {
+                if (distance >= minDistance && distance <= maxDistance) {
                     newMatchOffsets.add(new Offset(offsets[i], lengths[i] + distance + other.lengths[j]));
                 }
             }
         }
 
-        if(newMatchOffsets.isEmpty()) {
+        if (newMatchOffsets.isEmpty()) {
             return null;
         }
 
         final int wildCardSize = newMatchOffsets.get(0).length - matchTerm.length() - other.matchTerm.length();
         final StringBuilder matched = new StringBuilder(matchTerm);
-        for(int ii = 0; ii < wildCardSize; ii++) {
+        for (int ii = 0; ii < wildCardSize; ii++) {
             matched.append('?');
         }
         matched.append(other.matchTerm);
@@ -212,13 +221,13 @@ public abstract class Match implements Comparable<Match> {
      * @param maxExpand The maximum number of characters to expand this match by
      * @return The expanded match if possible, or null if no offset is far enough from the start.
      */
-    public Match expandBackward(final int minExpand, final int maxExpand) {
-        Match result = null;
-        for(int i = 0; i < currentOffset; i++) {
-            if(offsets[i] - minExpand >= 0) {
-                if(result == null) {
+    public @Nullable Match expandBackward(final int minExpand, final int maxExpand) {
+        @Nullable Match result = null;
+        for (int i = 0; i < currentOffset; i++) {
+            if (offsets[i] - minExpand >= 0) {
+                if (result == null) {
                     final StringBuilder matched = new StringBuilder();
-                    for(int ii = 0; ii < minExpand; ii++) {
+                    for (int ii = 0; ii < minExpand; ii++) {
                         matched.append('?');
                     }
                     matched.append(matchTerm);
@@ -240,12 +249,12 @@ public abstract class Match implements Comparable<Match> {
      * @param dataLength The length of the valued of the node, limiting the expansion
      * @return The expanded match if possible, or null if no offset is far enough from the end.
      */
-    public Match expandForward(final int minExpand, final int maxExpand, final int dataLength) {
-        Match result = null;
-        for(int i = 0; i < currentOffset; i++) {
-            if(offsets[i] + lengths[i] + minExpand <= dataLength) {
+    public @Nullable Match expandForward(final int minExpand, final int maxExpand, final int dataLength) {
+        @Nullable Match result = null;
+        for (int i = 0; i < currentOffset; i++) {
+            if (offsets[i] + lengths[i] + minExpand <= dataLength) {
                 final int expand = Math.min(dataLength - offsets[i] - lengths[i], maxExpand);
-                if(result == null) {
+                if (result == null) {
                     final StringBuilder matched = new StringBuilder(matchTerm);
                     for(int ii = 0; ii < expand; ii++) {
                         matched.append('?');
@@ -258,10 +267,10 @@ public abstract class Match implements Comparable<Match> {
         return result;
     }
 
-    private Match filterOffsets(final Predicate<Offset> predicate) {
+    private @Nullable Match filterOffsets(final Predicate<Offset> predicate) {
         final Match result = createInstance(context, nodeId, matchTerm);
         getOffsets().stream().filter(predicate).forEach(result::addOffset);
-        if(result.currentOffset == 0) {
+        if (result.currentOffset == 0) {
             return null;
         } else {
             return result;
@@ -275,7 +284,7 @@ public abstract class Match implements Comparable<Match> {
      * @return a match containing only offsets starting at the given position,
      * or null if no such offset exists.
      */
-    public Match filterOffsetsStartingAt(final int pos) {
+    public @Nullable Match filterOffsetsStartingAt(final int pos) {
         return filterOffsets(offset -> offset.offset == pos);
     }
 
@@ -286,7 +295,7 @@ public abstract class Match implements Comparable<Match> {
      * @return A match containing only offsets ending at the given position,
      * or null if no such offset exists.
      */
-    public Match filterOffsetsEndingAt(final int pos) {
+    public @Nullable Match filterOffsetsEndingAt(final int pos) {
         return filterOffsets(offset -> offset.offset + offset.length == pos);
     }
 
@@ -297,7 +306,7 @@ public abstract class Match implements Comparable<Match> {
      * @return a match containing only non-overlapping offsets
      */
     public Match filterOutOverlappingOffsets() {
-        if(currentOffset == 0) {
+        if (currentOffset == 0) {
             return newCopy();
         }
         final List<Offset> newMatchOffsets = getOffsets();
@@ -311,15 +320,15 @@ public abstract class Match implements Comparable<Match> {
         });
         final List<Offset> nonOverlappingMatchOffsets = new LinkedList<>();
         nonOverlappingMatchOffsets.add(newMatchOffsets.remove(0));
-        for(final Offset o : newMatchOffsets) {
+        for (final Offset o : newMatchOffsets) {
             boolean overlapsExistingOffset = false;
-            for(final Offset eo : nonOverlappingMatchOffsets) {
+            for (final Offset eo : nonOverlappingMatchOffsets) {
                 if(eo.overlaps(o)) {
                     overlapsExistingOffset = true;
                     break;
                 }
             }
-            if(!overlapsExistingOffset) {
+            if (!overlapsExistingOffset) {
                 nonOverlappingMatchOffsets.add(o);
             }
         }
@@ -336,8 +345,8 @@ public abstract class Match implements Comparable<Match> {
      * @return true if a match starts at the given position
      */
     public boolean hasMatchAt(final int pos) {
-        for(int i = 0; i < currentOffset; i++) {
-            if(offsets[i] == pos) {
+        for (int i = 0; i < currentOffset; i++) {
+            if (offsets[i] == pos) {
                 return true;
             }
         }
@@ -351,8 +360,8 @@ public abstract class Match implements Comparable<Match> {
      * @return true if the given position is within a match
      */
     public boolean hasMatchAround(final int pos) {
-        for(int i = 0; i < currentOffset; i++) {
-            if(offsets[i] + lengths[i] >= pos) {
+        for (int i = 0; i < currentOffset; i++) {
+            if (offsets[i] + lengths[i] >= pos) {
                 return true;
             }
         }
@@ -360,22 +369,18 @@ public abstract class Match implements Comparable<Match> {
     }
 
     public void mergeOffsets(final Match other) {
-        for(int i = 0; i < other.currentOffset; i++) {
-            if(!hasMatchAt(other.offsets[i])) {
+        for (int i = 0; i < other.currentOffset; i++) {
+            if (!hasMatchAt(other.offsets[i])) {
                 addOffset(other.offsets[i], other.lengths[i]);
             }
         }
     }
 
-    public Match getNextMatch() {
-        return nextMatch;
-    }
-
     public static boolean matchListEquals(final Match m1, final Match m2) {
         Match n1 = m1;
         Match n2 = m2;
-        while(n1 != null) {
-            if(n2 == null || n1 != n2) {
+        while (n1 != null) {
+            if (n2 == null || n1 != n2) {
                 return false;
             }
             n1 = n1.nextMatch;
@@ -386,23 +391,16 @@ public abstract class Match implements Comparable<Match> {
 
     @Override
     public boolean equals(final Object other) {
-        if(!(other instanceof Match)) {
+        if (other instanceof Match) {
+            final Match om = (Match) other;
+            return om.matchTerm != null
+                    && om.matchTerm.equals(matchTerm)
+                    && om.nodeId.equals(nodeId);
+        } else {
             return false;
         }
-        final Match om = (Match) other;
-        return om.matchTerm != null &&
-            om.matchTerm.equals(matchTerm) &&
-            om.nodeId.equals(nodeId);
     }
 
-    public boolean matchEquals(final Match other) {
-        if(this == other) {
-            return true;
-        }
-        return
-            (nodeId == other.nodeId || nodeId.equals(other.nodeId)) &&
-                matchTerm.equals(other.matchTerm);
-    }
 
     /**
      * Used to sort matches. Terms are compared by their string
@@ -418,19 +416,23 @@ public abstract class Match implements Comparable<Match> {
     @Override
     public String toString() {
         final StringBuilder buf = new StringBuilder();
-        if(matchTerm != null) {
+        if (matchTerm != null) {
             buf.append(matchTerm);
         }
 
-        for(int i = 0; i < currentOffset; i++) {
-            buf.append(" [");
+        for (int i = 0; i < currentOffset; i++) {
+            if (buf.length() > 0) {
+                buf.append(' ');
+            }
+            buf.append('[');
             buf.append(offsets[i]).append(':').append(lengths[i]);
-            buf.append("]");
+            buf.append(']');
         }
 
-        if(nextMatch != null) {
-            buf.append(' ').append(nextMatch.toString());
+        if (nextMatch != null) {
+            buf.append(' ').append(nextMatch);
         }
+
         return buf.toString();
     }
 }

--- a/exist-core/src/main/java/org/exist/dom/persistent/Match.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/Match.java
@@ -415,6 +415,10 @@ public abstract class Match implements Comparable<Match> {
 
     @Override
     public boolean equals(final Object other) {
+        if (other == this) {
+            return true;
+        }
+
         if (other instanceof Match) {
             final Match om = (Match) other;
             return om.matchTerm != null
@@ -424,7 +428,6 @@ public abstract class Match implements Comparable<Match> {
             return false;
         }
     }
-
 
     /**
      * Used to sort matches. Terms are compared by their string

--- a/exist-core/src/main/java/org/exist/dom/persistent/Match.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/Match.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *

--- a/exist-core/src/main/java/org/exist/dom/persistent/Match.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/Match.java
@@ -421,9 +421,8 @@ public abstract class Match implements Comparable<Match> {
 
         if (other instanceof Match) {
             final Match om = (Match) other;
-            return om.matchTerm != null
-                    && om.matchTerm.equals(matchTerm)
-                    && om.nodeId.equals(nodeId);
+            return om.nodeId.equals(nodeId)
+		    && ((om.matchTerm != null && om.matchTerm.equals(matchTerm)) || matchTerm == null);
         } else {
             return false;
         }

--- a/exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -107,7 +131,11 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
     private NodeProxy nodes[];
 
     public NewArrayNodeSet() {
-        nodes = new NodeProxy[INITIAL_SIZE];
+        this(INITIAL_SIZE);
+    }
+
+    public NewArrayNodeSet(final int initialSize) {
+        nodes = new NodeProxy[initialSize];
     }
 
     public NewArrayNodeSet(final NewArrayNodeSet other) {

--- a/exist-core/src/main/java/org/exist/dom/persistent/NodeProxy.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NodeProxy.java
@@ -549,36 +549,41 @@ public class NodeProxy implements NodeSet, NodeValue, NodeHandle, DocumentSet, C
     }
 
     public void addMatch(final Match m) {
-        if(match == null) {
-            match = m;
-            match.nextMatch = null;
+        if (this.match == null) {
+            this.match = m;
+            if (match.getNextMatch() != null) {
+                match.setNextMatch(null);
+            }
             return;
         }
+
         Match next = match;
-        while(next != null) {
-            if(next.matchEquals(m)) {
+        while (next != null) {
+            if (next.equals(m)) {
                 next.mergeOffsets(m);
                 return;
             }
-            if(next.nextMatch == null) {
-                next.nextMatch = m;
+            if (next.getNextMatch() == null) {
+                next.setNextMatch(m);
                 break;
             }
-            next = next.nextMatch;
+            next = next.getNextMatch();
         }
     }
 
     public void addMatches(final NodeProxy p) {
-        if(p == this) {
+        if (p == this) {
             return;
         }
+
         Match m = p.getMatches();
-        if(Match.matchListEquals(m, this.match)) {
+        if (Match.matchListEquals(m, this.match)) {
             return;
         }
-        while(m != null) {
+
+        while (m != null) {
             addMatch(m.newCopy());
-            m = m.nextMatch;
+            m = m.getNextMatch();
         }
     }
 

--- a/exist-core/src/main/java/org/exist/storage/ValueIndexFactory.java
+++ b/exist-core/src/main/java/org/exist/storage/ValueIndexFactory.java
@@ -127,6 +127,7 @@ public class ValueIndexFactory {
         return serialize(value, offset, true);
     }
 
+    // TODO(AR) switch implementation to various serialize methods in the AtomicValues (requires major version bump)
     public final static byte[] serialize(final Indexable value, final int offset, final boolean caseSensitive) throws EXistException {
         /* xs:string */
         if (Type.subTypeOf(value.getType(), Type.STRING)) {

--- a/exist-core/src/main/java/org/exist/util/ByteConversion.java
+++ b/exist-core/src/main/java/org/exist/util/ByteConversion.java
@@ -21,6 +21,8 @@
  */
 package org.exist.util;
 
+import java.nio.ByteBuffer;
+
 /**
  * A collection of static methods to write integer values from/to a
  * byte array.
@@ -65,6 +67,27 @@ public class ByteConversion {
     }
 
     /**
+     * Read an integer value from the specified byte buffer.
+     *
+     * This version of the method reads the highest byte first.
+     *
+     * @param buf the byte buffer to read from
+     *
+     * @return the integer
+     */
+    public final static int byteToIntH(final ByteBuffer buf) {
+        final byte b0 = buf.get();
+        final byte b1 = buf.get();
+        final byte b2 = buf.get();
+        final byte b3 = buf.get();
+
+        return (b3 & 0xff) |
+                ((b2 & 0xff) << 8) |
+                ((b1 & 0xff) << 16) |
+                ((b0 & 0xff) << 24);
+    }
+
+    /**
      *  Read a long value from the specified byte array, starting at start.
      *
      * @param data the input data
@@ -81,6 +104,33 @@ public class ByteConversion {
             ( ( ( (long) data[start + 5] ) & 0xffL ) << 16 ) |
             ( ( ( (long) data[start + 6] ) & 0xffL ) << 8 ) |
             ( ( (long) data[start + 7] ) & 0xffL );
+    }
+
+    /**
+     *  Read a long value from the specified byte buffer.
+     *
+     * @param buf the byte buffer to read from
+     *
+     * @return the long integer
+     */
+    public final static long byteToLong(final ByteBuffer buf) {
+        final byte b0 = buf.get();
+        final byte b1 = buf.get();
+        final byte b2 = buf.get();
+        final byte b3 = buf.get();
+        final byte b4 = buf.get();
+        final byte b5 = buf.get();
+        final byte b6 = buf.get();
+        final byte b7 = buf.get();
+
+        return ((((long) b0) & 0xffL) << 56) |
+                ((((long) b1) & 0xffL) << 48) |
+                ((((long) b2) & 0xffL) << 40) |
+                ((((long) b3) & 0xffL) << 32) |
+                ((((long) b4) & 0xffL) << 24) |
+                ((((long) b5) & 0xffL) << 16) |
+                ((((long) b6) & 0xffL) << 8) |
+                (((long) b7) & 0xffL);
     }
 
     /**
@@ -115,6 +165,21 @@ public class ByteConversion {
     }
 
     /**
+     * Read a short value from the specified byte array, starting at start.
+     *
+     * This version of the method reads the highest byte first.
+     *
+     * @param buf the byte buffer to read from
+     *
+     * @return the short integer
+     */
+    public final static short byteToShortH(final ByteBuffer buf) {
+        final byte b0 = buf.get();
+        final byte b1 = buf.get();
+        return (short) (((b0 & 0xff) << 8) | (b1 & 0xff));
+    }
+
+    /**
      * Write an int value to the specified byte array. The first byte is written
      * into the location specified by start.
      *
@@ -134,7 +199,22 @@ public class ByteConversion {
     }
 
     /**
-     * Write an int value to the specified byte array. The first byte is written
+     * Write an int value to the specified byte array.
+     *
+     * This version of the method writes the highest byte first.
+     *
+     * @param v the value
+     * @param buf the byte buffer to write into
+     */
+    public final static void intToByteH(final int v, final ByteBuffer buf) {
+        buf.put((byte) ((v >>> 24) & 0xff));
+        buf.put((byte) ((v >>> 16) & 0xff));
+        buf.put((byte) ((v >>> 8) & 0xff));
+        buf.put((byte) ((v >>> 0) & 0xff));
+    }
+
+    /**
+     * Write an int value to the specified byte buffer. The first byte is written
      * into the location specified by start.
      *
      * This version of the method writes the highest byte first.
@@ -173,6 +253,22 @@ public class ByteConversion {
         return data;
     }
 
+    /**
+     * Write a long value to the specified byte buffer.
+     *
+     * @param v the value
+     * @param buf the byte buffer to write into
+     */
+    public final static void longToByte(final long v, final ByteBuffer buf) {
+        buf.put((byte) ((v >>> 56) & 0xff));
+        buf.put((byte) ((v >>> 48) & 0xff));
+        buf.put((byte) ((v >>> 40) & 0xff));
+        buf.put((byte) ((v >>> 32) & 0xff));
+        buf.put((byte) ((v >>> 24) & 0xff));
+        buf.put((byte) ((v >>> 16) & 0xff));
+        buf.put((byte) ((v >>> 8) & 0xff));
+        buf.put((byte) ((v >>> 0) & 0xff));
+    }
 
     /**
      * Write an int value to a newly allocated byte array.
@@ -227,6 +323,20 @@ public class ByteConversion {
         data[start + 1] = (byte) ( ( v >>> 0 ) & 0xff );
         data[start] = (byte) ( ( v >>> 8 ) & 0xff );
         return data;
+    }
+
+    /**
+     * Write a short value to the specified byte array.
+     *
+     * This version writes the highest byte first.
+     *
+     * @param v the value
+     * @param buf the byte buffer to write into
+     */
+    public final static void shortToByteH(final short v, final ByteBuffer buf) {
+        buf.put( (byte) ((v >>> 8) & 0xff));
+        buf.put((byte) ((v >>> 0) & 0xff));
+
     }
 }
 

--- a/exist-core/src/main/java/org/exist/xquery/CombiningExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/CombiningExpression.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -144,4 +168,12 @@ public abstract class CombiningExpression extends AbstractExpression {
         left.accept(visitor);
         right.accept(visitor);
     }
+
+	public PathExpr getLeft() {
+		return left;
+	}
+
+	public PathExpr getRight() {
+		return right;
+	}
 }

--- a/exist-core/src/main/java/org/exist/xquery/LocationStep.java
+++ b/exist-core/src/main/java/org/exist/xquery/LocationStep.java
@@ -57,6 +57,7 @@ import org.exist.xquery.value.*;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import javax.annotation.Nullable;
 import javax.xml.stream.StreamFilter;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
@@ -510,26 +511,37 @@ public class LocationStep extends Step {
             final MemoryNodeSet nodes = contextSequence.toMemNodeSet();
             return nodes.getSelf(test);
         }
-        if (hasPreloadedData() && !test.isWildcardTest()) {
-            final NodeSet ns;
+
+        if (hasPreloadedData()) {
+            @Nullable final NodeSet ns;
             if (contextSequence instanceof NodeSet) {
                 ns = (NodeSet) contextSequence;
             } else {
                 ns = null;
             }
 
-            for (final NodeProxy p : currentSet) {
-                p.addContextNode(contextId, p);
-
-                if (ns != null) {
-                    final NodeProxy np = ns.get(p);
-
-                    if (np != null && np.getMatches() != null) {
-                        p.addMatch(np.getMatches());
+            final NewArrayNodeSet newCurrentSet = new NewArrayNodeSet(currentSet.getItemCount());
+            for (NodeProxy p : currentSet) {
+                if (test.isWildcardTest()) {
+                    if (ns != null) {
+                        @Nullable final NodeProxy np = ns.get(p);
+                        if (np != null) {
+                            p = np;
+                        }
+                    }
+                } else {
+                    if (ns != null) {
+                        @Nullable final NodeProxy np = ns.get(p);
+                        if (np != null && np.getMatches() != null) {
+                            p.addMatch(np.getMatches());
+                        }
                     }
                 }
+                p.addContextNode(contextId, p);
+                newCurrentSet.add(p);
             }
-            return currentSet;
+            currentSet = newCurrentSet;
+            return newCurrentSet;
         }
 
         final NodeSet contextSet = contextSequence.toNodeSet();

--- a/exist-core/src/main/java/org/exist/xquery/LocationStep.java
+++ b/exist-core/src/main/java/org/exist/xquery/LocationStep.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -37,7 +61,6 @@ import javax.xml.stream.StreamFilter;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import java.io.IOException;
-import java.util.Iterator;
 
 /**
  * Processes all location path steps (like descendant::*, ancestor::XXX).

--- a/exist-core/src/main/java/org/exist/xquery/Optimizer.java
+++ b/exist-core/src/main/java/org/exist/xquery/Optimizer.java
@@ -77,17 +77,15 @@ public class Optimizer extends DefaultExpressionVisitor {
 
     private static final Logger LOG = LogManager.getLogger(Optimizer.class);
 
-    private XQueryContext context;
+    private final XQueryContext context;
+    private final List<QueryRewriter> rewriters;
+    private final FindOptimizable findOptimizable = new FindOptimizable();
 
     private int predicates = 0;
 
     private boolean hasOptimized = false;
 
-    private List<QueryRewriter> rewriters;
-
-    private final FindOptimizable findOptimizable = new FindOptimizable();
-
-    public Optimizer(XQueryContext context) {
+    public Optimizer(final XQueryContext context) {
         this.context = context;
         final DBBroker broker = context.getBroker();
         this.rewriters = broker != null ? broker.getIndexController().getQueryRewriters(context) : Collections.emptyList();
@@ -142,11 +140,12 @@ public class Optimizer extends DefaultExpressionVisitor {
             // we found at least one Optimizable. Rewrite the whole expression and
             // enclose it in an (#exist:optimize#) pragma.
             if (!(parent instanceof RewritableExpression)) {
-            	if (LOG.isTraceEnabled())
-            		{
-                        LOG.trace("Parent expression of step is not a PathExpr: {}", parent);}
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("Parent expression of step is not a PathExpr: {}", parent);
+                }
                 return;
             }
+
             hasOptimized = true;
             final RewritableExpression path = (RewritableExpression) parent;
             try {
@@ -161,9 +160,9 @@ public class Optimizer extends DefaultExpressionVisitor {
                 // Replace the old expression with the pragma
                 path.replace(locationStep, extension);
 
-                if (LOG.isTraceEnabled())
-                    {
-                        LOG.trace("Rewritten expression: {}", ExpressionDumper.dump(parent));}
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("Rewritten expression: {}", ExpressionDumper.dump(parent));
+                }
             } catch (final XPathException e) {
                 LOG.warn("Failed to optimize expression: {}: {}", locationStep, e.getMessage(), e);
             }
@@ -178,7 +177,8 @@ public class Optimizer extends DefaultExpressionVisitor {
         }
     }
 
-    public void visitFilteredExpr(FilteredExpression filtered) {
+    @Override
+    public void visitFilteredExpr(final FilteredExpression filtered) {
         super.visitFilteredExpr(filtered);
 
         // check if filtered expression can be simplified:
@@ -211,14 +211,15 @@ public class Optimizer extends DefaultExpressionVisitor {
             // enclose it in an (#exist:optimize#) pragma.
             final Expression parent = filtered.getParent();
             if (!(parent instanceof RewritableExpression)) {
-            	if (LOG.isTraceEnabled())
-            		{
-                        LOG.trace("Parent expression: {} of step does not implement RewritableExpression", parent.getClass().getName());}
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("Parent expression: {} of step does not implement RewritableExpression", parent.getClass().getName());
+                }
                 return;
             }
-            if (LOG.isTraceEnabled())
-                {
-                    LOG.trace("Rewriting expression: {}", ExpressionDumper.dump(filtered));}
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Rewriting expression: {}", ExpressionDumper.dump(filtered));
+            }
+
             hasOptimized = true;
             final RewritableExpression path = (RewritableExpression) parent;
             try {
@@ -253,19 +254,21 @@ public class Optimizer extends DefaultExpressionVisitor {
         return optimizable;
     }
 
-    public void visitAndExpr(OpAnd and) {
+    @Override
+    public void visitAndExpr(final OpAnd and) {
         if (predicates > 0) {
             // inside a filter expression, we can often replace a logical and with
             // a chain of filters, which can then be further optimized
             Expression parent = and.getParent();
             if (!(parent instanceof PathExpr)) {
-            	if (LOG.isTraceEnabled())
-            		{
-                        LOG.trace("Parent expression of boolean operator is not a PathExpr: {}", parent);}
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("Parent expression of boolean operator is not a PathExpr: {}", parent);
+                }
                 return;
             }
-            PathExpr path;
-            Predicate predicate;
+
+            final PathExpr path;
+            final Predicate predicate;
             if (parent instanceof Predicate) {
                 predicate = (Predicate) parent;
                 path = predicate;
@@ -278,9 +281,10 @@ public class Optimizer extends DefaultExpressionVisitor {
                 }
                 predicate = (Predicate) parent;
             }
-            if (LOG.isTraceEnabled())
-                {
-                    LOG.trace("Rewriting boolean expression: {}", ExpressionDumper.dump(and));}
+
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Rewriting boolean expression: {}", ExpressionDumper.dump(and));
+            }
             hasOptimized = true;
             final LocationStep step = (LocationStep) predicate.getParent();
             final Predicate newPred = new Predicate(context);
@@ -293,7 +297,8 @@ public class Optimizer extends DefaultExpressionVisitor {
         }
     }
 
-	public void visitOrExpr(OpOr or) {
+    @Override
+    public void visitOrExpr(final OpOr or) {
     	if (or.isRewritable()) {
         	or.getLeft().accept(this);
 			or.getRight().accept(this);
@@ -301,7 +306,7 @@ public class Optimizer extends DefaultExpressionVisitor {
 	}
 
     @Override
-    public void visitGeneralComparison(GeneralComparison comparison) {
+    public void visitGeneralComparison(final GeneralComparison comparison) {
         // Check if the left operand is a path expression ending in a
         // text() step. This step is unnecessary and makes it hard
         // to further optimize the expression. We thus try to remove
@@ -320,7 +325,8 @@ public class Optimizer extends DefaultExpressionVisitor {
         comparison.getRight().accept(this);
     }
 
-    public void visitPredicate(Predicate predicate) {
+    @Override
+    public void visitPredicate(final Predicate predicate) {
         ++predicates;
         super.visitPredicate(predicate);
         --predicates;
@@ -384,19 +390,19 @@ public class Optimizer extends DefaultExpressionVisitor {
         return true;
     }
 
-    private int reverseAxis(int axis) {
-    	switch (axis) {
-    	case Constants.CHILD_AXIS:
-    		return Constants.PARENT_AXIS;
-    	case Constants.DESCENDANT_AXIS:
-    		return Constants.ANCESTOR_AXIS;
-    	case Constants.DESCENDANT_SELF_AXIS:
-    		return Constants.ANCESTOR_SELF_AXIS;
-    	}
-    	return Constants.UNKNOWN_AXIS;
+    private int reverseAxis(final int axis) {
+        switch (axis) {
+            case Constants.CHILD_AXIS:
+                return Constants.PARENT_AXIS;
+            case Constants.DESCENDANT_AXIS:
+                return Constants.ANCESTOR_AXIS;
+            case Constants.DESCENDANT_SELF_AXIS:
+                return Constants.ANCESTOR_SELF_AXIS;
+        }
+        return Constants.UNKNOWN_AXIS;
     }
 
-    private Expression simplifyPath(Expression expression) {
+    private Expression simplifyPath(final Expression expression) {
         if (!(expression instanceof PathExpr)) {
             return expression;
         }
@@ -404,6 +410,7 @@ public class Optimizer extends DefaultExpressionVisitor {
         if (path.getLength() != 1) {
             return path;
         }
+
         return path.getExpression(0);
     }
 
@@ -469,17 +476,18 @@ public class Optimizer extends DefaultExpressionVisitor {
         }
 
         @Override
-        public void visit(Expression expr) {
+        public void visit(final Expression expr) {
             if (expr instanceof LiteralValue) {
                 return;
             }
+
             if (expr instanceof Atomize ||
-                expr instanceof DynamicCardinalityCheck ||
-                expr instanceof DynamicNameCheck ||
-                expr instanceof DynamicTypeCheck ||
-                expr instanceof UntypedValueCheck ||
-                expr instanceof ConcatExpr ||
-                expr instanceof ArrayConstructor) {
+                    expr instanceof DynamicCardinalityCheck ||
+                    expr instanceof DynamicNameCheck ||
+                    expr instanceof DynamicTypeCheck ||
+                    expr instanceof UntypedValueCheck ||
+                    expr instanceof ConcatExpr ||
+                    expr instanceof ArrayConstructor) {
                 expr.accept(this);
             } else {
                 inlineable = false;
@@ -487,12 +495,12 @@ public class Optimizer extends DefaultExpressionVisitor {
         }
 
         @Override
-        public void visitPathExpr(PathExpr expr) {
+        public void visitPathExpr(final PathExpr expr) {
             // continue to check for numeric operators and other simple constructs,
             // abort for all other path expressions with length > 1
             if (expr instanceof OpNumeric ||
-                expr instanceof SequenceConstructor ||
-                expr.getLength() == 1) {
+                    expr instanceof SequenceConstructor ||
+                    expr.getLength() == 1) {
                 super.visitPathExpr(expr);
             } else {
                 inlineable = false;
@@ -500,106 +508,106 @@ public class Optimizer extends DefaultExpressionVisitor {
         }
 
         @Override
-        public void visitUserFunction(UserDefinedFunction function) {
+        public void visitUserFunction(final UserDefinedFunction function) {
             inlineable = false;
         }
 
         @Override
-        public void visitBuiltinFunction(Function function) {
+        public void visitBuiltinFunction(final Function function) {
             inlineable = false;
         }
 
         @Override
-        public void visitFunctionCall(FunctionCall call) {
+        public void visitFunctionCall(final FunctionCall call) {
             inlineable = false;
         }
 
         @Override
-        public void visitForExpression(ForExpr forExpr) {
+        public void visitForExpression(final ForExpr forExpr) {
             inlineable = false;
         }
 
         @Override
-        public void visitLetExpression(LetExpr letExpr) {
+        public void visitLetExpression(final LetExpr letExpr) {
             inlineable = false;
         }
 
         @Override
-        public void visitOrderByClause(OrderByClause orderBy) {
+        public void visitOrderByClause(final OrderByClause orderBy) {
             inlineable = false;
         }
 
         @Override
-        public void visitGroupByClause(GroupByClause groupBy) {
+        public void visitGroupByClause(final GroupByClause groupBy) {
             inlineable = false;
         }
 
         @Override
-        public void visitWhereClause(WhereClause where) {
+        public void visitWhereClause(final WhereClause where) {
             inlineable = false;
         }
 
         @Override
-        public void visitConditional(ConditionalExpression conditional) {
+        public void visitConditional(final ConditionalExpression conditional) {
             inlineable = false;
         }
 
         @Override
-        public void visitLocationStep(LocationStep locationStep) {
+        public void visitLocationStep(final LocationStep locationStep) {
         }
 
         @Override
-        public void visitPredicate(Predicate predicate) {
+        public void visitPredicate(final Predicate predicate) {
             super.visitPredicate(predicate);
         }
 
         @Override
-        public void visitDocumentConstructor(DocumentConstructor constructor) {
+        public void visitDocumentConstructor(final DocumentConstructor constructor) {
             inlineable = false;
         }
 
         @Override
-        public void visitElementConstructor(ElementConstructor constructor) {
+        public void visitElementConstructor(final ElementConstructor constructor) {
             inlineable = false;
         }
 
         @Override
-        public void visitTextConstructor(DynamicTextConstructor constructor) {
+        public void visitTextConstructor(final DynamicTextConstructor constructor) {
             inlineable = false;
         }
 
         @Override
-        public void visitAttribConstructor(AttributeConstructor constructor) {
+        public void visitAttribConstructor(final AttributeConstructor constructor) {
             inlineable = false;
         }
 
         @Override
-        public void visitAttribConstructor(DynamicAttributeConstructor constructor) {
+        public void visitAttribConstructor(final DynamicAttributeConstructor constructor) {
             inlineable = false;
         }
 
         @Override
-        public void visitUnionExpr(Union union) {
+        public void visitUnionExpr(final Union union) {
             inlineable = false;
         }
 
         @Override
-        public void visitIntersectionExpr(Intersect intersect) {
+        public void visitIntersectionExpr(final Intersect intersect) {
             inlineable = false;
         }
 
         @Override
-        public void visitVariableDeclaration(VariableDeclaration decl) {
+        public void visitVariableDeclaration(final VariableDeclaration decl) {
             inlineable = false;
         }
 
         @Override
-        public void visitTryCatch(TryCatchExpression tryCatch) {
+        public void visitTryCatch(final TryCatchExpression tryCatch) {
             inlineable = false;
         }
 
         @Override
-        public void visitCastExpr(CastExpression expression) {
+        public void visitCastExpr(final CastExpression expression) {
             inlineable = false;
         }
 
@@ -609,22 +617,22 @@ public class Optimizer extends DefaultExpressionVisitor {
         }
 
         @Override
-        public void visitAndExpr(OpAnd and) {
+        public void visitAndExpr(final OpAnd and) {
             inlineable = false;
         }
 
         @Override
-        public void visitOrExpr(OpOr or) {
+        public void visitOrExpr(final OpOr or) {
             inlineable = false;
         }
 
         @Override
-        public void visitFilteredExpr(FilteredExpression filtered) {
+        public void visitFilteredExpr(final FilteredExpression filtered) {
             inlineable = false;
         }
 
         @Override
-        public void visitVariableReference(VariableReference ref) {
+        public void visitVariableReference(final VariableReference ref) {
             inlineable = false;
         }
     }

--- a/exist-core/src/main/java/org/exist/xquery/Optimizer.java
+++ b/exist-core/src/main/java/org/exist/xquery/Optimizer.java
@@ -101,17 +101,17 @@ public class Optimizer extends DefaultExpressionVisitor {
 
         // check query rewriters if they want to rewrite the location step
         Pragma optimizePragma = null;
-        for (final QueryRewriter rewriter : rewriters) {
-            try {
+        try {  // Keep try-catch out of loop
+            for (final QueryRewriter rewriter : rewriters) {
                 optimizePragma = rewriter.rewriteLocationStep(locationStep);
                 if (optimizePragma != null) {
                     // expression was rewritten: return
                     hasOptimized = true;
                     break;
                 }
-            } catch (final XPathException e) {
-                LOG.warn("Exception called while rewriting location step: {}", e.getMessage(), e);
             }
+        } catch (final XPathException e) {
+            LOG.warn("Exception called while rewriting location step: {}", e.getMessage(), e);
         }
 
         boolean optimize = false;

--- a/exist-core/src/main/java/org/exist/xquery/value/DateValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DateValue.java
@@ -21,6 +21,7 @@
  */
 package org.exist.xquery.value;
 
+import org.exist.util.ByteConversion;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.Expression;
 import org.exist.xquery.XPathException;
@@ -28,6 +29,7 @@ import org.exist.xquery.XPathException;
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
+import java.nio.ByteBuffer;
 import java.util.GregorianCalendar;
 
 /**
@@ -35,6 +37,8 @@ import java.util.GregorianCalendar;
  * @author <a href="mailto:piotr@ideanest.com">Piotr Kaminski</a>
  */
 public class DateValue extends AbstractDateTimeValue {
+
+    public static final int SERIALIZED_SIZE = 8;
 
     public DateValue() throws XPathException {
         super(null, stripCalendar(TimeUtils.getInstance().newXMLGregorianCalendar(new GregorianCalendar())));
@@ -67,6 +71,10 @@ public class DateValue extends AbstractDateTimeValue {
         super(expression, stripCalendar(cloneXMLGregorianCalendar(calendar)));
     }
 
+    public DateValue(final int year, final int month, final int day, final int timezone) {
+        super(TimeUtils.getInstance().newXMLGregorianCalendarDate(year, month, day, timezone));
+    }
+    
     private static XMLGregorianCalendar stripCalendar(XMLGregorianCalendar calendar) {
         calendar.setHour(DatatypeConstants.FIELD_UNDEFINED);
         calendar.setMinute(DatatypeConstants.FIELD_UNDEFINED);
@@ -133,5 +141,51 @@ public class DateValue extends AbstractDateTimeValue {
                         "Operand to minus should be of type xdt:yearMonthDuration or xdt:dayTimeDuration; got: "
                                 + Type.getTypeName(other.getType()));
         }
+    }
+
+    @Override
+    public <T> T toJavaObject(final Class<T> target) throws XPathException {
+        if (target == byte[].class) {
+            final ByteBuffer buf = ByteBuffer.allocate(SERIALIZED_SIZE);
+            serialize(buf);
+            return (T) buf.array();
+        } else if (target == ByteBuffer.class) {
+            final ByteBuffer buf = ByteBuffer.allocate(SERIALIZED_SIZE);
+            serialize(buf);
+            return (T) buf;
+        } else {
+            return super.toJavaObject(target);
+        }
+    }
+
+    /**
+     * Serializes to a ByteBuffer.
+     *
+     * 8 bytes where: [0-3 (Year), 4 (Month), 5 (Day), 6-7 (Timezone)]
+     *
+     * @param buf the ByteBuffer to serialize to.
+     */
+    public void serialize(final ByteBuffer buf) {
+        ByteConversion.intToByteH(calendar.getYear(), buf);
+        buf.put((byte) calendar.getMonth());
+        buf.put((byte) calendar.getDay());
+
+        // values for timezone range from -14*60 to 14*60, so we can use a short, but
+        // need to choose a different value for FIELD_UNDEFINED, which is not the same as 0 (= UTC)
+        final int timezone = calendar.getTimezone();
+        ByteConversion.shortToByteH((short) (timezone == DatatypeConstants.FIELD_UNDEFINED ? Short.MAX_VALUE : timezone), buf);
+    }
+
+    public static AtomicValue deserialize(final ByteBuffer buf) {
+        final int year = ByteConversion.byteToIntH(buf);
+        final int month = buf.get();
+        final int day = buf.get();
+
+        int timezone = ByteConversion.byteToShortH(buf);
+        if (timezone == Short.MAX_VALUE) {
+            timezone = DatatypeConstants.FIELD_UNDEFINED;
+        }
+
+        return new DateValue(year, month, day, timezone);
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/value/DecimalValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DecimalValue.java
@@ -22,6 +22,7 @@
 package org.exist.xquery.value;
 
 import com.ibm.icu.text.Collator;
+import org.exist.util.ByteConversion;
 import org.exist.xquery.Constants;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.Expression;
@@ -33,6 +34,7 @@ import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
+import java.nio.ByteBuffer;
 import java.util.function.IntSupplier;
 import java.util.regex.Pattern;
 
@@ -40,6 +42,9 @@ import java.util.regex.Pattern;
  * @author wolf
  */
 public class DecimalValue extends NumericValue {
+
+    public static final int SERIALIZED_SIZE = 8;
+
     public static final BigInteger BIG_INTEGER_TEN = BigInteger.valueOf(10);
     // i × 10^-n where i, n = integers  and n >= 0
     // All ·minimally conforming· processors ·must· support decimal numbers
@@ -588,6 +593,14 @@ public class DecimalValue extends NumericValue {
         } else if (target == Byte.class || target == byte.class) {
             final IntegerValue v = (IntegerValue) convertTo(Type.BYTE);
             return (T) Byte.valueOf((byte) v.getValue());
+        } else if (target == byte[].class) {
+            final ByteBuffer buf = ByteBuffer.allocate(SERIALIZED_SIZE);
+            serialize(buf);
+            return (T) buf.array();
+        } else if (target == ByteBuffer.class) {
+            final ByteBuffer buf = ByteBuffer.allocate(SERIALIZED_SIZE);
+            serialize(buf);
+            return (T) buf;
         } else if (target == String.class) {
             return (T) getStringValue();
         } else if (target == Boolean.class) {
@@ -601,4 +614,22 @@ public class DecimalValue extends NumericValue {
                         + target.getName());
     }
     //End of copy
+
+    /**
+     * Serializes to a ByteBuffer.
+     *
+     * 8 bytes.
+     *
+     * @param buf the ByteBuffer to serialize to.
+     */
+    public void serialize(final ByteBuffer buf) {
+        final long ddBits = Double.doubleToLongBits(value.doubleValue()) ^ 0x8000000000000000L;
+        ByteConversion.longToByte(ddBits, buf);
+    }
+
+    public static DecimalValue deserialize(final ByteBuffer buf) {
+        final long dBits = ByteConversion.byteToLong(buf) ^ 0x8000000000000000L;
+        final double d = Double.longBitsToDouble(dBits);
+        return new DecimalValue(d);
+    }
 }

--- a/exist-core/src/main/java/org/exist/xquery/value/FloatValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/FloatValue.java
@@ -24,6 +24,7 @@ package org.exist.xquery.value;
 import com.ibm.icu.text.Collator;
 import net.sf.saxon.tree.util.FastStringBuffer;
 import net.sf.saxon.value.FloatingPointConverter;
+import org.exist.util.ByteConversion;
 import org.exist.xquery.Constants;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.Expression;
@@ -32,12 +33,16 @@ import org.exist.xquery.XPathException;
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.nio.ByteBuffer;
 import java.util.function.IntSupplier;
 
 /**
  * @author wolf
  */
 public class FloatValue extends NumericValue {
+
+    public static final int SERIALIZED_SIZE = 4;
+
     // m × 2^e, where m is an integer whose absolute value is less than 2^24, 
     // and e is an integer between -149 and 104, inclusive.
     // In addition also -INF, +INF and NaN.
@@ -484,6 +489,14 @@ public class FloatValue extends NumericValue {
         } else if (target == Byte.class || target == byte.class) {
             final IntegerValue v = (IntegerValue) convertTo(Type.BYTE);
             return (T) Byte.valueOf((byte) v.getValue());
+        } else if (target == byte[].class) {
+            final ByteBuffer buf = ByteBuffer.allocate(SERIALIZED_SIZE);
+            serialize(buf);
+            return (T) buf.array();
+        } else if (target == ByteBuffer.class) {
+            final ByteBuffer buf = ByteBuffer.allocate(SERIALIZED_SIZE);
+            serialize(buf);
+            return (T) buf;
         } else if (target == String.class) {
             return (T) getStringValue();
         } else if (target == Boolean.class) {
@@ -512,5 +525,23 @@ public class FloatValue extends NumericValue {
     @Override
     public int hashCode() {
         return Float.valueOf(value).hashCode();
+    }
+
+    /**
+     * Serializes to a ByteBuffer.
+     *
+     * 4 bytes.
+     *
+     * @param buf the ByteBuffer to serialize to.
+     */
+    public void serialize(final ByteBuffer buf) {
+        final int fBits = Float.floatToIntBits(value) ^ 0x80000000;
+        ByteConversion.intToByteH(fBits, buf);
+    }
+
+    public static FloatValue deserialize(final ByteBuffer buf) {
+        final int fBits = ByteConversion.byteToIntH(buf) ^ 0x80000000;
+        final float f = Float.intBitsToFloat(fBits);
+        return new FloatValue(f);
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/value/TimeUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/TimeUtils.java
@@ -76,7 +76,7 @@ public class TimeUtils {
      *
      * @param millis the timezone offset in milliseconds, positive or negative
      */
-    public void overrideLocalTimezoneOffset(int millis) {
+    void overrideLocalTimezoneOffset(final int millis) {
         timezoneOffset = millis;
         timezoneOverriden = true;
     }
@@ -87,7 +87,7 @@ public class TimeUtils {
      * NOTE calling this method is not thread-safe and has a global impact
      * it should only be used for test cases.
      */
-    public void resetLocalTimezoneOffset() {
+    void resetLocalTimezoneOffset() {
         timezoneOverriden = false;
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/value/TimeValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/TimeValue.java
@@ -21,6 +21,7 @@
  */
 package org.exist.xquery.value;
 
+import org.exist.util.ByteConversion;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.Expression;
 import org.exist.xquery.XPathException;
@@ -28,6 +29,8 @@ import org.exist.xquery.XPathException;
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
+import java.nio.BufferOverflowException;
+import java.nio.ByteBuffer;
 import java.util.GregorianCalendar;
 
 /**
@@ -35,6 +38,8 @@ import java.util.GregorianCalendar;
  * @author <a href="mailto:piotr@ideanest.com">Piotr Kaminski</a>
  */
 public class TimeValue extends AbstractDateTimeValue {
+
+    public static final int SERIALIZED_SIZE = 7;
 
     public TimeValue() throws XPathException {
         super(null, stripCalendar(TimeUtils.getInstance().newXMLGregorianCalendar(new GregorianCalendar())));
@@ -67,6 +72,9 @@ public class TimeValue extends AbstractDateTimeValue {
         }
     }
 
+    public TimeValue(final int hour, final int minute, final int second, final int millisecond, final int timezone) {
+        super(TimeUtils.getInstance().newXMLGregorianCalendarTime(hour, minute, second, millisecond, timezone));
+    }
     private static XMLGregorianCalendar stripCalendar(XMLGregorianCalendar calendar) {
         calendar = (XMLGregorianCalendar) calendar.clone();
         calendar.setYear(DatatypeConstants.FIELD_UNDEFINED);
@@ -128,4 +136,58 @@ public class TimeValue extends AbstractDateTimeValue {
                         + Type.getTypeName(other.getType()));
     }
 
+    @Override
+    public <T> T toJavaObject(final Class<T> target) throws XPathException {
+        if (target == byte[].class) {
+            final ByteBuffer buf = ByteBuffer.allocate(SERIALIZED_SIZE);
+            serialize(buf);
+            return (T) buf.array();
+        } else if (target == ByteBuffer.class) {
+            final ByteBuffer buf = ByteBuffer.allocate(SERIALIZED_SIZE);
+            serialize(buf);
+            return (T) buf;
+        } else {
+            return super.toJavaObject(target);
+        }
+    }
+
+    /**
+     * Serializes to a ByteBuffer.
+     *
+     * 7 bytes where: [0 (Hour), 1 (Minute), 2 (Second), 3-4 (Milliseconds), 5-6 (Timezone)]
+     *
+     * @param buf the ByteBuffer to serialize to.
+     */
+    public void serialize(final ByteBuffer buf) {
+        buf.put((byte) calendar.getHour());
+        buf.put((byte) calendar.getMinute());
+        buf.put((byte) calendar.getSecond());
+
+        final int ms = calendar.getMillisecond();
+        if (ms == DatatypeConstants.FIELD_UNDEFINED) {
+            buf.putShort((short) 0);
+        } else {
+            ByteConversion.shortToByteH((short) ms, buf);
+        }
+
+        // values for timezone range from -14*60 to 14*60, so we can use a short, but
+        // need to choose a different value for FIELD_UNDEFINED, which is not the same as 0 (= UTC)
+        final int timezone = calendar.getTimezone();
+        ByteConversion.shortToByteH((short) (timezone == DatatypeConstants.FIELD_UNDEFINED ? Short.MAX_VALUE : timezone), buf);
+    }
+
+    public static TimeValue deserialize(final ByteBuffer buf) {
+        final int hour = buf.get();
+        final int minute = buf.get();
+        final int second = buf.get();
+
+        final int ms = ByteConversion.byteToShortH(buf);
+
+        int timezone = ByteConversion.byteToShortH(buf);
+        if (timezone == Short.MAX_VALUE) {
+            timezone = DatatypeConstants.FIELD_UNDEFINED;
+        }
+
+        return new TimeValue(hour, minute, second, ms, timezone);
+    }
 }

--- a/extensions/indexes/lucene/pom.xml
+++ b/extensions/indexes/lucene/pom.xml
@@ -129,6 +129,11 @@
         </dependency>
 
         <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>net.sf.xmldb-org</groupId>
             <artifactId>xmldb-api</artifactId>
         </dependency>

--- a/extensions/indexes/lucene/pom.xml
+++ b/extensions/indexes/lucene/pom.xml
@@ -231,7 +231,11 @@
                                 <include>src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java</include>
                                 <include>src/main/java/org/exist/indexing/lucene/LuceneIndex.java</include>
                                 <include>src/main/java/org/exist/indexing/lucene/LuceneIndexConfig.java</include>
+                                <include>src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java</include>
+                                <include>src/main/java/org/exist/indexing/lucene/LuceneMatch.java</include>
                                 <include>src/main/java/org/exist/indexing/lucene/XMLToQuery.java</include>
+                                <include>src/main/java/org/exist/xquery/modules/lucene/Query.java</include>
+                                <include>src/main/java/org/exist/xquery/modules/lucene/QueryField.java</include>
                             </includes>
                         </licenseSet>
 
@@ -252,7 +256,11 @@
                                 <exclude>src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java</exclude>
                                 <exclude>src/main/java/org/exist/indexing/lucene/LuceneIndex.java</exclude>
                                 <exclude>src/main/java/org/exist/indexing/lucene/LuceneIndexConfig.java</exclude>
+                                <exclude>src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java</exclude>
+                                <exclude>src/main/java/org/exist/indexing/lucene/LuceneMatch.java</exclude>
                                 <exclude>src/main/java/org/exist/indexing/lucene/XMLToQuery.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/modules/lucene/Query.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/modules/lucene/QueryField.java</exclude>
                             </excludes>
                         </licenseSet>
                     </licenseSets>

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneConfig.java
@@ -55,6 +55,7 @@ import org.apache.lucene.queryparser.classic.QueryParserBase;
 import org.exist.dom.QName;
 import org.exist.indexing.lucene.analyzers.NoDiacriticsStandardAnalyzer;
 import org.exist.storage.NodePath;
+import org.exist.storage.NodePath2;
 import org.exist.util.DatabaseConfigurationException;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -126,6 +127,31 @@ public class LuceneConfig {
     	this.boost = other.boost;
     	this.analyzers = other.analyzers;
     	this.facetsConfig = other.facetsConfig;
+    }
+
+    /**
+     * Determines probabilistically if there might be a configured index
+     * for the QName. False positive matches are possible,
+     * but false negatives are not.
+     *
+     * @param qname the element/attribute to look for an index configuration for.
+     *
+     * @return true indicates that there might be a config, false indicates
+     *     that there definitely is not a config.
+     */
+    public boolean hasConfig(final QName qname) {
+        if (paths.containsKey(qname)) {
+            return true;
+        } else {
+            final NodePath2 path = new NodePath2();
+            path.addComponent(qname);
+            for (final LuceneIndexConfig config : wildcardPaths) {
+                if (config.match(path)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
     
     public boolean matches(final NodePath path) {

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneConfig.java
@@ -128,16 +128,18 @@ public class LuceneConfig {
     	this.facetsConfig = other.facetsConfig;
     }
     
-    public boolean matches(NodePath path) {
+    public boolean matches(final NodePath path) {
         LuceneIndexConfig idxConf = paths.get(path.getLastComponent());
         while (idxConf != null) {
-            if (idxConf.match(path))
+            if (idxConf.match(path)) {
                 return true;
+            }
             idxConf = idxConf.getNext();
         }
-        for (LuceneIndexConfig config : wildcardPaths) {
-            if (config.match(path))
+        for (final LuceneIndexConfig config : wildcardPaths) {
+            if (config.match(path)) {
                 return true;
+            }
         }
         return false;
     }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
@@ -47,6 +47,7 @@ package org.exist.indexing.lucene;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.*;
+import org.apache.lucene.util.BytesRef;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.NodeProxy;
 import org.exist.numbering.NodeId;
@@ -80,14 +81,16 @@ import java.util.Optional;
  */
 public class LuceneFieldConfig extends AbstractFieldConfig {
 
-    private final static String ATTR_FIELD_NAME = "name";
-    private final static String ATTR_TYPE = "type";
-    private final static String ATTR_STORE = "store";
-    private final static String ATTR_ANALYZER = "analyzer";
-    private final static String ATTR_IF = "if";
+    private static final String ATTR_FIELD_NAME = "name";
+    private static final String ATTR_TYPE = "type";
+    private static final String ATTR_BINARY = "binary";
+    private static final String ATTR_STORE = "store";
+    private static final String ATTR_ANALYZER = "analyzer";
+    private static final String ATTR_IF = "if";
 
     protected String fieldName;
     protected int type = Type.STRING;
+    protected boolean binary = false;
     protected boolean store = true;
     protected Analyzer analyzer= null;
     protected Optional<String> condition = Optional.empty();
@@ -126,6 +129,11 @@ public class LuceneFieldConfig extends AbstractFieldConfig {
         final String cond = configElement.getAttribute(ATTR_IF);
         if (!cond.isEmpty()) {
             this.condition = Optional.of(cond);
+        }
+
+        final String binaryStr = configElement.getAttribute(ATTR_BINARY);
+        if (StringUtils.isNotEmpty(binaryStr)) {
+            this.binary = StringUtils.equalsAnyIgnoreCase(binaryStr, "true", "yes");
         }
     }
 
@@ -183,7 +191,7 @@ public class LuceneFieldConfig extends AbstractFieldConfig {
     protected void processResult(Sequence result, Document luceneDoc) throws XPathException {
         for (SequenceIterator i = result.unorderedIterator(); i.hasNext(); ) {
             final String text = i.nextItem().getStringValue();
-            final Field field = convertToField(text);
+            final Field field = binary ? convertToDocValue(text) : convertToField(text);
             if (field != null) {
                 luceneDoc.add(field);
             }
@@ -192,7 +200,12 @@ public class LuceneFieldConfig extends AbstractFieldConfig {
 
     @Override
     protected void processText(CharSequence text, Document luceneDoc) {
-        final Field field = convertToField(text.toString());
+        final Field field;
+        if (binary) {
+            field = convertToDocValue(text.toString());
+        } else {
+            field = convertToField(text.toString());
+        }
         if (field != null) {
             luceneDoc.add(field);
         }
@@ -239,6 +252,54 @@ public class LuceneFieldConfig extends AbstractFieldConfig {
             LOG.trace("Cannot convert field {} to type {}. Content was: {}", fieldName, Type.getTypeName(type), content);
         }
         return null;
+    }
+
+    private Field convertToDocValue(final String content) {
+        try {
+            switch (type) {
+                case Type.TIME:
+                    final TimeValue timeValue = new TimeValue(content);
+                    return new BinaryDocValuesField(fieldName, new BytesRef(timeValue.toJavaObject(byte[].class)));
+
+                case Type.DATE_TIME:
+                    final DateTimeValue dateTimeValue = new DateTimeValue(content);
+                    return new BinaryDocValuesField(fieldName, new BytesRef(dateTimeValue.toJavaObject(byte[].class)));
+
+                case Type.DATE:
+                    final DateValue dateValue = new DateValue(content);
+                    return new BinaryDocValuesField(fieldName, new BytesRef(dateValue.toJavaObject(byte[].class)));
+
+                case Type.INTEGER:
+                case Type.LONG:
+                case Type.UNSIGNED_LONG:
+                case Type.INT:
+                case Type.UNSIGNED_INT:
+                case Type.SHORT:
+                case Type.UNSIGNED_SHORT:
+                    final IntegerValue iv = new IntegerValue(content, Type.INTEGER);
+                    return new BinaryDocValuesField(fieldName, new BytesRef(iv.serialize()));
+
+                case Type.DOUBLE:
+                    final DoubleValue dbv = new DoubleValue(content);
+                    return new BinaryDocValuesField(fieldName, new BytesRef(dbv.toJavaObject(byte[].class)));
+
+                case Type.FLOAT:
+                    final FloatValue fv = new FloatValue(content);
+                    return new BinaryDocValuesField(fieldName, new BytesRef(fv.toJavaObject(byte[].class)));
+
+                case Type.DECIMAL:
+                    final DecimalValue dv = new DecimalValue(content);
+                    return new BinaryDocValuesField(fieldName, new BytesRef(dv.toJavaObject(byte[].class)));
+
+                // everything else treated as string
+                default:
+                    return new BinaryDocValuesField(fieldName, new BytesRef(content));
+            }
+        } catch (final NumberFormatException | XPathException e) {
+            // wrong type: ignore
+            LOG.error("Cannot convert field {} to type {}. Content was: {}", fieldName, Type.getTypeName(type), content);
+            return null;
+        }
     }
 
     private static long dateToLong(DateValue date) {

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
@@ -54,6 +54,7 @@ import org.exist.numbering.NodeId;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.DBBroker;
 import org.exist.util.DatabaseConfigurationException;
+import org.exist.util.StringUtil;
 import org.exist.xquery.CompiledXQuery;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
@@ -132,8 +133,8 @@ public class LuceneFieldConfig extends AbstractFieldConfig {
         }
 
         final String binaryStr = configElement.getAttribute(ATTR_BINARY);
-        if (StringUtils.isNotEmpty(binaryStr)) {
-            this.binary = StringUtils.equalsAnyIgnoreCase(binaryStr, "true", "yes");
+        if (StringUtil.notNullOrEmpty(binaryStr)) {
+            this.binary = binaryStr.equalsIgnoreCase("true") || binaryStr.equalsIgnoreCase("yes");
         }
     }
 

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndex.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndex.java
@@ -277,7 +277,7 @@ public class LuceneIndex extends AbstractIndex implements RawBackupSupport {
         }
     }
 
-    public <R> R withSearcher(Function2E<SearcherTaxonomyManager.SearcherAndTaxonomy, R, IOException, XPathException> consumer) throws IOException, XPathException {
+    public <R> R withSearcher(final Function2E<SearcherTaxonomyManager.SearcherAndTaxonomy, R, IOException, XPathException> consumer) throws IOException, XPathException {
         searcherManager.maybeRefreshBlocking();
         final SearcherTaxonomyManager.SearcherAndTaxonomy searcher = searcherManager.acquire();
         try {

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -431,26 +455,26 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
      * @throws ParseException if the query cannot be parsed
      * @throws XPathException if an error occurs executing the query
      */
-    public NodeSet query(int contextId, DocumentSet docs, NodeSet contextSet,
-                         List<QName> qnames, String queryStr, int axis, QueryOptions options)
+    public NodeSet query(final int contextId, final DocumentSet docs, @Nullable final NodeSet contextSet,
+                         final List<QName> qnames, final String queryStr, final int axis, final QueryOptions options)
             throws IOException, ParseException, XPathException {
         return index.withSearcher(searcher -> {
             final List<QName> definedIndexes = getDefinedIndexes(qnames);
             final NodeSet resultSet = new NewArrayNodeSet();
             final boolean returnAncestor = axis == NodeSet.ANCESTOR;
-            for (QName qname : definedIndexes) {
-                String field = LuceneUtil.encodeQName(qname, index.getBrokerPool().getSymbols());
-                LuceneConfig config = getLuceneConfig(broker, docs);
-                Analyzer analyzer = getQueryAnalyzer(config,null, qname, options);
+            for (final QName qname : definedIndexes) {
+                final String field = LuceneUtil.encodeQName(qname, index.getBrokerPool().getSymbols());
+                final LuceneConfig config = getLuceneConfig(broker, docs);
+                final Analyzer analyzer = getQueryAnalyzer(config,null, qname, options);
                 Query query;
                 if (queryStr == null) {
                     query = new ConstantScoreQuery(new FieldValueFilter(field));
                 } else {
-                    QueryParserWrapper parser = getQueryParser(field, analyzer, docs);
+                    final QueryParserWrapper parser = getQueryParser(field, analyzer, docs);
                     options.configureParser(parser.getConfiguration());
                     query = parser.parse(queryStr);
                 }
-                Optional<Map<String, QueryOptions.FacetQuery>> facets = options.getFacets();
+                final Optional<Map<String, QueryOptions.FacetQuery>> facets = options.getFacets();
                 if (facets.isPresent() && config != null) {
                     query = drilldown(facets.get(), query, config);
                 }
@@ -533,7 +557,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
     }
 
     private void searchAndProcess(final int contextId, final QName qname, final DocumentSet docs,
-                                  final NodeSet contextSet, final NodeSet resultSet, final boolean returnAncestor,
+                                  @Nullable final NodeSet contextSet, final NodeSet resultSet, final boolean returnAncestor,
                                   final SearcherTaxonomyManager.SearcherAndTaxonomy searcher, final Query query,
                                   final LuceneConfig config) throws IOException {
         final LuceneFacets facets = new LuceneFacets();
@@ -946,7 +970,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
         private int docBase;
         private final QName qname;
         private final DocumentSet docs;
-        private final NodeSet contextSet;
+        private @Nullable final NodeSet contextSet;
         private final NodeSet resultSet;
         private final boolean returnAncestor;
         private final int contextId;
@@ -954,7 +978,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
         private final LuceneFacets facets;
         private final FacetsCollector chainedCollector;
 
-        private LuceneHitCollector(final QName qname, final Query query, final DocumentSet docs, final NodeSet contextSet, final NodeSet resultSet, final boolean returnAncestor, final int contextId, final LuceneFacets facets, final FacetsCollector nextCollector) {
+        private LuceneHitCollector(final QName qname, final Query query, final DocumentSet docs, @Nullable final NodeSet contextSet, final NodeSet resultSet, final boolean returnAncestor, final int contextId, final LuceneFacets facets, final FacetsCollector nextCollector) {
             this.qname = qname;
             this.docs = docs;
             this.contextSet = contextSet;
@@ -1000,8 +1024,9 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 //LOG.info("doc: " + docId + "; node: " + nodeId.toString() + "; units: " + units);
 
                 NodeProxy storedNode = new NodeProxy(null, storedDocument, nodeId);
-                if (qname != null)
+                if (qname != null) {
                     storedNode.setNodeType(qname.getNameType() == ElementValue.ATTRIBUTE ? Node.ATTRIBUTE_NODE : Node.ELEMENT_NODE);
+                }
                 // if a context set is specified, we can directly check if the
                 // matching node is a descendant of one of the nodes
                 // in the context set.
@@ -1032,7 +1057,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                     resultSet.add(storedNode);
                     chainedCollector.collect(doc);
                 }
-            } catch (IOException e) {
+            } catch (final IOException e) {
                 e.printStackTrace();
             }
         }
@@ -1065,21 +1090,23 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                     indexes.add(qname);
                 }
             }
-            return indexes;
+        } else {
+            getDefinedIndexesFor(null, indexes);
         }
-        return getDefinedIndexesFor(null, indexes);
+        return indexes;
     }
 
-    private List<QName> getDefinedIndexesFor(QName qname, final List<QName> indexes) throws IOException {
-        return index.withReader(reader -> {
-            for (FieldInfo info: MultiFields.getMergedFieldInfos(reader)) {
+    private void getDefinedIndexesFor(final QName qname, final List<QName> indexes) throws IOException {
+        index.<Void>withReader(reader -> {
+            for (final FieldInfo info: MultiFields.getMergedFieldInfos(reader)) {
                 if (!FIELD_DOC_ID.equals(info.name)) {
-                    QName name = LuceneUtil.decodeQName(info.name, index.getBrokerPool().getSymbols());
-                    if (name != null && (qname == null || matchQName(qname, name)))
+                    final QName name = LuceneUtil.decodeQName(info.name, index.getBrokerPool().getSymbols());
+                    if (name != null && (qname == null || matchQName(qname, name))) {
                         indexes.add(name);
+                    }
                 }
             }
-            return indexes;
+            return null;
         });
     }
 
@@ -1107,7 +1134,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
      */
     @Nullable protected Analyzer getQueryAnalyzer(LuceneConfig config, String field, QName qname, QueryOptions opts) {
         if (config != null) {
-            Analyzer analyzer;
+            final Analyzer analyzer;
             if (opts.getQueryAnalyzerId() != null) {
                 analyzer = config.getAnalyzerById(opts.getQueryAnalyzerId());
                 if (analyzer == null) {
@@ -1135,7 +1162,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
      *
      * @return the lucene config or null
      */
-    public LuceneConfig getLuceneConfig(DBBroker broker, DocumentSet docs) {
+    public static LuceneConfig getLuceneConfig(DBBroker broker, DocumentSet docs) {
         for (Iterator<Collection> i = docs.getCollectionIterator(); i.hasNext(); ) {
             Collection collection = i.next();
             IndexSpec idxConf = collection.getIndexConfiguration(broker);

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
@@ -120,7 +120,7 @@ public class LuceneMatch extends Match {
         if (other instanceof LuceneMatch) {
             final LuceneMatch lm = (LuceneMatch) other;
             return getNodeId().equals(lm.getNodeId())
-                    && query == lm.query;
+                    && query.equals(lm.query);
         } else {
             return false;
         }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -25,13 +49,8 @@ import org.apache.lucene.facet.Facets;
 import org.apache.lucene.search.Query;
 import org.exist.dom.persistent.Match;
 import org.exist.numbering.NodeId;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.value.AtomicValue;
-import org.exist.xquery.value.Sequence;
-import org.exist.xquery.value.ValueSequence;
 
 import javax.annotation.Nullable;
-import java.util.Map;
 
 /**
  * Match class containing the score of a match and a reference to
@@ -39,13 +58,11 @@ import java.util.Map;
  */
 public class LuceneMatch extends Match {
 
-    private int luceneDocId = -1;
+    private final int luceneDocId;
     private float score = 0.0f;
     private final Query query;
 
-    private LuceneIndexWorker.LuceneFacets facets;
-
-    private Map<String, FieldValue[]> fields = null;
+    private final LuceneIndexWorker.LuceneFacets facets;
 
     LuceneMatch(final int contextId, final int luceneDocId, final NodeId nodeId, final Query query, final LuceneIndexWorker.LuceneFacets facets) {
         super(contextId, nodeId, null);
@@ -54,18 +71,17 @@ public class LuceneMatch extends Match {
         this.facets = facets;
     }
 
-    private LuceneMatch(LuceneMatch copy) {
+    private LuceneMatch(final LuceneMatch copy) {
         super(copy);
         this.score = copy.score;
         this.luceneDocId = copy.luceneDocId;
         this.query = copy.query;
         this.facets = copy.facets;
-        this.fields = copy.fields;
     }
 
     @Override
-    public Match createInstance(int contextId, NodeId nodeId, String matchTerm) {
-        return null;
+    public Match createInstance(final int contextId, final NodeId nodeId, @Nullable final String matchTerm) {
+        throw new UnsupportedOperationException("Not supported from Lucene Full-Text Index");
     }
 
     public int getLuceneDocId() {
@@ -90,7 +106,7 @@ public class LuceneMatch extends Match {
         return score;
     }
 
-    protected void setScore(float score) {
+    protected void setScore(final float score) {
         this.score = score;
     }
 
@@ -98,41 +114,15 @@ public class LuceneMatch extends Match {
         return this.facets.getFacets();
     }
 
-    public @Nullable
-    Sequence getField(String name, int type) throws XPathException {
-        if (fields == null) {
-            return null;
-        }
-        final FieldValue[] values = fields.get(name);
-        if (values.length == 1) {
-            return values[0].getValue(type);
-        }
-        final ValueSequence result = new ValueSequence(values.length);
-        for (FieldValue value: values) {
-            result.add(value.getValue(type));
-        }
-        return result;
-    }
-
     // DW: missing hashCode() ?
     @Override
-    public boolean equals(Object other) {
-        if (!(other instanceof LuceneMatch)) {
+    public boolean equals(final Object other) {
+        if (other instanceof LuceneMatch) {
+            final LuceneMatch lm = (LuceneMatch) other;
+            return getNodeId().equals(lm.getNodeId())
+                    && query == lm.query;
+        } else {
             return false;
         }
-        LuceneMatch o = (LuceneMatch) other;
-        return (nodeId == o.nodeId || nodeId.equals(o.nodeId))
-                && query == ((LuceneMatch) other).query;
     }
-
-    @Override
-    public boolean matchEquals(Match other) {
-        return equals(other);
-    }
-
-    private interface FieldValue {
-
-        AtomicValue getValue(int type) throws XPathException;
-    }
-
 }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
@@ -117,6 +117,10 @@ public class LuceneMatch extends Match {
     // DW: missing hashCode() ?
     @Override
     public boolean equals(final Object other) {
+        if (other == this) {
+            return true;
+        }
+
         if (other instanceof LuceneMatch) {
             final LuceneMatch lm = (LuceneMatch) other;
             return getNodeId().equals(lm.getNodeId())

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
@@ -123,8 +123,9 @@ public class LuceneMatch extends Match {
 
         if (other instanceof LuceneMatch) {
             final LuceneMatch lm = (LuceneMatch) other;
-            return getNodeId().equals(lm.getNodeId())
-                    && query.equals(lm.query);
+            return luceneDocId == lm.luceneDocId
+                    && query.equals(lm.query)
+                    && super.equals(lm);
         } else {
             return false;
         }

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
@@ -25,11 +25,12 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
 import org.exist.Namespaces;
-import org.exist.dom.QName;
 import org.exist.dom.memtree.InMemoryNodeSet;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.dom.persistent.Match;
@@ -40,69 +41,77 @@ import org.exist.xquery.*;
 import org.exist.xquery.value.*;
 
 import javax.annotation.Nullable;
+import javax.xml.datatype.XMLGregorianCalendar;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.nio.ByteBuffer;
+import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.Map;
+
+import static org.exist.xquery.FunctionDSL.*;
+import static org.exist.xquery.modules.lucene.LuceneModule.functionSignature;
+import static org.exist.xquery.modules.lucene.LuceneModule.functionSignatures;
 
 public class Field extends BasicFunction {
 
-    public final static FunctionSignature[] signatures = {
-            new FunctionSignature(
-                new QName("field", LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
-                "Returns the value of a field attached to a particular node obtained via a full text search." +
-                        "Only fields listed in the 'fields' option of ft:query will be attached to the query result.",
-                new SequenceType[]{
-                        new FunctionParameterSequenceType("node", Type.NODE, Cardinality.EXACTLY_ONE,
-                                "the context node to check for attached fields"),
-                        new FunctionParameterSequenceType("field", Type.STRING, Cardinality.EXACTLY_ONE,
-                                "name of the field")
-                },
-                new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_MORE,
-                        "One or more string values corresponding to the values of the field attached")
-            ),
-            new FunctionSignature(
-                    new QName("field", LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
-                    "Returns the value of a field attached to a particular node obtained via a full text search." +
-                            "Only fields listed in the 'fields' option of ft:query will be attached to the query result." +
-                            "Accepts an additional parameter to name the target type into which the field " +
-                            "value should be cast. This is mainly relevant for fields having a different type than xs:string. " +
-                            "As lucene does not record type information, numbers or dates would be returned as numbers by default.",
-                    new SequenceType[]{
-                            new FunctionParameterSequenceType("node", Type.NODE, Cardinality.EXACTLY_ONE,
-                                    "the context node to check for attached fields"),
-                            new FunctionParameterSequenceType("field", Type.STRING, Cardinality.EXACTLY_ONE,
-                                    "name of the field"),
-                            new FunctionParameterSequenceType("type", Type.STRING, Cardinality.EXACTLY_ONE,
-                                    "intended target type to cast the field value to. Casting may fail with a dynamic error.")
-                    },
-                    new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE,
-                            "Sequence corresponding to the values of the field attached, cast to the desired target type")
-            ),
-            new FunctionSignature(
-                    new QName("highlight-field-matches", LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
-                    "Highlights matches for the last executed lucene query within the value of a field " +
-                    "attached to a particular node obtained via a full text search. Only fields listed in the 'fields' option of ft:query will be " +
-                    "available to highlighting.",
-                    new SequenceType[] {
-                            new FunctionParameterSequenceType("node", Type.NODE, Cardinality.EXACTLY_ONE,
-                                    "the context node to check for attached fields which should be highlighted"),
-                            new FunctionParameterSequenceType("field", Type.STRING, Cardinality.EXACTLY_ONE,
-                                    "name of the field to highlight")
-                    },
-                    new FunctionReturnSequenceType(Type.ELEMENT, Cardinality.ZERO_OR_ONE,
-                            "An exist:field containing the content of the requested field with all query " +
-                                    "matches enclosed in an exist:match")
-            )
-    };
+    private static final FunctionParameterSequenceType FS_PARAM_NODE = param("node", Type.NODE, "the context node to check for attached fields");
+    private static final FunctionParameterSequenceType FS_PARAM_FIELD = param("field", Type.STRING, "name of the field");
+    private static final FunctionParameterSequenceType TYPE_PARAMETER = param("type", Type.STRING, "intended target type to cast the field value to. Casting may fail with a dynamic error.");
 
-    public Field(XQueryContext context, FunctionSignature signature) {
+    private static final String FS_FIELD_NAME = "field";
+    static final FunctionSignature[] FS_FIELD = functionSignatures(
+            FS_FIELD_NAME,
+            "Returns the value of a field attached to a particular node obtained via a full text search." +
+            "The $type parameter allows you to name the target type into which the field " +
+            "value should be cast. This is mainly relevant for fields having a different type than xs:string. " +
+            "As lucene does not record type information, numbers or dates would be returned as strings by default.",
+            returnsOptMany(Type.ITEM, "Sequence corresponding to the values of the field attached, cast to the desired target type"),
+            arities(
+                    arity(
+                            FS_PARAM_NODE,
+                            FS_PARAM_FIELD
+                    ),
+                    arity(
+                            FS_PARAM_NODE,
+                            FS_PARAM_FIELD,
+                            TYPE_PARAMETER
+                    )
+            )
+    );
+
+    private static final String FS_BINARY_FIELD_NAME = "binary-field";
+    static final FunctionSignature FS_BINARY_FIELD = functionSignature(
+            FS_BINARY_FIELD_NAME,
+            "Returns the value of a binary field attached to a particular node obtained via a full text search." +
+            "Accepts an additional parameter to name the target type into which the field " +
+            "value should be cast. This is mainly relevant for fields having a different type than xs:string. " +
+            "As lucene does not record type information, numbers or dates would be returned as strings by default.",
+            returnsOptMany(Type.ITEM, "Sequence corresponding to the values of the field attached, cast to the desired target type"),
+            FS_PARAM_NODE,
+            FS_PARAM_FIELD,
+            TYPE_PARAMETER
+    );
+
+    private static final String FS_HIGHLIGHT_FIELD_MATCHES_NAME = "highlight-field-matches";
+    static final FunctionSignature FS_HIGHLIGHT_FIELD_MATCHES = functionSignature(
+            FS_HIGHLIGHT_FIELD_MATCHES_NAME,
+            "Highlights matches for the last executed lucene query within the value of a field " +
+            "attached to a particular node obtained via a full text search. Only fields listed in the 'fields' option of ft:query will be " +
+            "available to highlighting.",
+            returnsOpt(Type.ELEMENT, "An exist:field containing the content of the requested field with all query matches enclosed in an exist:match"),
+            FS_PARAM_NODE,
+            FS_PARAM_FIELD
+    );
+
+    public Field(final XQueryContext context, final FunctionSignature signature) {
         super(context, signature);
     }
 
     @Override
-    public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
-        NodeValue nodeValue = (NodeValue) args[0].itemAt(0);
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+        final NodeValue nodeValue = (NodeValue) args[0].itemAt(0);
         if (nodeValue.getImplementationType() != NodeValue.PERSISTENT_NODE) {
             return Sequence.EMPTY_SEQUENCE;
         }
@@ -120,15 +129,45 @@ public class Field extends BasicFunction {
         if (match == null) {
             return Sequence.EMPTY_SEQUENCE;
         }
-        final Sequence text = match.getField(fieldName, type);
-        if (isCalledAs("highlight-field-matches")) {
-            try {
-                return highlightMatches(fieldName, proxy, match, text);
-            } catch (IOException e) {
-                throw new XPathException(this, LuceneModule.EXXQDYFT0002, "Error highlighting matches in field: " + e.getMessage());
+        final String called = getSignature().getName().getLocalPart();
+
+        final LuceneIndexWorker index = (LuceneIndexWorker) context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
+        try {
+            switch (called) {
+                case FS_FIELD_NAME:
+                    return getFieldValues(fieldName, type, match, index);
+                case FS_HIGHLIGHT_FIELD_MATCHES_NAME:
+                    final Sequence result = getFieldValues(fieldName, type, match, index);
+                    return highlightMatches(fieldName, proxy, match, result);
+                case FS_BINARY_FIELD_NAME:
+                    return getBinaryFieldValue(fieldName, type, match, index);
+                default:
+                    throw new XPathException(this, ErrorCodes.FOER0000, "Unknown function: " + getName());
+            }
+        } catch (final IOException e) {
+            throw new XPathException(this, LuceneModule.EXXQDYFT0002, "Error retrieving field: " + e.getMessage());
+        }
+    }
+
+    private Sequence getBinaryFieldValue(final String fieldName, final int type, final LuceneMatch match, final LuceneIndexWorker index) throws IOException {
+        final BytesRef fieldValue = index.getBinaryField(match.getLuceneDocId(), fieldName);
+        if (fieldValue == null) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+        return bytesToAtomic(fieldValue, type);
+    }
+
+    private Sequence getFieldValues(final String fieldName, final int type, final LuceneMatch match, final LuceneIndexWorker index) throws IOException, XPathException {
+        final IndexableField[] fields = index.getField(match.getLuceneDocId(), fieldName);
+        final Sequence result = new ValueSequence(fields.length);
+        for (final IndexableField field : fields) {
+            if (field.numericValue() != null) {
+                result.add(numberToAtomic(type, field.numericValue()));
+            } else {
+                result.add(stringToAtomic(type, field.stringValue()));
             }
         }
-        return text;
+        return result;
     }
 
     /**
@@ -246,5 +285,104 @@ public class Field extends BasicFunction {
             match = match.getNextMatch();
         }
         return null;
+    }
+
+    static AtomicValue bytesToAtomic(final BytesRef field, final int type) {
+        switch (type) {
+            case Type.TIME:
+                return TimeValue.deserialize(ByteBuffer.wrap(field.bytes));
+
+            case Type.DATE_TIME:
+                return DateTimeValue.deserialize(ByteBuffer.wrap(field.bytes));
+
+            case Type.DATE:
+                return DateValue.deserialize(ByteBuffer.wrap(field.bytes));
+            case Type.INTEGER:
+            case Type.LONG:
+            case Type.UNSIGNED_LONG:
+            case Type.INT:
+            case Type.UNSIGNED_INT:
+            case Type.SHORT:
+            case Type.UNSIGNED_SHORT:
+                return IntegerValue.deserialize(ByteBuffer.wrap(field.bytes));
+
+            case Type.DOUBLE:
+                return DoubleValue.deserialize(ByteBuffer.wrap(field.bytes));
+
+            case Type.FLOAT:
+                return FloatValue.deserialize(ByteBuffer.wrap(field.bytes));
+
+            case Type.DECIMAL:
+                return DecimalValue.deserialize(ByteBuffer.wrap(field.bytes));
+
+            default:
+                return new StringValue(field.utf8ToString());
+        }
+    }
+
+    static AtomicValue stringToAtomic(final int type, final String value) throws XPathException {
+        switch(type) {
+            case Type.TIME:
+                return new TimeValue(value);
+            case Type.DATE_TIME:
+                return new DateTimeValue(value);
+            case Type.DATE:
+                return new DateValue(value);
+            case Type.INTEGER:
+            case Type.LONG:
+            case Type.UNSIGNED_LONG:
+            case Type.INT:
+            case Type.UNSIGNED_INT:
+            case Type.SHORT:
+            case Type.UNSIGNED_SHORT:
+                return new IntegerValue(value);
+            case Type.DOUBLE:
+                return new DoubleValue(value);
+            case Type.FLOAT:
+                return new FloatValue(value);
+            case Type.DECIMAL:
+                return new DecimalValue(value);
+            default:
+                return new StringValue(value);
+        }
+    }
+
+    static AtomicValue numberToAtomic(final int type, final Number value) throws XPathException {
+        switch(type) {
+            case Type.TIME:
+                final Date time = new Date(value.longValue());
+                final GregorianCalendar gregorianCalendar = new GregorianCalendar();
+                gregorianCalendar.setTime(time);
+                final XMLGregorianCalendar calendar = TimeUtils.getInstance().newXMLGregorianCalendar(gregorianCalendar);
+                return new TimeValue(calendar);
+            case Type.DATE_TIME:
+                throw new XPathException(LuceneModule.EXXQDYFT0004, "Cannot convert numeric field to xs:dateTime");
+            case Type.DATE:
+                final long dl = value.longValue();
+                final int year = (int)(dl >> 16) & 0xFFFF;
+                final int month = (int)(dl >> 8) & 0xFF;
+                final int day = (int)(dl & 0xFF);
+                final DateValue date = new DateValue();
+                date.calendar.setYear(year);
+                date.calendar.setMonth(month);
+                date.calendar.setDay(day);
+                return date;
+            case Type.INTEGER:
+            case Type.LONG:
+            case Type.UNSIGNED_LONG:
+            case Type.INT:
+            case Type.UNSIGNED_INT:
+            case Type.SHORT:
+            case Type.UNSIGNED_SHORT:
+                return new IntegerValue(value.longValue());
+            case Type.DOUBLE:
+                return new DoubleValue(value.doubleValue());
+            case Type.FLOAT:
+                return new FloatValue(value.floatValue());
+            case Type.DECIMAL:
+                return new DecimalValue(value.doubleValue());
+            default:
+                return new StringValue(value.toString());
+        }
     }
 }

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/LuceneModule.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/LuceneModule.java
@@ -27,7 +27,11 @@ import java.util.Map;
 import org.exist.dom.QName;
 import org.exist.xquery.AbstractInternalModule;
 import org.exist.xquery.ErrorCodes.ErrorCode;
+import org.exist.xquery.FunctionDSL;
 import org.exist.xquery.FunctionDef;
+import org.exist.xquery.FunctionSignature;
+import org.exist.xquery.value.FunctionParameterSequenceType;
+import org.exist.xquery.value.FunctionReturnSequenceType;
 
 /**
  * Module function definitions for Lucene-based full text indexed searching.
@@ -68,9 +72,10 @@ public class LuceneModule extends AbstractInternalModule {
         new FunctionDef(Facets.signatures[0], Facets.class),
         new FunctionDef(Facets.signatures[1], Facets.class),
         new FunctionDef(Facets.signatures[2], Facets.class),
-        new FunctionDef(Field.signatures[0], Field.class),
-        new FunctionDef(Field.signatures[1], Field.class),
-        new FunctionDef(Field.signatures[2], Field.class),
+        new FunctionDef(Field.FS_FIELD[0], Field.class),
+        new FunctionDef(Field.FS_FIELD[1], Field.class),
+        new FunctionDef(Field.FS_BINARY_FIELD, Field.class),
+        new FunctionDef(Field.FS_HIGHLIGHT_FIELD_MATCHES, Field.class),
         new FunctionDef(LuceneIndexKeys.signatures[0], LuceneIndexKeys.class)
     };
 
@@ -96,6 +101,14 @@ public class LuceneModule extends AbstractInternalModule {
     @Override
     public String getReleaseVersion() {
         return RELEASED_IN_VERSION;
+    }
+
+    static FunctionSignature functionSignature(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType... paramTypes) {
+        return FunctionDSL.functionSignature(new QName(name, NAMESPACE_URI, PREFIX), description, returnType, paramTypes);
+    }
+
+    static FunctionSignature[] functionSignatures(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType[][] variableParamTypes) {
+        return FunctionDSL.functionSignatures(new QName(name, NAMESPACE_URI, PREFIX), description, returnType, variableParamTypes);
     }
 
     protected final static class LuceneErrorCode extends ErrorCode {

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -21,8 +45,6 @@
  */
 package org.exist.xquery.modules.lucene;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.dom.persistent.DocumentSet;
 import org.exist.dom.persistent.NodeSet;
@@ -35,68 +57,54 @@ import org.exist.xquery.functions.map.AbstractMapType;
 import org.exist.xquery.value.*;
 import org.w3c.dom.Element;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
-public class Query extends Function implements Optimizable {
-	
-	protected static final Logger logger = LogManager.getLogger(Query.class);
+import static org.exist.xquery.FunctionDSL.*;
+import static org.exist.xquery.modules.lucene.LuceneModule.functionSignatures;
 
-    public final static FunctionSignature[] signatures = {
-        new FunctionSignature(
-            new QName("query", LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
+public class Query extends Function implements Optimizable {
+
+    private static final FunctionParameterSequenceType FS_PARAM_NODES = optManyParam("nodes", Type.NODE, "The node set to search using a Lucene full text index which is defined on those nodes");
+    private static final FunctionParameterSequenceType FS_PARAM_QUERY = optParam("query", Type.ITEM, "The query to search for, provided either as a string or text in Lucene's default query syntax or as an XML fragment to bypass Lucene's default query parser");
+
+    final static FunctionSignature[] signatures = functionSignatures(
+            "query",
             "Queries a node set using a Lucene full text index; a lucene index " +
-            "must already be defined on the nodes, because if no index is available " +
-            "on a node, nothing will be found. Indexes on descendant nodes are not " +
-            "used. The context of the Lucene query is determined by the given input " +
-            "node set. The query is specified either as a query string based on " +
-            "Lucene's default query syntax or as an XML fragment. " +
-            "See http://exist-db.org/lucene.html#N1029E for complete documentation.",
-            new SequenceType[] {
-                new FunctionParameterSequenceType("nodes", Type.NODE, Cardinality.ZERO_OR_MORE,
-                		"The node set to search using a Lucene full text index which is defined on those nodes"),
-                new FunctionParameterSequenceType("query", Type.ITEM, Cardinality.ZERO_OR_ONE,
-                		"The query to search for, provided either as a string or text in Lucene's default query " +
-                		"syntax or as an XML fragment to bypass Lucene's default query parser")
-            },
-            new FunctionReturnSequenceType(Type.NODE, Cardinality.ZERO_OR_MORE,
-                "all nodes from the input node set matching the query. match highlighting information " +
-                "will be available for all returned nodes. Lucene's match score can be retrieved via " +
-                "the ft:score function.")
-        ),
-        new FunctionSignature(
-            new QName("query", LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
-            "Queries a node set using a Lucene full text index; a lucene index " +
-            "must already be defined on the nodes, because if no index is available " +
-            "on a node, nothing will be found. Indexes on descendant nodes are not " +
-            "used. The context of the Lucene query is determined by the given input " +
-            "node set. The query is specified either as a query string based on " +
-            "Lucene's default query syntax or as an XML fragment. " +
-            "See http://exist-db.org/lucene.html#N1029E for complete documentation.",
-            new SequenceType[] {
-                new FunctionParameterSequenceType("nodes", Type.NODE, Cardinality.ZERO_OR_MORE,
-                		"The node set to search using a Lucene full text index which is defined on those nodes"),
-                new FunctionParameterSequenceType("query", Type.ITEM, Cardinality.ZERO_OR_ONE,
-                		"The query to search for, provided either as a string or text in Lucene's default query " +
-                		"syntax or as an XML fragment to bypass Lucene's default query parser"),
-                new FunctionParameterSequenceType("options", Type.ITEM, Cardinality.ZERO_OR_ONE,
-                		"An XML fragment containing options to be passed to Lucene's query parser. The following " +
-                        "options are supported (a description can be found in the docs):\n" +
-                        "<options>\n" +
-                        "   <default-operator>and|or</default-operator>\n" +
-                        "   <phrase-slop>number</phrase-slop>\n" +
-                        "   <leading-wildcard>yes|no</leading-wildcard>\n" +
-                        "   <filter-rewrite>yes|no</filter-rewrite>\n" +
-                        "   <lowercase-expanded-terms>yes|no</lowercase-expanded-terms>\n" +
-                        "</options>")
-            },
-            new FunctionReturnSequenceType(Type.NODE, Cardinality.ZERO_OR_MORE,
-                "all nodes from the input node set matching the query. match highlighting information " +
-                "will be available for all returned nodes. Lucene's match score can be retrieved via " +
-                "the ft:score function.")
-        )
-    };
+                    "must already be defined on the nodes, because if no index is available" +
+                    "on a node, nothing will be found. Indexes on descendant nodes are not " +
+                    "used. The context of the Lucene query is determined by the given input " +
+                    "node set. The query is specified either as a query string based on " +
+                    "Lucene's default query syntax or as an XML fragment. " +
+                    "See http://exist-db.org/lucene.html#N1029E for complete documentation.",
+            returnsOptMany(Type.NODE,
+                    "all nodes from the input node set matching the query. match highlighting information " +
+                    "will be available for all returned nodes. Lucene's match score can be retrieved via " +
+                    "the ft:score function."),
+            arities(
+                    arity(
+                        FS_PARAM_NODES,
+                        FS_PARAM_QUERY
+                    ),
+                    arity(
+                        FS_PARAM_NODES,
+                        FS_PARAM_QUERY,
+                        optParam("options", Type.ITEM,
+                                "An XML fragment or XDM Map containing options to be passed to Lucene's query parser. The following options are supported (a description can be found in the docs): \n" +
+                                        "<options>\n" +
+                                        "\t<default-operator>and|or</default-operator>\n" +
+                                        "\t<phrase-slop>number</phrase-slop>\n" +
+                                        "\t<leading-wildcard>yes|no</leading-wildcard>\n" +
+                                        "\t<filter-rewrite>yes|no</filter-rewrite>\n" +
+                                        "\t<lowercase-expanded-terms>yes|no</lowercase-expanded-terms>\n" +
+                                        "</options>\n"
+                        )
+                    )
+            )
+    );
 
     private LocationStep contextStep = null;
     protected QName contextQName = null;
@@ -105,13 +113,15 @@ public class Query extends Function implements Optimizable {
     protected boolean optimizeSelf = false;
     protected boolean optimizeChild = false;
 
-    public Query(XQueryContext context, FunctionSignature signature) {
+    public Query(final XQueryContext context, final FunctionSignature signature) {
         super(context, signature);
     }
 
-    public void setArguments(List<Expression> arguments) throws XPathException {
+    @Override
+    public void setArguments(final List<Expression> arguments) {
         steps.clear();
-        Expression path = arguments.get(0);
+
+        final Expression path = arguments.get(0);
         steps.add(path);
 
         Expression arg = arguments.get(1).simplify();
@@ -127,21 +137,19 @@ public class Query extends Function implements Optimizable {
         }
     }
 
-    /* (non-Javadoc)
-    * @see org.exist.xquery.PathExpr#analyze(org.exist.xquery.Expression)
-    */
-    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+    @Override
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
         super.analyze(new AnalyzeContextInfo(contextInfo));
 
-        List<LocationStep> steps = BasicExpressionVisitor.findLocationSteps(getArgument(0));
+        final List<LocationStep> steps = BasicExpressionVisitor.findLocationSteps(getArgument(0));
         if (!steps.isEmpty()) {
-            LocationStep firstStep = steps.get(0);
-            LocationStep lastStep = steps.get(steps.size() - 1);
+            final LocationStep firstStep = steps.get(0);
+            final LocationStep lastStep = steps.get(steps.size() - 1);
             if (firstStep != null && steps.size() == 1 && firstStep.getAxis() == Constants.SELF_AXIS) {
-                Expression outerExpr = contextInfo.getContextStep();
-                if (outerExpr != null && outerExpr instanceof LocationStep) {
-                    LocationStep outerStep = (LocationStep) outerExpr;
-                    NodeTest test = outerStep.getTest();
+                final Expression outerExpr = contextInfo.getContextStep();
+                if (outerExpr instanceof LocationStep) {
+                    final LocationStep outerStep = (LocationStep) outerExpr;
+                    final NodeTest test = outerStep.getTest();
 
                     final byte contextQNameType;
                     if (outerStep.getAxis() == Constants.ATTRIBUTE_AXIS || outerStep.getAxis() == Constants.DESCENDANT_ATTRIBUTE_AXIS) {
@@ -161,14 +169,12 @@ public class Query extends Function implements Optimizable {
                     optimizeSelf = true;
                 }
             } else if (lastStep != null && firstStep != null) {
-                NodeTest test = lastStep.getTest();
-                if (test.getName() == null)
+                final NodeTest test = lastStep.getTest();
+                if (test.getName() == null) {
                     contextQName = new QName(null, null, null);
-                else if (test.isWildcardTest())
+                } else if (test.isWildcardTest()) {
                     contextQName = test.getName();
-                else
-
-                if (lastStep.getAxis() == Constants.ATTRIBUTE_AXIS || lastStep.getAxis() == Constants.DESCENDANT_ATTRIBUTE_AXIS) {
+                } else if (lastStep.getAxis() == Constants.ATTRIBUTE_AXIS || lastStep.getAxis() == Constants.DESCENDANT_ATTRIBUTE_AXIS) {
                     contextQName = new QName(test.getName(), ElementValue.ATTRIBUTE);
                 } else {
                     contextQName = new QName(test.getName());
@@ -181,42 +187,46 @@ public class Query extends Function implements Optimizable {
         }
     }
 
-    public boolean canOptimize(Sequence contextSequence) {
+    public boolean canOptimize(final Sequence contextSequence) {
         return contextQName != null;
     }
 
+    @Override
     public boolean optimizeOnSelf() {
         return optimizeSelf;
     }
 
+    @Override
     public boolean optimizeOnChild() {
         return optimizeChild;
     }
 
+    @Override
     public int getOptimizeAxis() {
         return axis;
     }
 
-    public NodeSet preSelect(Sequence contextSequence, boolean useContext) throws XPathException {
+    @Override
+    public NodeSet preSelect(final Sequence contextSequence, final boolean useContext) throws XPathException {
         // guard against an empty contextSequence
     	if (contextSequence == null || !contextSequence.isPersistentSet()) {
     		// in-memory docs won't have an index
     		return NodeSet.EMPTY_SET;
         }
 
-        long start = System.currentTimeMillis();
+        final long start = System.currentTimeMillis();
         // the expression can be called multiple times, so we need to clear the previous preselectResult
         preselectResult = null;
-        LuceneIndexWorker index = (LuceneIndexWorker) context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
+        final LuceneIndexWorker index = (LuceneIndexWorker) context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
 
-        DocumentSet docs = contextSequence.getDocumentSet();
-        Item key = getKey(contextSequence, null);
-        List<QName> qnames = new ArrayList<>(1);
+        final DocumentSet docs = contextSequence.getDocumentSet();
+        final Item key = getKey(contextSequence, null);
+        final List<QName> qnames = new ArrayList<>(1);
         qnames.add(contextQName);
-        QueryOptions options = parseOptions(this, contextSequence, null, 3);
+        final QueryOptions options = parseOptions(this, contextSequence, null, 3);
         try {
             if (key != null && Type.subTypeOf(key.getType(), Type.ELEMENT)) {
-                final Element queryXML = key == null ? null : (Element) ((NodeValue) key).getNode();
+                final Element queryXML = (Element) ((NodeValue) key).getNode();
                 preselectResult = index.query(getExpressionId(), docs, useContext ? contextSequence.toNodeSet() : null,
                         qnames, queryXML, NodeSet.DESCENDANT, options);
             } else {
@@ -224,98 +234,114 @@ public class Query extends Function implements Optimizable {
                 preselectResult = index.query(getExpressionId(), docs, useContext ? contextSequence.toNodeSet() : null,
                         qnames, query, NodeSet.DESCENDANT, options);
             }
-        } catch (IOException | org.apache.lucene.queryparser.classic.ParseException e) {
+        } catch (final IOException | org.apache.lucene.queryparser.classic.ParseException e) {
             throw new XPathException(this, "Error while querying full text index: " + e.getMessage(), e);
         }
+
         LOG.trace("Lucene query took {}", System.currentTimeMillis() - start);
-        if( context.getProfiler().traceFunctions() ) {
-            context.getProfiler().traceIndexUsage( context, "lucene", this, PerformanceStats.OPTIMIZED_INDEX, System.currentTimeMillis() - start );
+
+        if (context.getProfiler().traceFunctions()) {
+            context.getProfiler().traceIndexUsage(context, "lucene", this, PerformanceStats.OPTIMIZED_INDEX, System.currentTimeMillis() - start);
         }
+
         return preselectResult;
     }
 
-    public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
+    @Override
+    public Sequence eval(Sequence contextSequence, @Nullable final Item contextItem) throws XPathException {
     	
-        if (contextItem != null)
+        if (contextItem != null) {
             contextSequence = contextItem.toSequence();
+        }
 
-        if (contextSequence != null && !contextSequence.isPersistentSet())
-    		// in-memory docs won't have an index
-    		return Sequence.EMPTY_SEQUENCE;
+        if (contextSequence != null && !contextSequence.isPersistentSet()) {
+            // in-memory docs won't have an index
+            return Sequence.EMPTY_SEQUENCE;
+        }
         
-        NodeSet result;
+        final NodeSet result;
         if (preselectResult == null) {
-            long start = System.currentTimeMillis();
-            Sequence input = getArgument(0).eval(contextSequence, null);
-            if (!(input instanceof VirtualNodeSet) && input.isEmpty())
+            final long start = System.currentTimeMillis();
+            final Sequence input = getArgument(0).eval(contextSequence, null);
+            if (!(input instanceof VirtualNodeSet) && input.isEmpty()) {
                 result = NodeSet.EMPTY_SET;
-            else {
-                NodeSet inNodes = input.toNodeSet();
-                DocumentSet docs = inNodes.getDocumentSet();
-                LuceneIndexWorker index = (LuceneIndexWorker)
-                        context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
-                Item key = getKey(contextSequence, contextItem);
-                List<QName> qnames = null;
+            } else {
+                final NodeSet inNodes = input.toNodeSet();
+                final DocumentSet docs = inNodes.getDocumentSet();
+                final LuceneIndexWorker index = (LuceneIndexWorker) context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
+                final Item key = getKey(contextSequence, contextItem);
+
+                @Nullable final List<QName> qnames;
                 if (contextQName != null) {
-                    qnames = new ArrayList<>(1);
-                    qnames.add(contextQName);
+                    qnames = Collections.singletonList(contextQName);
+                } else {
+                    qnames = null;
                 }
-                QueryOptions options = parseOptions(this, contextSequence, contextItem, 3);
+
+                final QueryOptions options = parseOptions(this, contextSequence, contextItem, 3);
                 try {
                     if (key != null && Type.subTypeOf(key.getType(), Type.ELEMENT)) {
                         final Element queryXML = (Element) ((NodeValue) key).getNode();
-                        result = index.query(getExpressionId(), docs, inNodes, qnames,
-                                queryXML, NodeSet.ANCESTOR, options);
+                        result = index.query(getExpressionId(), docs, inNodes, qnames, queryXML, NodeSet.ANCESTOR, options);
                     } else {
                         final String query = key == null ? null : key.getStringValue();
-                        result = index.query(getExpressionId(), docs, inNodes, qnames,
-                                query, NodeSet.ANCESTOR, options);
+                        result = index.query(getExpressionId(), docs, inNodes, qnames, query, NodeSet.ANCESTOR, options);
                     }
-                } catch (IOException | org.apache.lucene.queryparser.classic.ParseException e) {
+                } catch (final IOException | org.apache.lucene.queryparser.classic.ParseException e) {
                     throw new XPathException(this, e.getMessage());
                 }
             }
-            if( context.getProfiler().traceFunctions() ) {
-                context.getProfiler().traceIndexUsage( context, "lucene", this, PerformanceStats.BASIC_INDEX, System.currentTimeMillis() - start );
+
+            if(context.getProfiler().traceFunctions()) {
+                context.getProfiler().traceIndexUsage( context, "lucene", this, PerformanceStats.BASIC_INDEX, System.currentTimeMillis() - start);
             }
+
         } else {
             // DW: contextSequence can be null
             contextStep.setPreloadedData(contextSequence.getDocumentSet(), preselectResult);
             result = getArgument(0).eval(contextSequence, null).toNodeSet();
         }
+
         return result;
     }
 
-    protected Item getKey(Sequence contextSequence, Item contextItem) throws XPathException {
-        Sequence keySeq = getArgument(1).eval(contextSequence, contextItem);
+    protected Item getKey(final Sequence contextSequence, final Item contextItem) throws XPathException {
+        final Sequence keySeq = getArgument(1).eval(contextSequence, contextItem);
         if (keySeq.isEmpty()) {
             return null;
         }
-        Item key = keySeq.itemAt(0);
-        if (!(Type.subTypeOf(key.getType(), Type.STRING) || Type.subTypeOf(key.getType(), Type.NODE)))
+
+        final Item key = keySeq.itemAt(0);
+        if (!(Type.subTypeOf(key.getType(), Type.STRING) || Type.subTypeOf(key.getType(), Type.NODE))) {
             throw new XPathException(this, "Second argument to ft:query should either be a query string or " +
                     "an XML element describing the query. Found: " + Type.getTypeName(key.getType()));
+        }
+
         return key;
     }
 
+    @Override
     public int getDependencies() {
         final Expression stringArg = getArgument(0);
         if (Type.subTypeOf(stringArg.returnsType(), Type.NODE) &&
-            !Dependency.dependsOn(stringArg, Dependency.CONTEXT_ITEM)) {
+                !Dependency.dependsOn(stringArg, Dependency.CONTEXT_ITEM)) {
             return Dependency.CONTEXT_SET;
         } else {
             return Dependency.CONTEXT_SET + Dependency.CONTEXT_ITEM;
         }
     }
 
+    @Override
     public int returnsType() {
         return Type.NODE;
     }
 
-    protected static QueryOptions parseOptions(Function funct, Sequence contextSequence, Item contextItem, int position) throws XPathException {
-        if (funct.getArgumentCount() < position)
+    protected static QueryOptions parseOptions(final Function funct, final Sequence contextSequence, final Item contextItem, final int position) throws XPathException {
+        if (funct.getArgumentCount() < position) {
             return new QueryOptions();
-        Sequence optSeq = funct.getArgument(position - 1).eval(contextSequence, contextItem);
+        }
+
+        final Sequence optSeq = funct.getArgument(position - 1).eval(contextSequence, contextItem);
         if (Type.subTypeOf(optSeq.getItemType(), Type.ELEMENT)) {
             return new QueryOptions(funct.getContext(), (NodeValue) optSeq.itemAt(0));
         } else if (Type.subTypeOf(optSeq.getItemType(), Type.MAP)) {
@@ -326,7 +352,7 @@ public class Query extends Function implements Optimizable {
     }
 
     @Override
-    public void resetState(boolean postOptimization) {
+    public void resetState(final boolean postOptimization) {
         super.resetState(postOptimization);
         if (!postOptimization) {
             preselectResult = null;

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
@@ -59,8 +59,7 @@ import org.w3c.dom.Element;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.exist.xquery.FunctionDSL.*;
@@ -107,7 +106,7 @@ public class Query extends Function implements Optimizable {
     );
 
     private LocationStep contextStep = null;
-    protected QName contextQName = null;
+    @Nullable private QName contextQNames[] = null;
     protected int axis = Constants.UNKNOWN_AXIS;
     private NodeSet preselectResult = null;
     protected boolean optimizeSelf = false;
@@ -148,36 +147,29 @@ public class Query extends Function implements Optimizable {
             if (firstStep != null && steps.size() == 1 && firstStep.getAxis() == Constants.SELF_AXIS) {
                 final Expression outerExpr = contextInfo.getContextStep();
                 if (outerExpr instanceof LocationStep) {
-                    final LocationStep outerStep = (LocationStep) outerExpr;
-                    final NodeTest test = outerStep.getTest();
-
-                    final byte contextQNameType;
-                    if (outerStep.getAxis() == Constants.ATTRIBUTE_AXIS || outerStep.getAxis() == Constants.DESCENDANT_ATTRIBUTE_AXIS) {
-                        contextQNameType = ElementValue.ATTRIBUTE;
-                    } else {
-                        contextQNameType = ElementValue.ELEMENT;
+                    final LocationStep outerLocationStep = (LocationStep) outerExpr;
+                    analyzeLocationStep(firstStep, outerLocationStep);
+                } else if (outerExpr instanceof FilteredExpression) {
+                     final FilteredExpression outerStep = (FilteredExpression) outerExpr;
+                    // NOTE(AR) fix for https://github.com/eXist-db/exist/issues/3207
+                    if (outerStep.getExpression() instanceof LocationStep) {
+                        final LocationStep outerLocationStep = (LocationStep) outerStep.getExpression();
+                        analyzeLocationStep(firstStep, outerLocationStep);
+                    } else if (outerStep.getExpression() instanceof Union) {
+                        final Union union = (Union) outerStep.getExpression();
+                        analyzeUnion(firstStep, union);
                     }
-
-                    if (test.getName() == null) {
-                        contextQName = new QName(null, null, contextQNameType);
-                    } else {
-                        contextQName = new QName(test.getName(), contextQNameType);
-                    }
-
-                    contextStep = firstStep;
-                    axis = outerStep.getAxis();
-                    optimizeSelf = true;
                 }
             } else if (lastStep != null && firstStep != null) {
                 final NodeTest test = lastStep.getTest();
                 if (test.getName() == null) {
-                    contextQName = new QName(null, null, null);
+                    contextQNames = new QName[]{ new QName(null, null, null) };
                 } else if (test.isWildcardTest()) {
-                    contextQName = test.getName();
+                    contextQNames = new QName[]{ test.getName() };
                 } else if (lastStep.getAxis() == Constants.ATTRIBUTE_AXIS || lastStep.getAxis() == Constants.DESCENDANT_ATTRIBUTE_AXIS) {
-                    contextQName = new QName(test.getName(), ElementValue.ATTRIBUTE);
+                    contextQNames = new QName[]{ new QName(test.getName(), ElementValue.ATTRIBUTE) };
                 } else {
-                    contextQName = new QName(test.getName());
+                    contextQNames = new QName[]{ new QName(test.getName()) };
                 }
                 axis = firstStep.getAxis();
                 optimizeChild = steps.size() == 1 &&
@@ -187,8 +179,54 @@ public class Query extends Function implements Optimizable {
         }
     }
 
+    private void analyzeLocationStep(final LocationStep firstStep, final LocationStep locationStep) {
+        contextQNames = new QName[]{ getContextQName(locationStep) };
+        contextStep = firstStep;
+        axis = locationStep.getAxis();
+        optimizeSelf = true;
+    }
+
+    private void analyzeUnion(final LocationStep firstStep, final Union union) {
+        final PathExpr left = union.getLeft();
+        final PathExpr right = union.getRight();
+
+        if (left.getPrimaryAxis() != right.getPrimaryAxis()) {
+            return;
+        }
+
+        if (left.getSubExpressionCount() == 1 && left.getSubExpression(0) instanceof LocationStep
+                && right.getSubExpressionCount() == 1 && right.getSubExpression(0) instanceof LocationStep) {
+            final LocationStep leftLocationStep = (LocationStep) left.getSubExpression(0);
+            final LocationStep rightLocationStep = (LocationStep) right.getSubExpression(0);
+            contextQNames = new QName[] { getContextQName(leftLocationStep), getContextQName(rightLocationStep) };
+            contextStep = firstStep;
+            axis = left.getPrimaryAxis();
+            optimizeSelf = true;
+        }
+    }
+
+    private QName getContextQName(final LocationStep locationStep) {
+        final QName contextQName;
+
+        final byte contextQNameType;
+        if (locationStep.getAxis() == Constants.ATTRIBUTE_AXIS || locationStep.getAxis() == Constants.DESCENDANT_ATTRIBUTE_AXIS) {
+            contextQNameType = ElementValue.ATTRIBUTE;
+        } else {
+            contextQNameType = ElementValue.ELEMENT;
+        }
+
+        final NodeTest test = locationStep.getTest();
+        if (test.getName() == null) {
+            contextQName = new QName(null, null, contextQNameType);
+        } else {
+            contextQName = new QName(test.getName(), contextQNameType);
+        }
+
+        return contextQName;
+    }
+
     public boolean canOptimize(final Sequence contextSequence) {
-        return contextQName != null;
+        return contextQNames != null;
     }
 
     @Override
@@ -221,8 +259,7 @@ public class Query extends Function implements Optimizable {
 
         final DocumentSet docs = contextSequence.getDocumentSet();
         final Item key = getKey(contextSequence, null);
-        final List<QName> qnames = new ArrayList<>(1);
-        qnames.add(contextQName);
+        @Nullable final List<QName> qnames = contextQNames != null ? Arrays.asList(contextQNames) : null;
         final QueryOptions options = parseOptions(this, contextSequence, null, 3);
         try {
             if (key != null && Type.subTypeOf(key.getType(), Type.ELEMENT)) {
@@ -270,14 +307,7 @@ public class Query extends Function implements Optimizable {
                 final DocumentSet docs = inNodes.getDocumentSet();
                 final LuceneIndexWorker index = (LuceneIndexWorker) context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
                 final Item key = getKey(contextSequence, contextItem);
-
-                @Nullable final List<QName> qnames;
-                if (contextQName != null) {
-                    qnames = Collections.singletonList(contextQName);
-                } else {
-                    qnames = null;
-                }
-
+                @Nullable final List<QName> qnames = contextQNames != null ? Arrays.asList(contextQNames) : null;
                 final QueryOptions options = parseOptions(this, contextSequence, contextItem, 3);
                 try {
                     if (key != null && Type.subTypeOf(key.getType(), Type.ELEMENT)) {
@@ -298,7 +328,7 @@ public class Query extends Function implements Optimizable {
 
         } else {
             // DW: contextSequence can be null
-            contextStep.setPreloadedData(contextSequence.getDocumentSet(), preselectResult);
+            contextStep.setPreloadedData(preselectResult.getDocumentSet(), preselectResult);
             result = getArgument(0).eval(contextSequence, null).toNodeSet();
         }
 

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryField.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryField.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -21,81 +45,61 @@
  */
 package org.exist.xquery.modules.lucene;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.exist.dom.persistent.DocumentSet;
 import org.exist.dom.persistent.NodeSet;
-import org.exist.dom.QName;
 import org.exist.indexing.lucene.LuceneIndex;
 import org.exist.indexing.lucene.LuceneIndexWorker;
 import org.exist.xquery.*;
 import org.exist.xquery.value.*;
 import org.w3c.dom.Element;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 
-public class QueryField extends Query implements Optimizable {
-	
-	protected static final Logger logger = LogManager.getLogger(Query.class);
+import static org.exist.xquery.FunctionDSL.*;
+import static org.exist.xquery.modules.lucene.LuceneModule.functionSignatures;
 
-    public final static FunctionSignature[] signatures = {
-        new FunctionSignature(
-            new QName("query-field", LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
+public class QueryField extends Query implements Optimizable {
+
+    private static final FunctionParameterSequenceType FS_PARAM_FIELD = optManyParam("field", Type.STRING, "The lucene field name.");
+    private static final FunctionParameterSequenceType FS_PARAM_QUERY = param("query", Type.ITEM, "The query to search for, provided either as a string or text in Lucene's default query syntax or as an XML fragment to bypass Lucene's default query parser");
+
+    final static FunctionSignature[] signatures = functionSignatures(
+            "query-field",
             "Queries a Lucene field, which has to be explicitely created in the index configuration.",
-            new SequenceType[] {
-                new FunctionParameterSequenceType("field", Type.STRING, Cardinality.ZERO_OR_MORE,
-                		"The lucene field name."),
-                new FunctionParameterSequenceType("query", Type.ITEM, Cardinality.EXACTLY_ONE, 
-                		"The query to search for, provided either as a string or text in Lucene's default query " +
-                		"syntax or as an XML fragment to bypass Lucene's default query parser")
-            },
-            new FunctionReturnSequenceType(Type.NODE, Cardinality.ZERO_OR_MORE,
-                "all nodes from the input node set matching the query. match highlighting information " +
-                "will be available for all returned nodes. Lucene's match score can be retrieved via " +
-                "the ft:score function."),
-            "Use an index definition with nested fields and ft:query instead"
-        ),
-        new FunctionSignature(
-            new QName("query-field", LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
-            "Queries a Lucene field, which has to be explicitely created in the index configuration.",
-            new SequenceType[] {
-                new FunctionParameterSequenceType("field", Type.STRING, Cardinality.ZERO_OR_MORE,
-                		"The lucene field name."),
-                new FunctionParameterSequenceType("query", Type.ITEM, Cardinality.EXACTLY_ONE,
-                		"The query to search for, provided either as a string or text in Lucene's default query " +
-                		"syntax or as an XML fragment to bypass Lucene's default query parser"),
-                new FunctionParameterSequenceType("options", Type.NODE, Cardinality.ZERO_OR_ONE,
-                		"An XML fragment containing options to be passed to Lucene's query parser. The following " +
-                        "options are supported (a description can be found in the docs):\n" +
-                        "<options>\n" +
-                        "   <default-operator>and|or</default-operator>\n" +
-                        "   <phrase-slop>number</phrase-slop>\n" +
-                        "   <leading-wildcard>yes|no</leading-wildcard>\n" +
-                        "   <filter-rewrite>yes|no</filter-rewrite>\n" +
-                        "</options>")
-            },
-            new FunctionReturnSequenceType(Type.NODE, Cardinality.ZERO_OR_MORE,
-                "all nodes from the input node set matching the query. match highlighting information " +
-                "will be available for all returned nodes. Lucene's match score can be retrieved via " +
-                "the ft:score function."),
-            "Use an index definition with nested fields and ft:query instead"
-        )
-    };
+            returnsOptMany(Type.NODE, " all nodes from the input node set matching the query. match highlighting information " +
+                    "will be available for all returned nodes. Lucene's match score can be retrieved via " +
+                    "the ft:score function."),
+            arities(
+                    arity(
+                            FS_PARAM_FIELD,
+                            FS_PARAM_QUERY
+                    ),
+                    arity(
+                            FS_PARAM_FIELD,
+                            FS_PARAM_QUERY,
+                            optParam("options", Type.ITEM, "An XML fragment or XDM Map containing options to be passed to Lucene's query parser. The following " +
+                                    "options are supported (a description can be found in the docs):\n" +
+                                    "<options>\n" +
+                                    "\t<default-operator>and|or</default-operator>\n" +
+                                    "\t<phrase-slop>number</phrase-slop>\n" +
+                                    "\t<leading-wildcard>yes|no</leading-wildcard>\n" +
+                                    "\t<filter-rewrite>yes|no</filter-rewrite>\n" +
+                                    "</options>"
+                            )
+                    )
+            )
+    );
 
     private NodeSet preselectResult = null;
 
-    public QueryField(XQueryContext context, FunctionSignature signature) {
+    public QueryField(final XQueryContext context, final FunctionSignature signature) {
         super(context, signature);
     }
 
-    /* (non-Javadoc)
-    * @see org.exist.xquery.PathExpr#analyze(org.exist.xquery.Expression)
-    */
-
     @Override
-    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
         super.analyze(new AnalyzeContextInfo(contextInfo));
-
         this.contextId = contextInfo.getContextId();
     }
 
@@ -103,78 +107,86 @@ public class QueryField extends Query implements Optimizable {
     	return true;
     }
 
+    @Override
     public int getOptimizeAxis() {
         return Constants.DESCENDANT_SELF_AXIS;
     }
 
-    public NodeSet preSelect(Sequence contextSequence, boolean useContext) throws XPathException {
-        long start = System.currentTimeMillis();
+    @Override
+    public NodeSet preSelect(final Sequence contextSequence, final boolean useContext) throws XPathException {
+        final long start = System.currentTimeMillis();
         // the expression can be called multiple times, so we need to clear the previous preselectResult
         preselectResult = null;
-        LuceneIndexWorker index = (LuceneIndexWorker)
-                context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
-        String field = getArgument(0).eval(contextSequence, null).getStringValue();
-        DocumentSet docs = contextSequence.getDocumentSet();
-        Item query = getKey(contextSequence, null);
-        QueryOptions options = parseOptions(this, contextSequence, null, 3);
+        final LuceneIndexWorker index = (LuceneIndexWorker) context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
+        final String field = getArgument(0).eval(contextSequence, null).getStringValue();
+        final DocumentSet docs = contextSequence.getDocumentSet();
+        final Item query = getKey(contextSequence, null);
+        final QueryOptions options = parseOptions(this, contextSequence, null, 3);
         try {
-            if (Type.subTypeOf(query.getType(), Type.ELEMENT))
-                preselectResult = index.queryField(getExpressionId(), docs, useContext ? contextSequence.toNodeSet() : null,
-                    field, (Element) ((NodeValue)query).getNode(), NodeSet.DESCENDANT, options);
-            else
-                preselectResult = index.queryField(context, getExpressionId(), docs, useContext ? contextSequence.toNodeSet() : null,
-                    field, query.getStringValue(), NodeSet.DESCENDANT, options);
-        } catch (IOException e) {
+            if (Type.subTypeOf(query.getType(), Type.ELEMENT)) {
+                preselectResult = index.queryField(getExpressionId(), docs, useContext ? contextSequence.toNodeSet() : null, field, (Element) ((NodeValue) query).getNode(), NodeSet.DESCENDANT, options);
+            } else {
+                preselectResult = index.queryField(context, getExpressionId(), docs, useContext ? contextSequence.toNodeSet() : null, field, query.getStringValue(), NodeSet.DESCENDANT, options);
+            }
+        } catch (final IOException e) {
             throw new XPathException(this, "Error while querying full text index: " + e.getMessage(), e);
         }
+
         LOG.debug("Lucene query took {}", System.currentTimeMillis() - start);
-        if( context.getProfiler().traceFunctions() ) {
-            context.getProfiler().traceIndexUsage( context, "lucene", this, PerformanceStats.OPTIMIZED_INDEX, System.currentTimeMillis() - start );
+
+        if (context.getProfiler().traceFunctions()) {
+            context.getProfiler().traceIndexUsage(context, "lucene", this, PerformanceStats.OPTIMIZED_INDEX, System.currentTimeMillis() - start);
         }
+
         return preselectResult;
     }
 
-    public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
-    	
-        if (contextItem != null)
+    @Override
+    public Sequence eval(Sequence contextSequence, @Nullable final Item contextItem) throws XPathException {
+        if (contextItem != null) {
             contextSequence = contextItem.toSequence();
+        }
 
-        NodeSet result;
+        final NodeSet result;
         if (preselectResult == null) {
-        	long start = System.currentTimeMillis();
-        	String field = getArgument(0).eval(contextSequence, null).getStringValue();
+        	final long start = System.currentTimeMillis();
+        	final String field = getArgument(0).eval(contextSequence, null).getStringValue();
+        	final Item query = getKey(contextSequence, null);
         	
-        	Item query = getKey(contextSequence, null);
-        	
-        	DocumentSet docs = null;
-        	if (contextSequence == null)
+        	final DocumentSet docs;
+        	if (contextSequence == null) {
         		docs = context.getStaticallyKnownDocuments();
-        	else
-                docs = contextSequence.getDocumentSet();
+        	} else {
+        		docs = contextSequence.getDocumentSet();
+        	}
 
-        	NodeSet contextSet = null;
-        	if (contextSequence != null)
+        	final NodeSet contextSet;
+        	if (contextSequence != null) {
         		contextSet = contextSequence.toNodeSet();
+        	} else {
+        		contextSet = null;
+        	}
         	
-        	LuceneIndexWorker index = (LuceneIndexWorker)
-        		context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
-        	QueryOptions options = parseOptions(this, contextSequence, contextItem, 3);
+        	final LuceneIndexWorker index = (LuceneIndexWorker) context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
+        	final QueryOptions options = parseOptions(this, contextSequence, contextItem, 3);
         	try {
-        		if (Type.subTypeOf(query.getType(), Type.ELEMENT))
-        			result = index.queryField(getExpressionId(), docs, contextSet, field,
-        					(Element)((NodeValue)query).getNode(), NodeSet.ANCESTOR, options);
-        		else
-        			result = index.queryField(context, getExpressionId(), docs, contextSet, field,
-        					query.getStringValue(), NodeSet.ANCESTOR, options);
-            } catch (IOException e) {
+        		if (Type.subTypeOf(query.getType(), Type.ELEMENT)) {
+                    result = index.queryField(getExpressionId(), docs, contextSet, field, (Element) ((NodeValue) query).getNode(), NodeSet.ANCESTOR, options);
+                } else {
+                    result = index.queryField(context, getExpressionId(), docs, contextSet, field, query.getStringValue(), NodeSet.ANCESTOR, options);
+                }
+            } catch (final IOException e) {
         		throw new XPathException(this, e.getMessage());
         	}
-        	if( context.getProfiler().traceFunctions() ) {
-        		context.getProfiler().traceIndexUsage( context, "lucene", this, PerformanceStats.BASIC_INDEX, System.currentTimeMillis() - start );
+
+        	if (context.getProfiler().traceFunctions()) {
+        		context.getProfiler().traceIndexUsage(context, "lucene", this, PerformanceStats.BASIC_INDEX, System.currentTimeMillis() - start);
         	}
+
         } else {
             result = preselectResult.selectAncestorDescendant(contextSequence.toNodeSet(), NodeSet.DESCENDANT, true, getContextId(), true);
         }
+
         return result;
     }
 
@@ -184,7 +196,7 @@ public class QueryField extends Query implements Optimizable {
     }
 
     @Override
-    public void resetState(boolean postOptimization) {
+    public void resetState(final boolean postOptimization) {
         super.resetState(postOptimization);
         if (!postOptimization) {
             preselectResult = null;

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryOptions.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryOptions.java
@@ -53,7 +53,6 @@ public class QueryOptions {
     public static final String DEFAULT_OPERATOR_OR = "or";
     public static final String OPTION_LOWERCASE_EXPANDED_TERMS = "lowercase-expanded-terms";
     public static final String OPTION_FACETS = "facets";
-    public static final String OPTION_FIELDS = "fields";
     public static final String OPTION_QUERY_ANALYZER_ID = "query-analyzer-id";
 
     protected enum DefaultOperator {
@@ -99,21 +98,20 @@ public class QueryOptions {
         }
     }
 
-    public QueryOptions(AbstractMapType map) throws XPathException {
+    public QueryOptions(final AbstractMapType map) throws XPathException {
         for (final IEntry<AtomicValue, Sequence> entry: map) {
             final String key = entry.key().getStringValue();
-            if (key.equals(OPTION_FIELDS) && !entry.value().isEmpty()) {
-                fields = new HashSet<>();
-                for (SequenceIterator i = entry.value().unorderedIterator(); i.hasNext(); ) {
-                    fields.add(i.nextItem().getStringValue());
-                }
-            } else if (key.equals(OPTION_FACETS) && entry.value().hasOne() && entry.value().getItemType() == Type.MAP) {
-                // map to hold the facet values for each dimension
-                final Map<String, FacetQuery> tf = new HashMap<>();
+            if (key.equals(OPTION_FACETS) && entry.value().hasOne() && entry.value().getItemType() == Type.MAP) {
+
                 // iterate over each dimension and collect its values into a FacetQuery
-                for (final IEntry<AtomicValue, Sequence> facet: (AbstractMapType) entry.value().itemAt(0)) {
+                final AbstractMapType subMap = (AbstractMapType) entry.value().itemAt(0);
+
+                // map to hold the facet values for each dimension
+                final Map<String, FacetQuery> tf = new HashMap<>(subMap.size());
+
+                for (final IEntry<AtomicValue, Sequence> facet : subMap) {
                     final Sequence value = facet.value();
-                    FacetQuery values;
+                    final FacetQuery values;
                     if (value.hasOne() && value.getItemType() == Type.ARRAY) {
                         values = new FacetQuery((ArrayType) facet.value().itemAt(0));
                     } else {

--- a/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
@@ -32,7 +32,9 @@ declare variable $facet:XML :=
             <to>Egon</to>
             <place>Berlin</place>
             <date>2019-03-14</date>
+            <received>2019-03-14</received>
             <time>14:22:19.329+01:00</time>
+            <dateTime>1972-06-08T10:00:00-05:00</dateTime>
             <likes>9</likes>
             <score>6.0</score>
             <subject>art</subject>
@@ -43,7 +45,9 @@ declare variable $facet:XML :=
             <to>Egon</to>
             <place>Berlin</place>
             <date>2017-03-13</date>
+            <received>2017-03-20</received>
             <time>15:22:19.329+01:00</time>
+            <dateTime>1970-07-03T00:00:00-05:00</dateTime>
             <likes>19</likes>
             <score>8.25</score>
             <subject>history</subject>
@@ -53,6 +57,7 @@ declare variable $facet:XML :=
             <to>Hans</to>
             <place>Hamburg</place>
             <date>2019-04-01</date>
+            <received>2019-04-03</received>
             <likes>29</likes>
             <score>16.5</score>
             <subject>engineering</subject>
@@ -63,6 +68,7 @@ declare variable $facet:XML :=
             <to>Babsi Müller</to>
             <place></place>
             <date>2017-03-11</date>
+            <received>2017-04-01</received>
             <likes>1</likes>
             <score>14.25</score>
             <subject>history</subject>
@@ -72,6 +78,7 @@ declare variable $facet:XML :=
             <to>Basia Müller</to>
             <place>Wrocław</place>
             <date>2015-06-22</date>
+            <received>2018-06-24</received>
             <likes>5</likes>
             <score>29.50</score>
             <subject>history</subject>
@@ -81,6 +88,7 @@ declare variable $facet:XML :=
             <to>Basia Kowalska</to>
             <place>Wrocław</place>
             <date>2013-06-22</date>
+            <received>2013-08-01</received>
             <likes>3</likes>
             <subject>history</subject>
             <score>16.0</score>
@@ -221,10 +229,17 @@ declare variable $facet:XCONF1 :=
                     <field name="place" expression="place" analyzer="nodiacritics"/>
                     <field name="from" expression="from" store="no"/>
                     <field name="to" expression="to"/>
+                    <field name="to-binary" expression="to" binary="true"/>
                     <field name="date" expression="date" type="xs:date"/>
+                    <field name="received" expression="received" type="xs:date" binary="true"/>
                     <field name="likes" expression="likes" type="xs:int"/>
+                    <field name="likes-binary" expression="likes" type="xs:int" binary="true"/>
                     <field name="score" expression="score" type="xs:double"/>
+                    <field name="score-binary" expression="score" type="xs:double" binary="true"/>
                     <field name="time" expression="time" type="xs:time"/>
+                    <field name="time-binary" expression="time" type="xs:time" binary="true"/>
+                    <field name="date-binary" expression="date" type="xs:date" binary="true"/>
+                    <field name="dateTime-binary" expression="dateTime" type="xs:dateTime" binary="true"/>
                 </text>
                 <text qname="document">
                     <field name="title" expression="title"/>
@@ -573,7 +588,7 @@ function facet:query-field($query as xs:string) {
 declare
     %test:assertEquals("Babsi Müller", "Basia Kowalska", "Basia Müller")
 function facet:query-and-sort() {
-    for $letter in collection("/db/lucenetest")//letter[ft:query(., "from:heinz", map { "fields": "to" })]
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., "from:heinz")]
     order by ft:field($letter, "to")
     return
         $letter/to/text()
@@ -582,7 +597,7 @@ function facet:query-and-sort() {
 declare
     %test:assertEquals("Basia Kowalska", "Basia Müller", "Babsi Müller")
 function facet:query-and-sort-by-date() {
-    for $letter in collection("/db/lucenetest")//letter[ft:query(., "from:heinz", map { "fields": "date" })]
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., "from:heinz")]
     order by ft:field($letter, "date", "xs:date")
     return
         $letter/to/text()
@@ -591,7 +606,7 @@ function facet:query-and-sort-by-date() {
 declare
     %test:assertEquals("Hans", "Rudi")
 function facet:query-and-sort-by-time() {
-    for $letter in collection("/db/lucenetest")//letter[ft:query(., "place:berlin", map { "fields": "time" })]
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., "place:berlin")]
     order by ft:field($letter, "time", "xs:time")
     return
         $letter/from/text()
@@ -603,7 +618,7 @@ declare
     %test:args("score", "xs:float")
     %test:assertEquals(6, 8.25, 14.25, 16, 16.5, 29.5)
 function facet:query-and-sort-by-numeric($field as xs:string, $type as xs:string) {
-    for $letter in collection("/db/lucenetest")//letter[ft:query(., (), map { "fields": $field })]
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., ())]
     let $likes := ft:field($letter, $field, $type)
     order by $likes
     return
@@ -613,7 +628,7 @@ function facet:query-and-sort-by-numeric($field as xs:string, $type as xs:string
 declare
     %test:assertEmpty
 function facet:retrieve-non-existant-field() {
-    for $letter in collection("/db/lucenetest")//letter[ft:query(., (), map { "fields": "foo" })]
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., ())]
     return
         ft:field($letter, "foo")
 };
@@ -621,7 +636,7 @@ function facet:retrieve-non-existant-field() {
 declare
     %test:assertEmpty
 function facet:retrieve-not-stored() {
-    for $letter in collection("/db/lucenetest")//letter[ft:query(., (), map { "fields": "from" })]
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., ())]
     return
         ft:field($letter, "from")
 };
@@ -629,7 +644,7 @@ function facet:retrieve-not-stored() {
 declare
     %test:assertEquals("Egon", "Berlin")
 function facet:retrieve-multiple-fields() {
-    for $letter in collection("/db/lucenetest")//letter[ft:query(., "from:rudi", map { "fields": ("to", "place") })]
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., "from:rudi")]
     return
         (ft:field($letter, "to"), ft:field($letter, "place"))
 };
@@ -637,7 +652,7 @@ function facet:retrieve-multiple-fields() {
 declare
     %test:assertEquals("2017-03-13", 19, 8.25)
 function facet:test-field-type() {
-    let $letter := collection("/db/lucenetest")//letter[ft:query(., "from:rudi", map { "fields": ("date", "likes", "score") })]
+    let $letter := collection("/db/lucenetest")//letter[ft:query(., "from:rudi")]
     return (
         ft:field($letter, "date", "xs:date"),
         ft:field($letter, "likes", "xs:integer"),
@@ -801,7 +816,88 @@ declare
     %test:args('title:"Streiten und Hoffen"', "title")
     %test:assertEquals("<exist:field xmlns:exist='http://exist.sourceforge.net/NS/exist'><exist:match>Streiten und Hoffen</exist:match></exist:field>")
 function facet:query-field-expand-matches($query as xs:string, $field as xs:string) {
-    let $result := doc("/db/lucenetest/documents.xml")//document[ft:query(., $query, map { "fields": $field })]
+    let $result := doc("/db/lucenetest/documents.xml")//document[ft:query(., $query)]
     return
         ft:highlight-field-matches($result, $field)[.//exist:match]
+};
+
+declare
+    %test:assertEquals("Basia Kowalska", "Babsi Müller", "Basia Müller")
+function facet:query-and-sort-by-binary-date() {
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., "from:heinz")]
+    order by ft:binary-field($letter, "received", "xs:date")
+    return
+        $letter/to/text()
+};
+
+declare
+    %test:assertEquals("2017", "20")
+function facet:retrieve-binary-date-field() {
+    let $letter := collection("/db/lucenetest")//letter[ft:query(., "from:rudi")]
+    let $date := ft:binary-field($letter, "received", "xs:date")
+    return (
+        year-from-date($date),
+        day-from-date($date)
+    )
+};
+
+declare
+    %test:assertEquals("Babsi Müller", "Basia Kowalska", "Basia Müller")
+function facet:query-and-sort-by-binary-string() {
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., "from:heinz")]
+    order by ft:binary-field($letter, "to-binary", "xs:string") empty least
+    return
+        $letter/to/text()
+};
+
+declare
+    %test:args("likes-binary", "xs:int")
+    %test:assertEquals(1, 3, 5, 9, 19, 29)
+    %test:args("score-binary", "xs:double")
+    %test:assertEquals(6, 8.25, 14.25, 16, 16.5, 29.5)
+function facet:query-and-sort-by-binary-numeric($field as xs:string, $type as xs:string) {
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., ())]
+    let $field-value := ft:binary-field($letter, $field, $type)
+    order by $field-value
+    return $field-value
+};
+
+declare
+    %test:args("time-binary", "xs:time")
+    %test:assertEquals("14:22:19.329+01:00", "15:22:19.329+01:00")
+    %test:args("date-binary", "xs:date")
+    %test:assertEquals("2013-06-22", "2015-06-22", "2017-03-11", "2017-03-13", "2019-03-14", "2019-04-01")
+function facet:query-and-sort-by-binary-dates-and-times($field as xs:string, $type as xs:string) {
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., ())]
+    let $field-value := ft:binary-field($letter, $field, $type)
+    order by $field-value
+    return $field-value
+};
+
+declare
+    %test:args("dateTime-binary", "xs:dateTime")
+    %test:assertEquals("1970-07-03T00:00:00-05:00", "1972-06-08T10:00:00-05:00")
+function facet:query-and-sort-by-binary-dateTime($field as xs:string, $type as xs:string) {
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., ())]
+    let $field-value := ft:binary-field($letter, $field, $type)
+    order by $field-value
+    return $field-value
+};
+
+declare
+    %test:assertEquals("Hans", "Rudi")
+function facet:query-and-sort-by-binary-time() {
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., "to:Egon")]
+    order by ft:binary-field($letter, "time-binary", "xs:time")
+    return
+        $letter/from/text()
+};
+
+declare
+    %test:assertEquals("Rudi", "Hans")
+function facet:query-and-sort-by-binary-dateTime() {
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., "place:berlin")]
+    order by ft:binary-field($letter, "dateTime-binary", "xs:dateTime")
+    return
+        $letter/from/text()
 };

--- a/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
@@ -145,6 +145,9 @@ declare variable $facet:MULTI_LANGUAGE :=
             </div>
         </body>
         <body xml:lang="en">
+            <span>
+                <p>The sun was shining</p>
+            </span>
             <div>
                 <p>And the birds are singing</p>
             </div>
@@ -259,6 +262,12 @@ declare variable $facet:XCONF1 :=
                     <facet dimension="language" expression="ancestor::body/@xml:lang"/>
                     <ignore qname="note"/>
                 </text>
+                <text match="/text/body/span" index="no">
+                    <field name="german2" if="ancestor::body[@xml:lang = 'de']" analyzer="german"/>
+                    <field name="english2" if="ancestor::body[@xml:lang = 'en']" analyzer="english"/>
+                    <facet dimension="language" expression="ancestor::body/@xml:lang"/>
+                    <ignore qname="note"/>
+                </text>`
                 <text qname="person">
                     <facet dimension="city" expression="idx:city-id-to-label(city-id)"/>
                 </text>
@@ -972,6 +981,31 @@ declare
     %test:assertEquals("1 1")
 function facet:query-no-default-index-bracketed-element-one-nonexistent-element-count-and-facets() {
     let $result := doc("/db/lucenetest/multi-lang.xml")//(div|other)[ft:query(., "english:*", map { "leading-wildcard": "yes" })]
+    return
+        count($result) || " " || ft:facets($result, "language")?en
+};
+
+
+declare
+    %test:assertEquals(2)
+function facet:query-no-default-index-bracketed-two-elements-count() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//(div|span)[ft:query(., "english:* OR english2:*", map { "leading-wildcard": "yes" })]
+    return
+        count($result)
+};
+
+declare
+    %test:assertEquals(2)
+function facet:query-no-default-index-bracketed-two-elements-facets() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//(div|span)[ft:query(., "english:* OR english2:*", map { "leading-wildcard": "yes" })]
+    return
+        ft:facets($result, "language")?en
+};
+
+declare
+    %test:assertEquals("2 2")
+function facet:query-no-default-index-bracketed-two-elements-count-and-facets() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//(div|span)[ft:query(., "english:* OR english2:*", map { "leading-wildcard": "yes" })]
     return
         count($result) || " " || ft:facets($result, "language")?en
 };

--- a/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
@@ -21,9 +21,11 @@
  :)
 xquery version "3.1";
 
-module namespace facet="http://exist-db.org/xquery/lucene/test/facets";
+module namespace facet = "http://exist-db.org/xquery/lucene/test/facets";
 
-declare namespace test="http://exist-db.org/xquery/xqsuite";
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+import module namespace ft = "http://exist-db.org/xquery/lucene";
 
 declare variable $facet:XML :=
     <letters>
@@ -900,4 +902,52 @@ function facet:query-and-sort-by-binary-dateTime() {
     order by ft:binary-field($letter, "dateTime-binary", "xs:dateTime")
     return
         $letter/from/text()
+};
+
+declare
+    %test:assertEquals(1)
+function facet:query-no-default-index-count() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//div[ft:query(., "english:*", map { "leading-wildcard": "yes" })]
+    return
+        count($result)
+};
+
+declare
+    %test:assertEquals(1)
+function facet:query-no-default-index-facets() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//div[ft:query(., "english:*", map { "leading-wildcard": "yes" })]
+    return
+        ft:facets($result, "language")?en
+};
+
+declare
+    %test:assertEquals("1 1")
+function facet:query-no-default-index-count-and-facets() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//div[ft:query(., "english:*", map { "leading-wildcard": "yes" })]
+    return
+        count($result) || " " || ft:facets($result, "language")?en
+};
+
+declare
+    %test:assertEquals(1)
+function facet:query-no-default-index-bracketed-element-count() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//(div)[ft:query(., "english:*", map { "leading-wildcard": "yes" })]
+    return
+        count($result)
+};
+
+declare
+    %test:assertEquals(1)
+function facet:query-no-default-index-bracketed-element-facets() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//(div)[ft:query(., "english:*", map { "leading-wildcard": "yes" })]
+    return
+        ft:facets($result, "language")?en
+};
+
+declare
+    %test:assertEquals("1 1")
+function facet:query-no-default-index-bracketed-element-count-and-facets() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//(div)[ft:query(., "english:*", map { "leading-wildcard": "yes" })]
+    return
+        count($result) || " " || ft:facets($result, "language")?en
 };

--- a/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
@@ -951,3 +951,27 @@ function facet:query-no-default-index-bracketed-element-count-and-facets() {
     return
         count($result) || " " || ft:facets($result, "language")?en
 };
+
+declare
+    %test:assertEquals(1)
+function facet:query-no-default-index-bracketed-element-one-nonexistent-element-count() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//(div|other)[ft:query(., "english:*", map { "leading-wildcard": "yes" })]
+    return
+        count($result)
+};
+
+declare
+    %test:assertEquals(1)
+function facet:query-no-default-index-bracketed-element-one-nonexistent-element-facets() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//(div|other)[ft:query(., "english:*", map { "leading-wildcard": "yes" })]
+    return
+        ft:facets($result, "language")?en
+};
+
+declare
+    %test:assertEquals("1 1")
+function facet:query-no-default-index-bracketed-element-one-nonexistent-element-count-and-facets() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//(div|other)[ft:query(., "english:*", map { "leading-wildcard": "yes" })]
+    return
+        count($result) || " " || ft:facets($result, "language")?en
+};

--- a/extensions/indexes/ngram/pom.xml
+++ b/extensions/indexes/ngram/pom.xml
@@ -149,6 +149,7 @@
                                 <include>src/test/resources/log4j2.xml</include>
                                 <include>src/test/java/org/exist/indexing/ngram/CustomIndexTest.java</include>
                                 <include>src/main/java/org/exist/indexing/ngram/NGramIndexWorker.java</include>
+                                <include>src/main/java/org/exist/indexing/ngram/NGramMatch.java</include>
                             </includes>
                         </licenseSet>
 
@@ -163,6 +164,7 @@
                                 <exclude>src/test/resources/log4j2.xml</exclude>
                                 <exclude>src/test/java/org/exist/indexing/ngram/CustomIndexTest.java</exclude>
                                 <exclude>src/main/java/org/exist/indexing/ngram/NGramIndexWorker.java</exclude>
+                                <exclude>src/main/java/org/exist/indexing/ngram/NGramMatch.java</exclude>
                             </excludes>
                         </licenseSet>
                     </licenseSets>

--- a/extensions/indexes/ngram/src/main/java/org/exist/indexing/ngram/NGramMatch.java
+++ b/extensions/indexes/ngram/src/main/java/org/exist/indexing/ngram/NGramMatch.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -26,20 +50,20 @@ import org.exist.numbering.NodeId;
 
 public class NGramMatch extends Match {
 
-    public NGramMatch(int contextId, NodeId nodeId, String matchTerm) {
+    public NGramMatch(final int contextId, final NodeId nodeId, final String matchTerm) {
         super(contextId, nodeId, matchTerm);
     }
 
-    public NGramMatch(int contextId, NodeId nodeId, String matchTerm, int frequency) {
+    public NGramMatch(final int contextId, final NodeId nodeId, final String matchTerm, final int frequency) {
         super(contextId, nodeId, matchTerm, frequency);
     }
 
-    public NGramMatch(Match match) {
+    public NGramMatch(final Match match) {
         super(match);
     }
 
     @Override
-    public Match createInstance(int contextId, NodeId nodeId, String matchTerm) {
+    public Match createInstance(final int contextId, final NodeId nodeId, final String matchTerm) {
         return new NGramMatch(contextId, nodeId, matchTerm);
     }
 


### PR DESCRIPTION
Backport of https://github.com/eXist-db/exist/pull/4989

This code is already in Elemental 7.x.x, but is also needed in Elemental 6.x.x to support https://github.com/evolvedbinary/elemental/pull/39

Closes https://github.com/eXist-db/exist/issues/3207

Fixes a number of bugs whereby too many Matches were set from `ft:query` and several potentially optimisable expressions were not correctly optimised.