### PR TITLE
[6.x.x] Small improvements to the Docker Images

### DIFF
--- a/exist-docker/src/main/resources-filtered/Dockerfile
+++ b/exist-docker/src/main/resources-filtered/Dockerfile
@@ -24,7 +24,7 @@ FROM cgr.dev/chainguard/wolfi-base AS builder
 
 RUN apk update && apk upgrade
 # Install dependencies needed for JRE
-RUN apk add zlib libjpeg-turbo libpng lcms2 freetype ttf-dejavu fontconfig-config libfontconfig1 expat libuuid libbrotlicommon1 libbrotlidec1 libbrotlienc1 libcrypt1
+RUN apk add tzdata zlib libjpeg-turbo libpng lcms2 freetype ttf-dejavu fontconfig-config libfontconfig1 expat libuuid libbrotlicommon1 libbrotlidec1 libbrotlienc1 libcrypt1
 # Install latest CA certificates
 RUN apk add ca-certificates java-cacerts
 # Install latest JRE
@@ -34,6 +34,7 @@ RUN apk add openjdk-8-jre
 FROM cgr.dev/chainguard/glibc-dynamic:latest
 
 # Copy over dependencies for updated JRE from Wolfi
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder /lib/libz.so.1 /lib/libz.so.1
 COPY --from=builder /usr/lib/libjpeg.so.8 /usr/lib/libjpeg.so.8
 COPY --from=builder /usr/lib/libturbojpeg.so.0 /usr/lib/libturbojpeg.so.0

--- a/exist-docker/src/main/resources-filtered/Dockerfile
+++ b/exist-docker/src/main/resources-filtered/Dockerfile
@@ -25,6 +25,8 @@ FROM cgr.dev/chainguard/wolfi-base AS builder
 RUN apk update && apk upgrade
 # Install dependencies needed for JRE
 RUN apk add zlib libjpeg-turbo libpng lcms2 freetype ttf-dejavu fontconfig-config libfontconfig1 expat libuuid libbrotlicommon1 libbrotlidec1 libbrotlienc1 libcrypt1
+# Install latest CA certificates
+RUN apk add ca-certificates java-cacerts
 # Install latest JRE
 RUN apk add openjdk-8-jre
 
@@ -32,8 +34,6 @@ RUN apk add openjdk-8-jre
 FROM cgr.dev/chainguard/glibc-dynamic:latest
 
 # Copy over dependencies for updated JRE from Wolfi
-COPY --from=builder /etc/ca-certificates /etc/ca-certificates
-COPY --from=builder /etc/ca-certificates.conf /etc/ca-certificates.conf
 COPY --from=builder /lib/libz.so.1 /lib/libz.so.1
 COPY --from=builder /usr/lib/libjpeg.so.8 /usr/lib/libjpeg.so.8
 COPY --from=builder /usr/lib/libturbojpeg.so.0 /usr/lib/libturbojpeg.so.0
@@ -51,6 +51,14 @@ COPY --from=builder /usr/lib/libuuid.so.1 /usr/lib/libuuid.so.1
 COPY --from=builder /usr/lib/libbrotlicommon.so.1 /usr/lib/libbrotlicommon.so.1
 COPY --from=builder /usr/lib/libbrotlidec.so.1 /usr/lib/libbrotlidec.so.1
 COPY --from=builder /usr/lib/libbrotlienc.so.1 /usr/lib/libbrotlienc.so.1
+
+# Copy over certificates for updated JRE from Wolfi
+COPY --from=builder /etc/ca-certificates /etc/ca-certificates
+COPY --from=builder /etc/ca-certificates.conf /etc/ca-certificates.conf
+COPY --from=builder /etc/apk/protected_paths.d/ca-certificates.list /etc/apk/protected_paths.d/ca-certificates.list
+COPY --from=builder /etc/ssl /etc/ssl
+COPY --from=builder /etc/pki /etc/pki
+COPY --from=builder /usr/share/ca-certificates /usr/share/ca-certificates
 
 # Copy over updated JRE from Wolfi
 COPY --from=builder /usr/lib/jvm/java-1.8-openjdk /usr/lib/jvm/java-1.8-openjdk

--- a/exist-docker/src/main/resources-filtered/Dockerfile
+++ b/exist-docker/src/main/resources-filtered/Dockerfile
@@ -32,6 +32,8 @@ ARG ELEMENTAL_SERVER_MAX_BROKER="20"
 ##
 # JVM maximum RAM use (as a percentage of RAM available to the Docker Container)
 ARG JVM_MAX_RAM_PERCENTAGE="75.0"
+# JVM Garbage Collector
+ARG JVM_GC="G1"
 
 # Any additional options to be added to the JAVA_TOOL_OPTIONS Environment Variable for the JVM
 ARG ADDITIONAL_JAVA_TOOL_OPTIONS
@@ -58,6 +60,7 @@ FROM cgr.dev/chainguard/glibc-dynamic:latest
 ARG ELEMENTAL_SERVER_CACHE_MEM
 ARG ELEMENTAL_SERVER_MAX_BROKER
 ARG JVM_MAX_RAM_PERCENTAGE
+ARG JVM_GC
 ARG ADDITIONAL_JAVA_TOOL_OPTIONS
 
 # Copy over dependencies for updated JRE from Wolfi
@@ -121,7 +124,7 @@ ENV CLASSPATH="/elemental/lib/${elemental.uber.jar.filename}"
 
 ENV JAVA_HOME="/usr/lib/jvm/java-1.8-openjdk"
 
-ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8 -Dsun.jnu.encoding=UTF-8 -Djava.awt.headless=true -Dorg.exist.db-connection.cacheSize=${ELEMENTAL_SERVER_CACHE_MEM}M -Dorg.exist.db-connection.pool.max=${ELEMENTAL_SERVER_MAX_BROKER} -Dlog4j.configurationFile=/elemental/etc/log4j2.xml -Dexist.home=/elemental -Dexist.configurationFile=/elemental/etc/conf.xml -Djetty.home=/elemental -Dexist.jetty.config=/elemental/etc/jetty/standard.enabled-jetty-configs -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+UseContainerSupport -XX:MaxRAMPercentage=${JVM_MAX_RAM_PERCENTAGE} -XX:+ExitOnOutOfMemoryError ${ADDITIONAL_JAVA_TOOL_OPTIONS}"
+ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8 -Dsun.jnu.encoding=UTF-8 -Djava.awt.headless=true -Dorg.exist.db-connection.cacheSize=${ELEMENTAL_SERVER_CACHE_MEM}M -Dorg.exist.db-connection.pool.max=${ELEMENTAL_SERVER_MAX_BROKER} -Dlog4j.configurationFile=/elemental/etc/log4j2.xml -Dexist.home=/elemental -Dexist.configurationFile=/elemental/etc/conf.xml -Djetty.home=/elemental -Dexist.jetty.config=/elemental/etc/jetty/standard.enabled-jetty-configs -XX:+Use${JVM_GC}GC -XX:+UseStringDeduplication -XX:+UseContainerSupport -XX:MaxRAMPercentage=${JVM_MAX_RAM_PERCENTAGE} -XX:+ExitOnOutOfMemoryError ${ADDITIONAL_JAVA_TOOL_OPTIONS}"
 
 ENV PATH="/usr/lib/jvm/java-1.8-openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 

--- a/exist-docker/src/main/resources-filtered/Dockerfile
+++ b/exist-docker/src/main/resources-filtered/Dockerfile
@@ -32,6 +32,9 @@ ARG ELEMENTAL_SERVER_MAX_BROKER="20"
 ##
 # JVM maximum RAM use (as a percentage of RAM available to the Docker Container)
 ARG JVM_MAX_RAM_PERCENTAGE="75.0"
+
+# Any additional options to be added to the JAVA_TOOL_OPTIONS Environment Variable for the JVM
+ARG ADDITIONAL_JAVA_TOOL_OPTIONS
 ##
 ### END: Container build time args for JVM (Java Virtual Machine)
 
@@ -55,6 +58,7 @@ FROM cgr.dev/chainguard/glibc-dynamic:latest
 ARG ELEMENTAL_SERVER_CACHE_MEM
 ARG ELEMENTAL_SERVER_MAX_BROKER
 ARG JVM_MAX_RAM_PERCENTAGE
+ARG ADDITIONAL_JAVA_TOOL_OPTIONS
 
 # Copy over dependencies for updated JRE from Wolfi
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
@@ -117,7 +121,7 @@ ENV CLASSPATH="/elemental/lib/${elemental.uber.jar.filename}"
 
 ENV JAVA_HOME="/usr/lib/jvm/java-1.8-openjdk"
 
-ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8 -Dsun.jnu.encoding=UTF-8 -Djava.awt.headless=true -Dorg.exist.db-connection.cacheSize=${ELEMENTAL_SERVER_CACHE_MEM}M -Dorg.exist.db-connection.pool.max=${ELEMENTAL_SERVER_MAX_BROKER} -Dlog4j.configurationFile=/elemental/etc/log4j2.xml -Dexist.home=/elemental -Dexist.configurationFile=/elemental/etc/conf.xml -Djetty.home=/elemental -Dexist.jetty.config=/elemental/etc/jetty/standard.enabled-jetty-configs -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+UseContainerSupport -XX:MaxRAMPercentage=${JVM_MAX_RAM_PERCENTAGE} -XX:+ExitOnOutOfMemoryError"
+ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8 -Dsun.jnu.encoding=UTF-8 -Djava.awt.headless=true -Dorg.exist.db-connection.cacheSize=${ELEMENTAL_SERVER_CACHE_MEM}M -Dorg.exist.db-connection.pool.max=${ELEMENTAL_SERVER_MAX_BROKER} -Dlog4j.configurationFile=/elemental/etc/log4j2.xml -Dexist.home=/elemental -Dexist.configurationFile=/elemental/etc/conf.xml -Djetty.home=/elemental -Dexist.jetty.config=/elemental/etc/jetty/standard.enabled-jetty-configs -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+UseContainerSupport -XX:MaxRAMPercentage=${JVM_MAX_RAM_PERCENTAGE} -XX:+ExitOnOutOfMemoryError ${ADDITIONAL_JAVA_TOOL_OPTIONS}"
 
 ENV PATH="/usr/lib/jvm/java-1.8-openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 

--- a/exist-docker/src/main/resources-filtered/Dockerfile
+++ b/exist-docker/src/main/resources-filtered/Dockerfile
@@ -21,6 +21,10 @@
 
 ### START: Container build time args for Elemental Server
 ##
+# Names of the Linux user account and group to run the Elemental Server service under
+ARG ELEMENTAL_SERVER_SERVICE_ACCOUNT="edb01"
+ARG ELEMENTAL_SERVER_SERVICE_GROUP="edb01"
+
 # Elemental data cache size
 ARG ELEMENTAL_SERVER_CACHE_MEM="256"
 # Elemental maximum number of database brokers
@@ -44,6 +48,10 @@ ARG ADDITIONAL_JAVA_TOOL_OPTIONS
 # Install latest JRE 8 in Chainguard Wolfi temporary builder image
 FROM cgr.dev/chainguard/wolfi-base AS builder
 
+# Inherit global args to this build stage
+ARG ELEMENTAL_SERVER_SERVICE_ACCOUNT
+ARG ELEMENTAL_SERVER_SERVICE_GROUP
+
 RUN apk update && apk upgrade
 # Install dependencies needed for JRE
 RUN apk add tzdata zlib libjpeg-turbo libpng lcms2 freetype ttf-dejavu fontconfig-config libfontconfig1 expat libuuid libbrotlicommon1 libbrotlidec1 libbrotlienc1 libcrypt1
@@ -52,11 +60,17 @@ RUN apk add ca-certificates java-cacerts
 # Install latest JRE
 RUN apk add openjdk-8-jre
 
+# Add Elemental Server service group and account
+RUN addgroup -S ${ELEMENTAL_SERVER_SERVICE_GROUP} \
+    && adduser -S -G ${ELEMENTAL_SERVER_SERVICE_GROUP} -H -h /nonexistent -s /sbin/nologin -g "Elemental Database Server - Instance 01" ${ELEMENTAL_SERVER_SERVICE_ACCOUNT}
+
 
 # Use Chainguard distroless glibc base for dynamically linked libraries
 FROM cgr.dev/chainguard/glibc-dynamic:latest
 
 # Inherit global args to this build stage
+ARG ELEMENTAL_SERVER_SERVICE_ACCOUNT
+ARG ELEMENTAL_SERVER_SERVICE_GROUP
 ARG ELEMENTAL_SERVER_CACHE_MEM
 ARG ELEMENTAL_SERVER_MAX_BROKER
 ARG JVM_MAX_RAM_PERCENTAGE
@@ -94,17 +108,22 @@ COPY --from=builder /usr/share/ca-certificates /usr/share/ca-certificates
 # Copy over updated JRE from Wolfi
 COPY --from=builder /usr/lib/jvm/java-1.8-openjdk /usr/lib/jvm/java-1.8-openjdk
 
-# Switch to nonroot user
-USER nonroot
+# Copy Elemental Server service group and account
+COPY --from=builder --chown=root:root --chmod=0644 /etc/passwd /etc/passwd
+COPY --from=builder --chown=root:root --chmod=0644 /etc/group /etc/group
+COPY --from=builder --chown=root:root --chmod=0600 /etc/shadow /etc/shadow
+
+# Switch to Elemental Server service account
+USER ${ELEMENTAL_SERVER_SERVICE_ACCOUNT}
 
 # Copy Elemental
-COPY --chmod=0555 logs /elemental
-COPY --chmod=0444 LICENSE /elemental/LICENSE
-COPY --chmod=0570 autodeploy /elemental/autodeploy
-COPY --chmod=0570 etc /elemental/etc
-COPY --chmod=0550 lib /elemental/lib
-COPY --chown=nonroot --chmod=0750 logs /elemental/logs
-COPY --chown=nonroot --chmod=0750 logs /elemental/data
+COPY --chown=${ELEMENTAL_SERVER_SERVICE_ACCOUNT}:${ELEMENTAL_SERVER_SERVICE_GROUP} --chmod=0555 logs /elemental
+COPY --chown=${ELEMENTAL_SERVER_SERVICE_ACCOUNT}:${ELEMENTAL_SERVER_SERVICE_GROUP} --chmod=0444 LICENSE /elemental/LICENSE
+COPY --chown=${ELEMENTAL_SERVER_SERVICE_ACCOUNT}:${ELEMENTAL_SERVER_SERVICE_GROUP} --chmod=0570 autodeploy /elemental/autodeploy
+COPY --chown=${ELEMENTAL_SERVER_SERVICE_ACCOUNT}:${ELEMENTAL_SERVER_SERVICE_GROUP} --chmod=0570 etc /elemental/etc
+COPY --chown=${ELEMENTAL_SERVER_SERVICE_ACCOUNT}:${ELEMENTAL_SERVER_SERVICE_GROUP} --chmod=0550 lib /elemental/lib
+COPY --chown=${ELEMENTAL_SERVER_SERVICE_ACCOUNT}:${ELEMENTAL_SERVER_SERVICE_GROUP} --chmod=0750 logs /elemental/logs
+COPY --chown=${ELEMENTAL_SERVER_SERVICE_ACCOUNT}:${ELEMENTAL_SERVER_SERVICE_GROUP} --chmod=0750 logs /elemental/data
 
 # Build-time metadata as defined at http://label-schema.org
 # and used by autobuilder @hooks/build

--- a/exist-docker/src/main/resources-filtered/Dockerfile
+++ b/exist-docker/src/main/resources-filtered/Dockerfile
@@ -19,6 +19,23 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #
 
+### START: Container build time args for Elemental Server
+##
+# Elemental data cache size
+ARG ELEMENTAL_SERVER_CACHE_MEM="256"
+# Elemental maximum number of database brokers
+ARG ELEMENTAL_SERVER_MAX_BROKER="20"
+##
+### END: Container build time args for Elemental Server
+
+### START: Container build time args for JVM (Java Virtual Machine)
+##
+# JVM maximum RAM use (as a percentage of RAM available to the Docker Container)
+ARG JVM_MAX_RAM_PERCENTAGE="75.0"
+##
+### END: Container build time args for JVM (Java Virtual Machine)
+
+
 # Install latest JRE 8 in Chainguard Wolfi temporary builder image
 FROM cgr.dev/chainguard/wolfi-base AS builder
 
@@ -30,8 +47,14 @@ RUN apk add ca-certificates java-cacerts
 # Install latest JRE
 RUN apk add openjdk-8-jre
 
+
 # Use Chainguard distroless glibc base for dynamically linked libraries
 FROM cgr.dev/chainguard/glibc-dynamic:latest
+
+# Inherit global args to this build stage
+ARG ELEMENTAL_SERVER_CACHE_MEM
+ARG ELEMENTAL_SERVER_MAX_BROKER
+ARG JVM_MAX_RAM_PERCENTAGE
 
 # Copy over dependencies for updated JRE from Wolfi
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
@@ -88,18 +111,13 @@ LABEL org.label-schema.build-date=${maven.build.timestamp} \
 
 EXPOSE 8080 8443
 
-# make CACHE_MEM, MAX_BROKER, and JVM_MAX_RAM_PERCENTAGE available to users
-ARG CACHE_MEM
-ARG MAX_BROKER
-ARG JVM_MAX_RAM_PERCENTAGE
-
 ENV ELEMENTAL_HOME="/elemental"
 ENV EXIST_HOME="/elemental"
 ENV CLASSPATH="/elemental/lib/${elemental.uber.jar.filename}"
 
 ENV JAVA_HOME="/usr/lib/jvm/java-1.8-openjdk"
 
-ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8 -Dsun.jnu.encoding=UTF-8 -Djava.awt.headless=true -Dorg.exist.db-connection.cacheSize=${CACHE_MEM:-256}M -Dorg.exist.db-connection.pool.max=${MAX_BROKER:-20} -Dlog4j.configurationFile=/elemental/etc/log4j2.xml -Dexist.home=/elemental -Dexist.configurationFile=/elemental/etc/conf.xml -Djetty.home=/elemental -Dexist.jetty.config=/elemental/etc/jetty/standard.enabled-jetty-configs -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+UseContainerSupport -XX:MaxRAMPercentage=${JVM_MAX_RAM_PERCENTAGE:-75.0} -XX:+ExitOnOutOfMemoryError"
+ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8 -Dsun.jnu.encoding=UTF-8 -Djava.awt.headless=true -Dorg.exist.db-connection.cacheSize=${ELEMENTAL_SERVER_CACHE_MEM}M -Dorg.exist.db-connection.pool.max=${ELEMENTAL_SERVER_MAX_BROKER} -Dlog4j.configurationFile=/elemental/etc/log4j2.xml -Dexist.home=/elemental -Dexist.configurationFile=/elemental/etc/conf.xml -Djetty.home=/elemental -Dexist.jetty.config=/elemental/etc/jetty/standard.enabled-jetty-configs -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+UseContainerSupport -XX:MaxRAMPercentage=${JVM_MAX_RAM_PERCENTAGE} -XX:+ExitOnOutOfMemoryError"
 
 ENV PATH="/usr/lib/jvm/java-1.8-openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 

--- a/exist-docker/src/main/resources-filtered/Dockerfile
+++ b/exist-docker/src/main/resources-filtered/Dockerfile
@@ -98,12 +98,13 @@ COPY --from=builder /usr/lib/jvm/java-1.8-openjdk /usr/lib/jvm/java-1.8-openjdk
 USER nonroot
 
 # Copy Elemental
-COPY LICENSE /elemental/LICENSE
-COPY autodeploy /elemental/autodeploy
-COPY etc /elemental/etc
-COPY lib /elemental/lib
-COPY --chown=nonroot logs /elemental/logs
-COPY --chown=nonroot logs /elemental/data
+COPY --chmod=0555 logs /elemental
+COPY --chmod=0444 LICENSE /elemental/LICENSE
+COPY --chmod=0570 autodeploy /elemental/autodeploy
+COPY --chmod=0570 etc /elemental/etc
+COPY --chmod=0550 lib /elemental/lib
+COPY --chown=nonroot --chmod=0750 logs /elemental/logs
+COPY --chown=nonroot --chmod=0750 logs /elemental/data
 
 # Build-time metadata as defined at http://label-schema.org
 # and used by autobuilder @hooks/build

--- a/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
+++ b/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
@@ -25,6 +25,9 @@
 ARG ELEMENTAL_SERVER_SERVICE_ACCOUNT="edb01"
 ARG ELEMENTAL_SERVER_SERVICE_GROUP="edb01"
 
+# Name of the Linux user account to use for the interactive container user when needing to debug
+ARG ELEMENTAL_CONTAINER_DEBUG_USER_ACCOUNT="debug"
+
 # Elemental data cache size
 ARG ELEMENTAL_SERVER_CACHE_MEM="256"
 # Elemental maximum number of database brokers
@@ -56,6 +59,7 @@ FROM cgr.dev/chainguard/wolfi-base
 # Inherit global args to this build stage
 ARG ELEMENTAL_SERVER_SERVICE_ACCOUNT
 ARG ELEMENTAL_SERVER_SERVICE_GROUP
+ARG ELEMENTAL_CONTAINER_DEBUG_USER_ACCOUNT
 ARG ELEMENTAL_SERVER_CACHE_MEM
 ARG ELEMENTAL_SERVER_MAX_BROKER
 ARG JVM_MAX_RAM_PERCENTAGE
@@ -75,6 +79,16 @@ RUN apk add openjdk-8
 # Add Elemental Server service group and account
 RUN addgroup -S ${ELEMENTAL_SERVER_SERVICE_GROUP} \
     && adduser -S -G ${ELEMENTAL_SERVER_SERVICE_GROUP} -H -h /nonexistent -s /sbin/nologin -g "Elemental Database Server - Instance 01" ${ELEMENTAL_SERVER_SERVICE_ACCOUNT}
+
+# Add 'debug' user for interactive use, and add then to the Elemental Server service group
+RUN adduser -D -g "Elemental Docker Container - debug user" ${ELEMENTAL_CONTAINER_DEBUG_USER_ACCOUNT} \
+    && addgroup ${ELEMENTAL_CONTAINER_DEBUG_USER_ACCOUNT} ${ELEMENTAL_SERVER_SERVICE_GROUP}
+
+# Install sudo
+RUN apk add sudo-rs
+COPY --chmod=0440 <<EOF /etc/sudoers.d/${ELEMENTAL_CONTAINER_DEBUG_USER_ACCOUNT}
+${ELEMENTAL_CONTAINER_DEBUG_USER_ACCOUNT} ALL = (ALL:ALL) NOPASSWD:ALL
+EOF
 
 # Switch to Elemental Server service account
 USER ${ELEMENTAL_SERVER_SERVICE_ACCOUNT}

--- a/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
+++ b/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
@@ -21,6 +21,10 @@
 
 ### START: Container build time args for Elemental Server
 ##
+# Names of the Linux user account and group to run the Elemental Server service under
+ARG ELEMENTAL_SERVER_SERVICE_ACCOUNT="edb01"
+ARG ELEMENTAL_SERVER_SERVICE_GROUP="edb01"
+
 # Elemental data cache size
 ARG ELEMENTAL_SERVER_CACHE_MEM="256"
 # Elemental maximum number of database brokers
@@ -50,6 +54,8 @@ ARG ADDITIONAL_JAVA_TOOL_OPTIONS
 FROM cgr.dev/chainguard/wolfi-base
 
 # Inherit global args to this build stage
+ARG ELEMENTAL_SERVER_SERVICE_ACCOUNT
+ARG ELEMENTAL_SERVER_SERVICE_GROUP
 ARG ELEMENTAL_SERVER_CACHE_MEM
 ARG ELEMENTAL_SERVER_MAX_BROKER
 ARG JVM_MAX_RAM_PERCENTAGE
@@ -66,17 +72,21 @@ RUN apk add ca-certificates java-cacerts
 # Install latest JDK
 RUN apk add openjdk-8
 
-# Switch to nonroot user
-USER nonroot
+# Add Elemental Server service group and account
+RUN addgroup -S ${ELEMENTAL_SERVER_SERVICE_GROUP} \
+    && adduser -S -G ${ELEMENTAL_SERVER_SERVICE_GROUP} -H -h /nonexistent -s /sbin/nologin -g "Elemental Database Server - Instance 01" ${ELEMENTAL_SERVER_SERVICE_ACCOUNT}
+
+# Switch to Elemental Server service account
+USER ${ELEMENTAL_SERVER_SERVICE_ACCOUNT}
 
 # Copy Elemental
-COPY --chmod=0555 logs /elemental
-COPY --chmod=0444 LICENSE /elemental/LICENSE
-COPY --chmod=0570 autodeploy /elemental/autodeploy
-COPY --chmod=0570 etc /elemental/etc
-COPY --chmod=0550 lib /elemental/lib
-COPY --chown=nonroot --chmod=0750 logs /elemental/logs
-COPY --chown=nonroot --chmod=0750 logs /elemental/data
+COPY --chown=${ELEMENTAL_SERVER_SERVICE_ACCOUNT}:${ELEMENTAL_SERVER_SERVICE_GROUP} --chmod=0555 logs /elemental
+COPY --chown=${ELEMENTAL_SERVER_SERVICE_ACCOUNT}:${ELEMENTAL_SERVER_SERVICE_GROUP} --chmod=0444 LICENSE /elemental/LICENSE
+COPY --chown=${ELEMENTAL_SERVER_SERVICE_ACCOUNT}:${ELEMENTAL_SERVER_SERVICE_GROUP} --chmod=0570 autodeploy /elemental/autodeploy
+COPY --chown=${ELEMENTAL_SERVER_SERVICE_ACCOUNT}:${ELEMENTAL_SERVER_SERVICE_GROUP} --chmod=0570 etc /elemental/etc
+COPY --chown=${ELEMENTAL_SERVER_SERVICE_ACCOUNT}:${ELEMENTAL_SERVER_SERVICE_GROUP} --chmod=0550 lib /elemental/lib
+COPY --chown=${ELEMENTAL_SERVER_SERVICE_ACCOUNT}:${ELEMENTAL_SERVER_SERVICE_GROUP} --chmod=0750 logs /elemental/logs
+COPY --chown=${ELEMENTAL_SERVER_SERVICE_ACCOUNT}:${ELEMENTAL_SERVER_SERVICE_GROUP} --chmod=0750 logs /elemental/data
 
 # Build-time metadata as defined at http://label-schema.org
 # and used by autobuilder @hooks/build

--- a/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
+++ b/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
@@ -37,6 +37,9 @@ ARG JVM_MAX_RAM_PERCENTAGE="75.0"
 ARG JVM_JDWP_SUSPEND="n"
 # JVM debugging protocol address and/or port
 ARG JVM_JDWP_ADDRESS="5005"
+
+# Any additional options to be added to the JAVA_TOOL_OPTIONS Environment Variable for the JVM
+ARG ADDITIONAL_JAVA_TOOL_OPTIONS
 ##
 ### END: Container build time args for JVM (Java Virtual Machine)
 
@@ -50,6 +53,7 @@ ARG ELEMENTAL_SERVER_MAX_BROKER
 ARG JVM_MAX_RAM_PERCENTAGE
 ARG JVM_JDWP_SUSPEND
 ARG JVM_JDWP_ADDRESS
+ARG ADDITIONAL_JAVA_TOOL_OPTIONS
 
 RUN apk update && apk upgrade
 # Install dependencies needed for JDK
@@ -89,7 +93,7 @@ ENV CLASSPATH="/elemental/lib/${elemental.uber.jar.filename}"
 
 ENV JAVA_HOME="/usr/lib/jvm/java-1.8-openjdk"
 
-ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8 -Dsun.jnu.encoding=UTF-8 -Djava.awt.headless=true -Dorg.exist.db-connection.cacheSize=${ELEMENTAL_SERVER_CACHE_MEM}M -Dorg.exist.db-connection.pool.max=${ELEMENTAL_SERVER_MAX_BROKER} -Dlog4j.configurationFile=/elemental/etc/log4j2.xml -Dexist.home=/elemental -Dexist.configurationFile=/elemental/etc/conf.xml -Djetty.home=/elemental -Dexist.jetty.config=/elemental/etc/jetty/standard.enabled-jetty-configs -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+UseContainerSupport -XX:MaxRAMPercentage=${JVM_MAX_RAM_PERCENTAGE} -XX:+ExitOnOutOfMemoryError -agentlib:jdwp=transport=dt_socket,server=y,suspend=${JVM_JDWP_SUSPEND},address=${JVM_JDWP_ADDRESS}"
+ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8 -Dsun.jnu.encoding=UTF-8 -Djava.awt.headless=true -Dorg.exist.db-connection.cacheSize=${ELEMENTAL_SERVER_CACHE_MEM}M -Dorg.exist.db-connection.pool.max=${ELEMENTAL_SERVER_MAX_BROKER} -Dlog4j.configurationFile=/elemental/etc/log4j2.xml -Dexist.home=/elemental -Dexist.configurationFile=/elemental/etc/conf.xml -Djetty.home=/elemental -Dexist.jetty.config=/elemental/etc/jetty/standard.enabled-jetty-configs -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+UseContainerSupport -XX:MaxRAMPercentage=${JVM_MAX_RAM_PERCENTAGE} -XX:+ExitOnOutOfMemoryError -agentlib:jdwp=transport=dt_socket,server=y,suspend=${JVM_JDWP_SUSPEND},address=${JVM_JDWP_ADDRESS} ${ADDITIONAL_JAVA_TOOL_OPTIONS}"
 
 ENV PATH="/usr/lib/jvm/java-1.8-openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 

--- a/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
+++ b/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
@@ -24,7 +24,7 @@ FROM cgr.dev/chainguard/wolfi-base
 
 RUN apk update && apk upgrade
 # Install dependencies needed for JDK
-RUN apk add zlib libjpeg-turbo libpng lcms2 freetype ttf-dejavu fontconfig-config libfontconfig1 expat libuuid libbrotlicommon1 libbrotlidec1 libbrotlienc1 libcrypt1
+RUN apk add tzdata zlib libjpeg-turbo libpng lcms2 freetype ttf-dejavu fontconfig-config libfontconfig1 expat libuuid libbrotlicommon1 libbrotlidec1 libbrotlienc1 libcrypt1
 # Install latest CA certificates
 RUN apk add ca-certificates java-cacerts
 # Install latest JDK

--- a/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
+++ b/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
@@ -19,8 +19,37 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #
 
+### START: Container build time args for Elemental Server
+##
+# Elemental data cache size
+ARG ELEMENTAL_SERVER_CACHE_MEM="256"
+# Elemental maximum number of database brokers
+ARG ELEMENTAL_SERVER_MAX_BROKER="20"
+##
+### END: Container build time args for Elemental Server
+
+### START: Container build time args for JVM (Java Virtual Machine)
+##
+# JVM maximum RAM use (as a percentage of RAM available to the Docker Container)
+ARG JVM_MAX_RAM_PERCENTAGE="75.0"
+
+# JVM debugging protocol, suspend process on startup (y = Yes, n = No)
+ARG JVM_JDWP_SUSPEND="n"
+# JVM debugging protocol address and/or port
+ARG JVM_JDWP_ADDRESS="5005"
+##
+### END: Container build time args for JVM (Java Virtual Machine)
+
+
 # Use Chainguard Wolfi
 FROM cgr.dev/chainguard/wolfi-base
+
+# Inherit global args to this build stage
+ARG ELEMENTAL_SERVER_CACHE_MEM
+ARG ELEMENTAL_SERVER_MAX_BROKER
+ARG JVM_MAX_RAM_PERCENTAGE
+ARG JVM_JDWP_SUSPEND
+ARG JVM_JDWP_ADDRESS
 
 RUN apk update && apk upgrade
 # Install dependencies needed for JDK
@@ -54,19 +83,13 @@ LABEL org.label-schema.build-date=${maven.build.timestamp} \
 
 EXPOSE 8080 8443 5005
 
-# make CACHE_MEM, MAX_BROKER, JVM_MAX_RAM_PERCENTAGE, and JVM_JDWP_SUSPEND available to users at build time
-ARG CACHE_MEM
-ARG MAX_BROKER
-ARG JVM_MAX_RAM_PERCENTAGE
-ARG JVM_JDWP_SUSPEND
-
 ENV ELEMENTAL_HOME="/elemental"
 ENV EXIST_HOME="/elemental"
 ENV CLASSPATH="/elemental/lib/${elemental.uber.jar.filename}"
 
 ENV JAVA_HOME="/usr/lib/jvm/java-1.8-openjdk"
 
-ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8 -Dsun.jnu.encoding=UTF-8 -Djava.awt.headless=true -Dorg.exist.db-connection.cacheSize=${CACHE_MEM:-256}M -Dorg.exist.db-connection.pool.max=${MAX_BROKER:-20} -Dlog4j.configurationFile=/elemental/etc/log4j2.xml -Dexist.home=/elemental -Dexist.configurationFile=/elemental/etc/conf.xml -Djetty.home=/elemental -Dexist.jetty.config=/elemental/etc/jetty/standard.enabled-jetty-configs -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+UseContainerSupport -XX:MaxRAMPercentage=${JVM_MAX_RAM_PERCENTAGE:-75.0} -XX:+ExitOnOutOfMemoryError -agentlib:jdwp=transport=dt_socket,server=y,suspend=${JVM_JDWP_SUSPEND:-n},address=5005"
+ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8 -Dsun.jnu.encoding=UTF-8 -Djava.awt.headless=true -Dorg.exist.db-connection.cacheSize=${ELEMENTAL_SERVER_CACHE_MEM}M -Dorg.exist.db-connection.pool.max=${ELEMENTAL_SERVER_MAX_BROKER} -Dlog4j.configurationFile=/elemental/etc/log4j2.xml -Dexist.home=/elemental -Dexist.configurationFile=/elemental/etc/conf.xml -Djetty.home=/elemental -Dexist.jetty.config=/elemental/etc/jetty/standard.enabled-jetty-configs -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+UseContainerSupport -XX:MaxRAMPercentage=${JVM_MAX_RAM_PERCENTAGE} -XX:+ExitOnOutOfMemoryError -agentlib:jdwp=transport=dt_socket,server=y,suspend=${JVM_JDWP_SUSPEND},address=${JVM_JDWP_ADDRESS}"
 
 ENV PATH="/usr/lib/jvm/java-1.8-openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 

--- a/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
+++ b/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
@@ -32,6 +32,8 @@ ARG ELEMENTAL_SERVER_MAX_BROKER="20"
 ##
 # JVM maximum RAM use (as a percentage of RAM available to the Docker Container)
 ARG JVM_MAX_RAM_PERCENTAGE="75.0"
+# JVM Garbage Collector
+ARG JVM_GC="G1"
 
 # JVM debugging protocol, suspend process on startup (y = Yes, n = No)
 ARG JVM_JDWP_SUSPEND="n"
@@ -51,6 +53,7 @@ FROM cgr.dev/chainguard/wolfi-base
 ARG ELEMENTAL_SERVER_CACHE_MEM
 ARG ELEMENTAL_SERVER_MAX_BROKER
 ARG JVM_MAX_RAM_PERCENTAGE
+ARG JVM_GC
 ARG JVM_JDWP_SUSPEND
 ARG JVM_JDWP_ADDRESS
 ARG ADDITIONAL_JAVA_TOOL_OPTIONS
@@ -93,7 +96,7 @@ ENV CLASSPATH="/elemental/lib/${elemental.uber.jar.filename}"
 
 ENV JAVA_HOME="/usr/lib/jvm/java-1.8-openjdk"
 
-ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8 -Dsun.jnu.encoding=UTF-8 -Djava.awt.headless=true -Dorg.exist.db-connection.cacheSize=${ELEMENTAL_SERVER_CACHE_MEM}M -Dorg.exist.db-connection.pool.max=${ELEMENTAL_SERVER_MAX_BROKER} -Dlog4j.configurationFile=/elemental/etc/log4j2.xml -Dexist.home=/elemental -Dexist.configurationFile=/elemental/etc/conf.xml -Djetty.home=/elemental -Dexist.jetty.config=/elemental/etc/jetty/standard.enabled-jetty-configs -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+UseContainerSupport -XX:MaxRAMPercentage=${JVM_MAX_RAM_PERCENTAGE} -XX:+ExitOnOutOfMemoryError -agentlib:jdwp=transport=dt_socket,server=y,suspend=${JVM_JDWP_SUSPEND},address=${JVM_JDWP_ADDRESS} ${ADDITIONAL_JAVA_TOOL_OPTIONS}"
+ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8 -Dsun.jnu.encoding=UTF-8 -Djava.awt.headless=true -Dorg.exist.db-connection.cacheSize=${ELEMENTAL_SERVER_CACHE_MEM}M -Dorg.exist.db-connection.pool.max=${ELEMENTAL_SERVER_MAX_BROKER} -Dlog4j.configurationFile=/elemental/etc/log4j2.xml -Dexist.home=/elemental -Dexist.configurationFile=/elemental/etc/conf.xml -Djetty.home=/elemental -Dexist.jetty.config=/elemental/etc/jetty/standard.enabled-jetty-configs -XX:+Use${JVM_GC}GC -XX:+UseStringDeduplication -XX:+UseContainerSupport -XX:MaxRAMPercentage=${JVM_MAX_RAM_PERCENTAGE} -XX:+ExitOnOutOfMemoryError -agentlib:jdwp=transport=dt_socket,server=y,suspend=${JVM_JDWP_SUSPEND},address=${JVM_JDWP_ADDRESS} ${ADDITIONAL_JAVA_TOOL_OPTIONS}"
 
 ENV PATH="/usr/lib/jvm/java-1.8-openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 

--- a/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
+++ b/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
@@ -25,6 +25,8 @@ FROM cgr.dev/chainguard/wolfi-base
 RUN apk update && apk upgrade
 # Install dependencies needed for JDK
 RUN apk add zlib libjpeg-turbo libpng lcms2 freetype ttf-dejavu fontconfig-config libfontconfig1 expat libuuid libbrotlicommon1 libbrotlidec1 libbrotlienc1 libcrypt1
+# Install latest CA certificates
+RUN apk add ca-certificates java-cacerts
 # Install latest JDK
 RUN apk add openjdk-8
 

--- a/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
+++ b/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
@@ -70,12 +70,13 @@ RUN apk add openjdk-8
 USER nonroot
 
 # Copy Elemental
-COPY LICENSE /elemental/LICENSE
-COPY autodeploy /elemental/autodeploy
-COPY etc /elemental/etc
-COPY lib /elemental/lib
-COPY --chown=nonroot logs /elemental/logs
-COPY --chown=nonroot logs /elemental/data
+COPY --chmod=0555 logs /elemental
+COPY --chmod=0444 LICENSE /elemental/LICENSE
+COPY --chmod=0570 autodeploy /elemental/autodeploy
+COPY --chmod=0570 etc /elemental/etc
+COPY --chmod=0550 lib /elemental/lib
+COPY --chown=nonroot --chmod=0750 logs /elemental/logs
+COPY --chown=nonroot --chmod=0750 logs /elemental/data
 
 # Build-time metadata as defined at http://label-schema.org
 # and used by autobuilder @hooks/build


### PR DESCRIPTION
Backport of https://github.com/evolvedbinary/elemental/pull/69

* Add latest CA certificates
* Add latest Time Zone data
* Make Docker build arguments specifiable at compile time
* Improve security on the `/elemental` directory
* Run Elemental under a dedicated service account named `edb01`
* Add a `debug` user account with sudo privileges to the DEBUG image