### PR TITLE
[7.x.x] Correct issue with boolean evaluation in predicates

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -766,6 +766,7 @@
                                 <include>src/test/java/org/exist/xquery/functions/xmldb/XMLDBStoreTest.java</include>
                                 <include>src/test/java/org/exist/xquery/functions/xquery3/SerializeTest.java</include>
                                 <include>src/test/java/org/exist/xquery/value/DateTimeTypesTest.java</include>
+                                <include>src/test/xquery/emptySeq.xq</include>
                             </includes>
                         </licenseSet>
 
@@ -1085,6 +1086,7 @@
                                 <include>src/main/java/org/exist/xslt/EXistURIResolver.java</include>
                                 <include>src/main/java/org/exist/xslt/XsltURIResolverHelper.java</include>
                                 <include>src/test/java/org/exist/xupdate/RemoveAppendTest.java</include>
+                                <include>src/main/java/org/exist/xquery/GeneralComparison.java</include>
                             </includes>
                         </licenseSet>
 
@@ -1538,7 +1540,8 @@
                                 <exclude>src/main/java/org/exist/xslt/EXistURIResolver.java</exclude>
                                 <exclude>src/main/java/org/exist/xslt/XsltURIResolverHelper.java</exclude>
                                 <exclude>src/test/java/org/exist/xupdate/RemoveAppendTest.java</exclude>
-
+                                <exclude>src/main/java/org/exist/xquery/GeneralComparison.java</exclude>
+                                <exclude>src/test/xquery/emptySeq.xq</exclude>
                                 <!--
                                     Derivative work licensed under dbXML 1.0 and LGPL 2.1
                                 -->

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -767,6 +767,7 @@
                                 <include>src/test/java/org/exist/xquery/functions/xquery3/SerializeTest.java</include>
                                 <include>src/test/java/org/exist/xquery/value/DateTimeTypesTest.java</include>
                                 <include>src/test/xquery/emptySeq.xq</include>
+                                <include>src/test/xquery/startWithComp.xq</include>
                             </includes>
                         </licenseSet>
 
@@ -1087,6 +1088,7 @@
                                 <include>src/main/java/org/exist/xslt/XsltURIResolverHelper.java</include>
                                 <include>src/test/java/org/exist/xupdate/RemoveAppendTest.java</include>
                                 <include>src/main/java/org/exist/xquery/GeneralComparison.java</include>
+                                <include>src/main/java/org/exist/xquery/Predicate.java</include>
                             </includes>
                         </licenseSet>
 
@@ -1542,6 +1544,8 @@
                                 <exclude>src/test/java/org/exist/xupdate/RemoveAppendTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/GeneralComparison.java</exclude>
                                 <exclude>src/test/xquery/emptySeq.xq</exclude>
+                                <exclude>src/main/java/org/exist/xquery/Predicate.java</exclude>
+                                <exclude>src/test/xquery/startWithComp.xq</exclude>
                                 <!--
                                     Derivative work licensed under dbXML 1.0 and LGPL 2.1
                                 -->

--- a/exist-core/src/main/java/org/exist/xquery/GeneralComparison.java
+++ b/exist-core/src/main/java/org/exist/xquery/GeneralComparison.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -647,6 +671,9 @@ public class GeneralComparison extends BinaryOp implements Optimizable, IndexUse
                         result.add( item );
                     }
                 }
+            }
+            if (result.isEmpty()) {
+                return BooleanValue.FALSE;
             }
         }
 

--- a/exist-core/src/main/java/org/exist/xquery/Predicate.java
+++ b/exist-core/src/main/java/org/exist/xquery/Predicate.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -36,6 +60,7 @@ import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.SequenceIterator;
 import org.exist.xquery.value.Type;
 import org.exist.xquery.value.ValueSequence;
+import org.exist.xquery.value.BooleanValue;
 
 import javax.annotation.Nullable;
 import java.util.Set;
@@ -377,7 +402,14 @@ public class Predicate extends PathExpr {
         final NodeSet contextSet = contextSequence.toNodeSet();
         final boolean contextIsVirtual = contextSet instanceof VirtualNodeSet;
         contextSet.setTrackMatches(false);
-        final NodeSet nodes = super.eval(contextSet, null).toNodeSet();
+        final Sequence res = super.eval(contextSet, null);
+        if(!(res instanceof NodeSet)) {
+            if(res == BooleanValue.FALSE)
+                return NodeSet.EMPTY_SET;
+            return res;
+        }
+        final NodeSet nodes = res.toNodeSet();
+
         /*
          * if the predicate expression returns results from the cache we can
          * also return the cached result.

--- a/exist-core/src/test/xquery/emptySeq.xq
+++ b/exist-core/src/test/xquery/emptySeq.xq
@@ -1,0 +1,58 @@
+(:
+ : Elemental
+ : Copyright (C) 2024, Evolved Binary Ltd
+ :
+ : admin@evolvedbinary.com
+ : https://www.evolvedbinary.com | https://www.elemental.xyz
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; version 2.1.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace t="http://exist-db.org/xquery/test";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $t:XML := document {
+    <F id="1"/>
+};
+
+declare
+    %test:setUp
+function t:setup() {
+    xmldb:create-collection("/db", "test"),
+    xmldb:store("/db/test", "test.xml", $t:XML)
+};
+
+declare
+    %test:tearDown
+function t:tearDown() {
+    xmldb:remove("/db/test")
+};
+
+declare
+    %test:assertTrue
+function t:test-db() {
+    exists(
+        doc("/db/test/test.xml")//F[boolean(count(@id >= 2))]
+    )
+};
+
+declare
+    %test:assertTrue
+function t:test-mem() {
+    exists(
+        $t:XML//F[boolean(count(@id >= 2))]
+    )
+};

--- a/exist-core/src/test/xquery/startWithComp.xq
+++ b/exist-core/src/test/xquery/startWithComp.xq
@@ -1,0 +1,52 @@
+(:
+ : Elemental
+ : Copyright (C) 2024, Evolved Binary Ltd
+ :
+ : admin@evolvedbinary.com
+ : https://www.evolvedbinary.com | https://www.elemental.xyz
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; version 2.1.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace t="http://exist-db.org/xquery/test";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $t:XML := document {
+    <Y1 id="1">
+        <H1 id="2" a2="2">true</H1>
+    </Y1>
+};
+
+declare
+    %test:setUp
+function t:setup() {
+    let $testCol := xmldb:create-collection("/db", "test")
+    return
+        xmldb:store("/db/test", "test.xml", $t:XML)
+};
+
+declare
+    %test:tearDown
+function t:tearDown() {
+    xmldb:remove("/db/test")
+};
+
+declare
+    %test:assertTrue
+function t:test() {
+    doc("/db/test/test.xml")//*[starts-with(@a2, "1") = false()]
+    => exists()
+};


### PR DESCRIPTION
### Description:

Issues:
Closes https://github.com/eXist-db/exist/issues/4958
Closes https://github.com/eXist-db/exist/issues/4810

What
- Return `false` instead of `()` in `GeneralComparison` when no operands match (#4958).
- Update `Predicate` to handle the boolean correctly (#4810).
- Add license header includes/excludes in `exist-core/pom.xml` and ran `mvn license:format`.

Why
- Empty sequence was semantically wrong here; spec-compliant boolean result is `false`.
- Predicate logic needed to align with the new return semantics.
- License headers required by project policy.

How
- Modified GeneralComparison.java and Predicate.java.
- Adjusted emptySeq.xq and startWithComp.xq.
- Inserted include/exclude entries in the correct `pom.xml` sections (order preserved).
- Amended commits so each file’s license change appears in the first commit touching it.

### Reference:
XPath 3.1 is explicit: a general comparison must return true or false, never a node sequence. See: 3.7.2 [General comparison](https://www.w3.org/TR/xpath-31/#id-general-comparisons)

### Tests:
Added a couple of test cases
- exist-core/src/test/xquery/startWithComp.xq
- exist-core/src/test/xquery/emptySeq.xq