### PR TITLE
[6.x.x] Add missing license enforcement check for RedirectTest.java

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -693,6 +693,7 @@
                                 <include>src/main/java/org/exist/dom/memtree/reference/ElementReferenceImpl.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/reference/ProcessingInstructionReferenceImpl.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/reference/TextReferenceImpl.java</include>
+                                <include>src/test/java/org/exist/http/urlrewrite/RedirectTest.java</include>
                                 <include>src/main/java/org/exist/security/PermissionRequiredCheck.java</include>
                                 <include>src/main/java/org/exist/storage/io/AbstractVariableByteOutput.java</include>
                                 <include>src/main/java/org/exist/storage/io/VariableByteArrayOutputStream.java</include>


### PR DESCRIPTION
Add a missing license enforcement check for RedirectTest.java that was previously lost during a backport and merge.