### PR TITLE
[6.x.x] Show prefix of XPath standard library functions in the profiling output

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -752,6 +752,7 @@
                                 <include>src/test/java/org/exist/IndexerTest.java</include>
                                 <include>src/test/java/org/exist/IndexerTest2.java</include>
                                 <include>src/test/java/org/exist/IndexerTest3.java</include>
+                                <include>src/main/java/org/exist/Namespaces.java</include>
                                 <include>src/main/resources-filtered/org/exist/system.properties</include>
                                 <include>src/main/java/org/exist/backup/SystemExport.java</include>
                                 <include>src/main/java/org/exist/backup/ZipWriter.java</include>
@@ -1176,6 +1177,7 @@
                                 <exclude>src/test/java/org/exist/IndexerTest.java</exclude>
                                 <exclude>src/test/java/org/exist/IndexerTest2.java</exclude>
                                 <exclude>src/test/java/org/exist/IndexerTest3.java</exclude>
+                                <exclude>src/main/java/org/exist/Namespaces.java</exclude>
                                 <exclude>src/main/resources-filtered/org/exist/system.properties</exclude>
                                 <exclude>src/main/java/org/exist/backup/SystemExport.java</exclude>
                                 <exclude>src/main/java/org/exist/backup/ZipWriter.java</exclude>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -965,8 +965,10 @@
                                 <include>src/main/java/org/exist/xquery/ErrorCodes.java</include>
                                 <include>src/main/java/org/exist/xquery/FilteredExpression.java</include>
                                 <include>src/test/java/org/exist/xquery/ForwardReferenceTest.java</include>
+                                <include>src/main/java/org/exist/xquery/Function.java</include>
                                 <include>src/main/java/org/exist/xquery/FunctionFactory.java</include>
                                 <include>src/main/java/org/exist/xquery/LocationStep.java</include>
+                                <include>src/main/java/org/exist/xquery/NamedFunctionReference.java</include>
                                 <include>src/main/java/org/exist/xquery/Optimizer.java</include>
                                 <include>src/main/java/org/exist/xquery/PerformanceStats.java</include>
                                 <include>src/main/java/org/exist/xquery/TryCatchExpression.java</include>
@@ -977,17 +979,107 @@
                                 <include>src/test/java/org/exist/xquery/XQueryTest.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/array/ArrayType.java</include>
                                 <include>src/test/java/org/exist/xquery/functions/fn/DocTest.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/ExtCollection.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FnDefaultLanguage.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FnDefaultLanguage.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FnFormatDates.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FnHasChildren.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FnInnerMost.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/FnModule.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FnOuterMost.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunAbs.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunAdjustTimezone.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunAnalyzeString.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunAvg.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/FunBaseURI.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunBoolean.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunCeiling.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunCodepointEqual.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunCodepointsToString.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunCompare.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunConcat.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunContains.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunContainsToken.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunCount.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunCurrentDateTime.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunData.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunDateTime.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/FunDeepEqual.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunDefaultCollation.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunDistinctValues.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunDoc.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunEmpty.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunEncodeForURI.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunEndsWith.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunEnvironment.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunEquals.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunError.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunEscapeHTMLURI.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunEscapeURI.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunExactlyOne.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunExists.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunFloor.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunGetDateComponent.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunGetDurationComponent.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunHeadTail.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunHigherOrderFun.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunIRIToURI.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunId.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunIdRef.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunImplicitTimezone.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunInScopePrefixes.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunIndexOf.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunInsertBefore.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunLang.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunLast.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunLocalName.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunMax.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunMin.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunName.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunNamespaceURI.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunNamespaceURIForPrefix.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunNodeName.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunNormalizeSpace.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunNormalizeUnicode.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunNot.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunNumber.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunOnFunctions.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunOneOrMore.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/FunParseIetfDate.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunPath.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunPosition.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunQName.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunRemove.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunReplace.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunResolveQName.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunResolveURI.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunReverse.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunRoot.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/FunSerialize.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunSort.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunStartsWith.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunStrLength.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunString.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunStringJoin.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunStringToCodepoints.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunSubSequence.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunSubstring.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunSubstringAfter.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunSubstringBefore.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunSum.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunTokenize.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/FunTrace.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunTranslate.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunTrueOrFalse.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunUnordered.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/FunUnparsedText.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunUpperOrLowerCase.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/FunUriCollection.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/FunXmlToJson.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/FunZeroOrOne.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/LoadXQueryModule.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/ParsingFunctions.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/fn/QNameFunctions.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/transform/Convert.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/transform/Delivery.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/transform/Options.java</include>
@@ -1179,7 +1271,7 @@
                                 <exclude>src/test/java/org/exist/http/urlrewrite/RedirectTest.java</exclude>
                                 <exclude>src/main/java/org/exist/http/urlrewrite/RewriteConfig.java</exclude>
                                 <exclude>src/main/java/org/exist/indexing/Index.java</exclude>
-                                <include>src/main/java/org/exist/indexing/IndexController.java</include>
+                                <exclude>src/main/java/org/exist/indexing/IndexController.java</exclude>
                                 <exclude>src/main/java/org/exist/indexing/IndexManager.java</exclude>
                                 <exclude>src/main/java/org/exist/indexing/ngram/NGramIndexWorker.java</exclude>
                                 <exclude>src/main/java/org/exist/jetty/JettyStart.java</exclude>
@@ -1373,6 +1465,7 @@
                                 <exclude>src/main/java/org/exist/xquery/ErrorCodes.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/FilteredExpression.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/ForwardReferenceTest.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/Function.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/FunctionFactory.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/LocationStep.java</exclude>
                                 <exclude>src/test/resources-filtered/org/exist/xquery/import-from-pkg-test.conf.xml</exclude>
@@ -1383,6 +1476,7 @@
                                 <exclude>src/test/java/org/exist/xquery/JavaBindingTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/LocationStep.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/Materializable.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/NamedFunctionReference.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/NameTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/Optimizer.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/PerformanceStats.java</exclude>
@@ -1395,21 +1489,111 @@
                                 <exclude>src/test/java/org/exist/xquery/XQueryFunctionsTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/XQueryTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/array/ArrayType.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/ExtCollection.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/fn/DocTest.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FnDefaultLanguage.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FnDefaultLanguage.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FnFormatDates.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FnHasChildren.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FnInnerMost.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FnModule.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FnOuterMost.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunAbs.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunAdjustTimezone.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunAnalyzeString.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunAvg.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FunBaseURI.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunBoolean.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunCeiling.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunCodepointEqual.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunCodepointsToString.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunCompare.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunConcat.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunContains.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunContainsToken.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunCount.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunCurrentDateTime.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunData.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunDateTime.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FunDeepEqual.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunDefaultCollation.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunDistinctValues.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunDoc.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FunDocAvailable.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunEmpty.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunEncodeForURI.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunEndsWith.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunEnvironment.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunEquals.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunError.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunEscapeHTMLURI.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunEscapeURI.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunExactlyOne.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunExists.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunFloor.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunGetDateComponent.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunGetDurationComponent.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunHeadTail.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunHigherOrderFun.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunIRIToURI.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunId.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunIdRef.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunImplicitTimezone.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunInScopePrefixes.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunIndexOf.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunInsertBefore.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunLang.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunLast.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunLocalName.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunMax.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunMin.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunName.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunNamespaceURI.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunNamespaceURIForPrefix.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunNodeName.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunNormalizeSpace.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunNormalizeUnicode.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunNot.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunNumber.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunOnFunctions.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunOneOrMore.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FunParseIetfDate.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunPath.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunPosition.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunQName.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunRemove.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunReplace.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunResolveQName.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunResolveURI.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunReverse.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunRoot.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FunSerialize.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunSort.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunStartsWith.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunStrLength.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunString.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunStringJoin.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunStringToCodepoints.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunSubSequence.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunSubstring.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunSubstringAfter.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunSubstringBefore.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunSum.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunTokenize.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FunTrace.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunTranslate.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunTrueOrFalse.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunUnordered.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FunUnparsedText.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunUpperOrLowerCase.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FunUriCollection.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FunXmlToJson.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/fn/FunXmlToJsonTest.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/FunZeroOrOne.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/LoadXQueryModule.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/ParsingFunctions.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/fn/ParsingFunctionsTest.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/fn/QNameFunctions.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/transform/Convert.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/fn/transform/ConvertTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/transform/Delivery.java</exclude>

--- a/exist-core/src/main/java/org/exist/Namespaces.java
+++ b/exist-core/src/main/java/org/exist/Namespaces.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -40,7 +64,8 @@ public interface Namespaces {
 	String SCHEMA_INSTANCE_NS = XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI;
     
     // Move this here from Function.BUILTIN_FUNCTION_NS? /ljo
-	String XPATH_FUNCTIONS_NS = "http://www.w3.org/2005/xpath-functions";	
+	String XPATH_FUNCTIONS_NS = "http://www.w3.org/2005/xpath-functions";
+	String XPATH_FUNCTIONS_PREFIX = "fn";
     String XQUERY_LOCAL_NS = "http://www.w3.org/2005/xquery-local-functions";
 	String XPATH_DATATYPES_NS = "http://www.w3.org/2003/05/xpath-datatypes";
         

--- a/exist-core/src/main/java/org/exist/xquery/Function.java
+++ b/exist-core/src/main/java/org/exist/xquery/Function.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -54,10 +78,6 @@ import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
  * @author wolf
  */
 public abstract class Function extends PathExpr {
-
-    // Declare it in Namespaces instead? /ljo
-    public final static String BUILTIN_FUNCTION_NS =
-            "http://www.w3.org/2005/xpath-functions";
 
     /**
      * The module that declared the function.

--- a/exist-core/src/main/java/org/exist/xquery/NamedFunctionReference.java
+++ b/exist-core/src/main/java/org/exist/xquery/NamedFunctionReference.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -25,6 +49,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.exist.dom.QName;
+import org.exist.xquery.functions.fn.FnModule;
 import org.exist.xquery.parser.XQueryAST;
 import org.exist.xquery.util.ExpressionDumper;
 import org.exist.xquery.value.FunctionReference;
@@ -53,7 +78,7 @@ public class NamedFunctionReference extends AbstractExpression {
 	}
 
 	public static FunctionCall lookupFunction(Expression self, XQueryContext context, QName funcName, int arity) throws XPathException {
-		if (Function.BUILTIN_FUNCTION_NS.equals(funcName.getNamespaceURI())
+		if (FnModule.NAMESPACE_URI.equals(funcName.getNamespaceURI())
 				&& "concat".equals(funcName.getLocalPart())
 				&& arity < 2) {
 			throw new XPathException(self, ErrorCodes.XPST0017, "No such function; fn:concat requires at least two arguments");

--- a/exist-core/src/main/java/org/exist/xquery/PerformanceStats.java
+++ b/exist-core/src/main/java/org/exist/xquery/PerformanceStats.java
@@ -58,6 +58,9 @@ import java.util.Arrays;
 import java.io.PrintWriter;
 import java.util.HashSet;
 
+import static org.exist.Namespaces.XPATH_FUNCTIONS_NS;
+import static org.exist.Namespaces.XPATH_FUNCTIONS_PREFIX;
+
 public class PerformanceStats implements BrokerPoolService {
 
     public final static String RANGE_IDX_TYPE = "range";
@@ -250,7 +253,12 @@ public class PerformanceStats implements BrokerPoolService {
         }
     }
 
-    public void recordFunctionCall(QName qname, String source, long elapsed) {
+    public void recordFunctionCall(QName qname, final String source, final long elapsed) {
+        if (XPATH_FUNCTIONS_NS.equals(qname.getNamespaceURI()) && qname.getPrefix() == null) {
+            // make sure that functions from the XPath/XQuery standard library are shown correctly in the output
+            qname = new QName(qname.getLocalPart(), qname.getNamespaceURI(), XPATH_FUNCTIONS_PREFIX, qname.getNameType());
+        }
+
         final FunctionStats newStats = new FunctionStats(source, qname);
         final FunctionStats stats = functions.get(newStats);
         if (stats == null) {

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -310,7 +310,7 @@ public class XQueryContext implements BinaryValueManager, Context {
 
     protected String moduleLoadPath = ".";
 
-    private String defaultFunctionNamespace = Function.BUILTIN_FUNCTION_NS;
+    private String defaultFunctionNamespace = Namespaces.XPATH_FUNCTIONS_NS;
     private AnyURIValue defaultElementNamespace = AnyURIValue.EMPTY_URI;
     private AnyURIValue defaultElementNamespaceSchema = AnyURIValue.EMPTY_URI;
 
@@ -444,7 +444,7 @@ public class XQueryContext implements BinaryValueManager, Context {
      */
     @Nullable
     private HttpContext httpContext = null;
-    private static final QName UNNAMED_DECIMAL_FORMAT = new QName("__UNNAMED__", Function.BUILTIN_FUNCTION_NS);
+    private static final QName UNNAMED_DECIMAL_FORMAT = new QName("__UNNAMED__", Namespaces.XPATH_FUNCTIONS_NS);
 
     private final Map<QName, DecimalFormat> staticDecimalFormats = HashMap(Tuple(UNNAMED_DECIMAL_FORMAT, DecimalFormat.UNNAMED));
 
@@ -1063,7 +1063,7 @@ public class XQueryContext implements BinaryValueManager, Context {
     @Override
     public void setDefaultFunctionNamespace(final String uri) throws XPathException {
         //Not sure for the 2nd clause : eXist-db forces the function NS as default.
-        if ((defaultFunctionNamespace != null) && !defaultFunctionNamespace.equals(Function.BUILTIN_FUNCTION_NS) && !defaultFunctionNamespace.equals(uri)) {
+        if ((defaultFunctionNamespace != null) && !defaultFunctionNamespace.equals(Namespaces.XPATH_FUNCTIONS_NS) && !defaultFunctionNamespace.equals(uri)) {
             throw new XPathException(rootExpression, ErrorCodes.XQST0066, "Default function namespace is already set to: '" + defaultFunctionNamespace + "'");
         }
         defaultFunctionNamespace = uri;

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/ExtCollection.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/ExtCollection.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -54,7 +78,7 @@ public class ExtCollection extends Function {
 
     public final static FunctionSignature signature =
             new FunctionSignature(
-                    new QName("collection", Function.BUILTIN_FUNCTION_NS),
+                    new QName("collection", FnModule.NAMESPACE_URI),
                     "Returns the documents contained in the collections specified in " +
                             "the input sequence. " + XMLDBModule.COLLECTION_URI +
                             " Documents contained in sub-collections are also included. If no value is supplied, the statically know documents are used, for the REST Server this could be the addressed collection.",

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FnDefaultLanguage.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FnDefaultLanguage.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -32,7 +56,7 @@ import org.exist.xquery.value.Type;
 public class FnDefaultLanguage extends BasicFunction {
 
     public static final FunctionSignature FS_DEFAULT_LANGUAGE = FunctionDSL.functionSignature(
-            new QName("default-language", Function.BUILTIN_FUNCTION_NS),
+            new QName("default-language", FnModule.NAMESPACE_URI),
             "Returns the xs:language that is " +
                     "the value of the default language property from the dynamic context " +
                     "during the evaluation of a query or transformation in which " +

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FnFormatDates.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FnFormatDates.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -69,7 +93,7 @@ public class FnFormatDates extends BasicFunction {
 
 
     public final static FunctionSignature FNS_FORMAT_DATETIME_2 = new FunctionSignature(
-        new QName("format-dateTime", Function.BUILTIN_FUNCTION_NS),
+        new QName("format-dateTime", FnModule.NAMESPACE_URI),
         "Returns a string containing an xs:date value formatted for display.",
         new SequenceType[] {
             DATETIME,
@@ -79,7 +103,7 @@ public class FnFormatDates extends BasicFunction {
     );
 
     public final static FunctionSignature FNS_FORMAT_DATETIME_5 = new FunctionSignature(
-        new QName("format-dateTime", Function.BUILTIN_FUNCTION_NS),
+        new QName("format-dateTime", FnModule.NAMESPACE_URI),
         "Returns a string containing an xs:date value formatted for display.",
         new SequenceType[] {
             DATETIME,
@@ -92,7 +116,7 @@ public class FnFormatDates extends BasicFunction {
     );
 
     public final static FunctionSignature FNS_FORMAT_DATE_2 = new FunctionSignature(
-        new QName("format-date", Function.BUILTIN_FUNCTION_NS),
+        new QName("format-date", FnModule.NAMESPACE_URI),
         "Returns a string containing an xs:date value formatted for display.",
         new SequenceType[] {
             DATE,
@@ -102,7 +126,7 @@ public class FnFormatDates extends BasicFunction {
     );
 
     public final static FunctionSignature FNS_FORMAT_DATE_5 = new FunctionSignature(
-        new QName("format-date", Function.BUILTIN_FUNCTION_NS),
+        new QName("format-date", FnModule.NAMESPACE_URI),
         "Returns a string containing an xs:date value formatted for display.",
         new SequenceType[] {
             DATE,
@@ -115,7 +139,7 @@ public class FnFormatDates extends BasicFunction {
     );
 
     public final static FunctionSignature FNS_FORMAT_TIME_2 = new FunctionSignature(
-        new QName("format-time", Function.BUILTIN_FUNCTION_NS),
+        new QName("format-time", FnModule.NAMESPACE_URI),
         "Returns a string containing an xs:time value formatted for display.",
         new SequenceType[] {
             TIME,
@@ -125,7 +149,7 @@ public class FnFormatDates extends BasicFunction {
     );
 
     public final static FunctionSignature FNS_FORMAT_TIME_5 = new FunctionSignature(
-        new QName("format-time", Function.BUILTIN_FUNCTION_NS),
+        new QName("format-time", FnModule.NAMESPACE_URI),
         "Returns a string containing an xs:time value formatted for display.",
         new SequenceType[] {
             TIME,

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FnHasChildren.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FnHasChildren.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -29,7 +53,7 @@ import org.w3c.dom.Node;
 
 public class FnHasChildren extends Function {
 
-    private final static QName QN_HAS_CHILDREN = new QName("has-children", Function.BUILTIN_FUNCTION_NS);
+    private final static QName QN_HAS_CHILDREN = new QName("has-children", FnModule.NAMESPACE_URI);
 
     public final static FunctionSignature FNS_HAS_CHILDREN_0 = new FunctionSignature(
             QN_HAS_CHILDREN,

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FnInnerMost.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FnInnerMost.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -35,7 +59,7 @@ import java.util.Set;
 public class FnInnerMost extends BasicFunction {
 
     public final static FunctionSignature FNS_INNERMOST = new FunctionSignature(
-            new QName("innermost", Function.BUILTIN_FUNCTION_NS),
+            new QName("innermost", FnModule.NAMESPACE_URI),
             "Returns every node within the input sequence that is not an ancestor of another member of the input sequence; the nodes are returned in document order with duplicates eliminated.",
             new SequenceType[] {
                     new FunctionParameterSequenceType("nodes", Type.NODE, Cardinality.ZERO_OR_MORE, "The nodes to test")

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FnModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FnModule.java
@@ -49,6 +49,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.exist.Namespaces;
 import org.exist.dom.QName;
 import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionParameterSequenceType;
@@ -63,6 +64,7 @@ import org.exist.xquery.value.FunctionReturnSequenceType;
  */
 public class FnModule extends AbstractInternalModule {
 
+    public static final String NAMESPACE_URI = Namespaces.XPATH_FUNCTIONS_NS;
     public final static String PREFIX = "";
     public final static String INCLUSION_DATE = "2004-01-29";
     public final static String RELEASED_IN_VERSION = "pre eXist-1.0";
@@ -318,7 +320,7 @@ public class FnModule extends AbstractInternalModule {
 
     @Override
     public String getNamespaceURI() {
-        return Function.BUILTIN_FUNCTION_NS;
+        return NAMESPACE_URI;
     }
 
     @Override
@@ -333,13 +335,13 @@ public class FnModule extends AbstractInternalModule {
 
     static FunctionSignature functionSignature(final String name, final String description,
             final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType... paramTypes) {
-        return FunctionDSL.functionSignature(new QName(name, Function.BUILTIN_FUNCTION_NS), description,
+        return FunctionDSL.functionSignature(new QName(name, FnModule.NAMESPACE_URI), description,
                 returnType, paramTypes);
     }
 
     static FunctionSignature[] functionSignatures(final String name, final String description,
             final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType[][] variableParamTypes) {
-        return FunctionDSL.functionSignatures(new QName(name, Function.BUILTIN_FUNCTION_NS), description,
+        return FunctionDSL.functionSignatures(new QName(name, FnModule.NAMESPACE_URI), description,
                 returnType, variableParamTypes);
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FnOuterMost.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FnOuterMost.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -35,7 +59,7 @@ import java.util.Set;
 public class FnOuterMost extends BasicFunction {
 
     public final static FunctionSignature FNS_OUTERMOST = new FunctionSignature(
-            new QName("outermost", Function.BUILTIN_FUNCTION_NS),
+            new QName("outermost", FnModule.NAMESPACE_URI),
             "Returns every node within the input sequence that has no ancestor that is itself a member of the input sequence; the nodes are returned in document order with duplicates eliminated.",
             new SequenceType[] {
                     new FunctionParameterSequenceType("nodes", Type.NODE, Cardinality.ZERO_OR_MORE, "The nodes to test")

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAbs.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAbs.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -44,7 +68,7 @@ public class FunAbs extends Function {
 
     public final static FunctionSignature signature =
         new FunctionSignature(
-            new QName("abs", Function.BUILTIN_FUNCTION_NS),
+            new QName("abs", FnModule.NAMESPACE_URI),
             "Returns the absolute value of the argument $number." +
             "If the argument is negative returns -$number otherwise returns $number.",
             new SequenceType[] {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAdjustTimezone.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAdjustTimezone.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -55,14 +79,14 @@ public class FunAdjustTimezone extends BasicFunction {
 
     public final static FunctionSignature[] fnAdjustDateTimeToTimezone = {
         new FunctionSignature(
-            new QName("adjust-dateTime-to-timezone", Function.BUILTIN_FUNCTION_NS),
+            new QName("adjust-dateTime-to-timezone", FnModule.NAMESPACE_URI),
             "Adjusts the xs:dateTime value $date-time to the implicit timezone of the current locale.",
             new SequenceType[] { 
                 DATE_TIME_01_PARAM
             },
             DATE_TIME_01_RETURN),
         new FunctionSignature(
-            new QName("adjust-dateTime-to-timezone", Function.BUILTIN_FUNCTION_NS),
+            new QName("adjust-dateTime-to-timezone", FnModule.NAMESPACE_URI),
             "Adjusts the xs:dateTime value $date-time to a specific timezone, or to no timezone at all. " +
             "If $duration is the empty sequence, returns an xs:dateTime without a timezone.",
             new SequenceType[] {
@@ -74,14 +98,14 @@ public class FunAdjustTimezone extends BasicFunction {
 
     public final static FunctionSignature[] fnAdjustDateToTimezone = {
         new FunctionSignature(
-            new QName("adjust-date-to-timezone", Function.BUILTIN_FUNCTION_NS),
+            new QName("adjust-date-to-timezone", FnModule.NAMESPACE_URI),
             "Adjusts the xs:date value $date to the implicit timezone of the current locale.",
             new SequenceType[] {
                 DATE_01_PARAM
             },
             DATE_01_RETURN),
         new FunctionSignature(
-            new QName("adjust-date-to-timezone", Function.BUILTIN_FUNCTION_NS),
+            new QName("adjust-date-to-timezone", FnModule.NAMESPACE_URI),
             "Adjusts the xs:date value $date to a specific timezone, or to no timezone at all. " +
             "If $duration is the empty sequence, returns an xs:date without a timezone.",
             new SequenceType[] { 
@@ -93,14 +117,14 @@ public class FunAdjustTimezone extends BasicFunction {
 
     public final static FunctionSignature[] fnAdjustTimeToTimezone = {
         new FunctionSignature(
-            new QName("adjust-time-to-timezone", Function.BUILTIN_FUNCTION_NS),
+            new QName("adjust-time-to-timezone", FnModule.NAMESPACE_URI),
             "Adjusts the xs:time value $time to the implicit timezone of the current locale.",
             new SequenceType[] { 
                 TIME_01_PARAM
             },
             TIME_01_RETURN),
         new FunctionSignature(
-            new QName("adjust-time-to-timezone", Function.BUILTIN_FUNCTION_NS),
+            new QName("adjust-time-to-timezone", FnModule.NAMESPACE_URI),
             "Adjusts the xs:time value $time to a specific timezone, or to no timezone at all. " +
             "If $duration is the empty sequence, returns an xs:time without a timezone.",
             new SequenceType[] { 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAnalyzeString.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAnalyzeString.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -48,12 +72,12 @@ import javax.xml.XMLConstants;
  */
 public class FunAnalyzeString extends BasicFunction {
 
-    private final static QName fnAnalyzeString = new QName("analyze-string", Function.BUILTIN_FUNCTION_NS);
+    private final static QName fnAnalyzeString = new QName("analyze-string", FnModule.NAMESPACE_URI);
 
-    private final static QName QN_MATCH = new QName("match", Function.BUILTIN_FUNCTION_NS);
-    private final static QName QN_GROUP = new QName("group", Function.BUILTIN_FUNCTION_NS);
+    private final static QName QN_MATCH = new QName("match", FnModule.NAMESPACE_URI);
+    private final static QName QN_GROUP = new QName("group", FnModule.NAMESPACE_URI);
     private final static QName QN_NR = new QName("nr", XMLConstants.NULL_NS_URI);
-    private final static QName QN_NON_MATCH = new QName("non-match", Function.BUILTIN_FUNCTION_NS);
+    private final static QName QN_NON_MATCH = new QName("non-match", FnModule.NAMESPACE_URI);
     
     public final static FunctionSignature[] signatures = {
         new FunctionSignature(
@@ -102,7 +126,7 @@ public class FunAnalyzeString extends BasicFunction {
         try {
             final MemTreeBuilder builder = context.getDocumentBuilder();
             builder.startDocument();
-            builder.startElement(new QName("analyze-string-result", Function.BUILTIN_FUNCTION_NS), null);
+            builder.startElement(new QName("analyze-string-result", FnModule.NAMESPACE_URI), null);
             String input = "";
             if (!args[0].isEmpty()) {
                 input = args[0].itemAt(0).getStringValue();

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAvg.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAvg.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -57,7 +81,7 @@ public class FunAvg extends Function {
 
     public final static FunctionSignature signature =
         new FunctionSignature(
-            new QName("avg", Function.BUILTIN_FUNCTION_NS),
+            new QName("avg", FnModule.NAMESPACE_URI),
             "Returns the average of the values in the input sequence $values, " +
             "that is, the sum of the values divided by the number of values.",
             new SequenceType[] {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunBoolean.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunBoolean.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -45,7 +69,7 @@ public class FunBoolean extends Function {
 
     public final static FunctionSignature signature =
         new FunctionSignature(
-            new QName("boolean", Function.BUILTIN_FUNCTION_NS),
+            new QName("boolean", FnModule.NAMESPACE_URI),
             "Computes the xs:boolean value of the sequence items.",
             new SequenceType[] { 
                 new FunctionParameterSequenceType("items", Type.ITEM,

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCeiling.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCeiling.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -41,7 +65,7 @@ public class FunCeiling extends Function {
 
     public final static FunctionSignature signature =
         new FunctionSignature(
-            new QName("ceiling", Function.BUILTIN_FUNCTION_NS),
+            new QName("ceiling", FnModule.NAMESPACE_URI),
             "Returns a value of the same type as the argument. Specifically, " +
             "returns the smallest (closest to negative infinity) number " +
             "with no fractional part that is not less than the value of the argument, $number.",

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCodepointEqual.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCodepointEqual.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -48,7 +72,7 @@ public class FunCodepointEqual extends BasicFunction {
 
     public final static FunctionSignature signature =
         new FunctionSignature(
-            new QName("codepoint-equal", Function.BUILTIN_FUNCTION_NS, FnModule.PREFIX),
+            new QName("codepoint-equal", FnModule.NAMESPACE_URI, FnModule.PREFIX),
             "Returns true or false depending on whether the value of $string-1 " +
             "is equal to the value of $string-2, according to the Unicode " +
             "code point collation.",

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCodepointsToString.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCodepointsToString.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -55,7 +79,7 @@ public class FunCodepointsToString extends BasicFunction {
 
     public final static FunctionSignature signature =
         new FunctionSignature(
-            new QName("codepoints-to-string", Function.BUILTIN_FUNCTION_NS, FnModule.PREFIX),
+            new QName("codepoints-to-string", FnModule.NAMESPACE_URI, FnModule.PREFIX),
             "Creates an xs:string from a sequence of code points. Returns the " +
             "zero-length string if $codepoints is the empty sequence. " +
             "If any of the code points in $codepoints is not a " +

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCompare.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCompare.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -50,7 +74,7 @@ public class FunCompare extends CollatingFunction {
 
     public final static FunctionSignature[] signatures = {
         new FunctionSignature (
-            new QName("compare", Function.BUILTIN_FUNCTION_NS),
+            new QName("compare", FnModule.NAMESPACE_URI),
             "Returns the collatable comparison between $string-1 and $string-2, using $collation-uri. " +
             "-1 if $string-1 is inferior to $string-2, 0 if $string-1 is equal " +
             "to $string-2, 1 if $string-1 is superior to $string-2. " + 
@@ -70,7 +94,7 @@ public class FunCompare extends CollatingFunction {
                 "1 if $string-1 is superior to $string-2. " +
                 "If either comparand is the empty sequence, the empty sequence is returned.")),
         new FunctionSignature (
-            new QName("compare", Function.BUILTIN_FUNCTION_NS),
+            new QName("compare", FnModule.NAMESPACE_URI),
             "Returns the collatable comparison between $string-1 and $string-2, using $collation-uri. " +
             "-1 if $string-1 is inferior to $string-2, 0 if $string-1 is equal " +
             "to $string-2, 1 if $string-1 is superior to $string-2. " +

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunConcat.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunConcat.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -58,7 +82,7 @@ public class FunConcat extends Function {
 
     public final static FunctionSignature signature =
         new FunctionSignature(
-            new QName("concat", Function.BUILTIN_FUNCTION_NS),
+            new QName("concat", FnModule.NAMESPACE_URI),
             "Accepts two or more xdt:anyAtomicType arguments, $atomizable-values, " +
             "and converts them to xs:string. Returns the xs:string that is the " +
             "concatenation of the values of its arguments after conversion. " +

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunContains.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunContains.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -43,7 +67,7 @@ public class FunContains extends CollatingFunction {
 
     public final static FunctionSignature[] signatures = {
         new FunctionSignature(
-            new QName("contains", Function.BUILTIN_FUNCTION_NS),
+            new QName("contains", FnModule.NAMESPACE_URI),
             "Returns an xs:boolean indicating whether or not the value of " +
             "$source-string contains (at the beginning, at the end, " +
             "or anywhere within) at least one sequence of collation units " +
@@ -58,7 +82,7 @@ public class FunContains extends CollatingFunction {
             new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE,
                 "true() if $source-string contains $substring, false() otherwise")),
         new FunctionSignature(
-            new QName("contains", Function.BUILTIN_FUNCTION_NS),
+            new QName("contains", FnModule.NAMESPACE_URI),
             "Returns an xs:boolean indicating whether or not the value of " +
             "$source-string contains (at the beginning, at the end, " +
             "or anywhere within) at least one sequence of collation units " +

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunContainsToken.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunContainsToken.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -40,7 +64,7 @@ import static org.exist.xquery.FunctionDSL.*;
  * @see <a href="https://www.w3.org/TR/xpath-functions-31/#func-contains-token">https://www.w3.org/TR/xpath-functions-31/#func-contains-token</a>
  */
 public class FunContainsToken extends BasicFunction {
-    private static final QName FS_CONTAINS_TOKEN_NAME = new QName("contains-token", Function.BUILTIN_FUNCTION_NS);
+    private static final QName FS_CONTAINS_TOKEN_NAME = new QName("contains-token", FnModule.NAMESPACE_URI);
 
     private final static FunctionParameterSequenceType FS_INPUT = optManyParam("input", Type.STRING, "The input string");
     private final static FunctionParameterSequenceType FS_TOKEN = param("token", Type.STRING, "The token to be searched for");

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCount.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCount.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -41,7 +65,7 @@ public class FunCount extends Function {
 
     public final static FunctionSignature signature =
             new FunctionSignature(
-                    new QName("count", Function.BUILTIN_FUNCTION_NS),
+                    new QName("count", FnModule.NAMESPACE_URI),
                     "Returns the number of items in the argument sequence, $items.",
                     new SequenceType[]{
                             new FunctionParameterSequenceType("items", Type.ITEM,

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCurrentDateTime.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCurrentDateTime.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -47,7 +71,7 @@ public class FunCurrentDateTime extends Function {
 
     public final static FunctionSignature fnCurrentDateTime =
         new FunctionSignature(
-            new QName("current-dateTime", Function.BUILTIN_FUNCTION_NS),
+            new QName("current-dateTime", FnModule.NAMESPACE_URI),
             "Returns the xs:dateTimeStamp (with timezone) that is current at some time " +
             "during the evaluation of a query or transformation in which " +
             "fn:current-dateTime() is executed.",
@@ -58,7 +82,7 @@ public class FunCurrentDateTime extends Function {
 
     public final static FunctionSignature fnCurrentTime =
         new FunctionSignature(
-            new QName("current-time", Function.BUILTIN_FUNCTION_NS),
+            new QName("current-time", FnModule.NAMESPACE_URI),
             "Returns the xs:time (with timezone) that is current at some time " +
             "during the evaluation of a query or transformation in which " +
             "fn:current-time() is executed.",
@@ -69,7 +93,7 @@ public class FunCurrentDateTime extends Function {
 
     public final static FunctionSignature fnCurrentDate =
         new FunctionSignature(
-            new QName("current-date", Function.BUILTIN_FUNCTION_NS),
+            new QName("current-date", FnModule.NAMESPACE_URI),
             "Returns the xs:date (with timezone) that is current at some time " +
             "during the evaluation of a query or transformation in which " +
             "fn:current-date() is executed.",

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunData.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunData.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -43,7 +67,7 @@ import org.exist.xquery.value.ValueSequence;
  */
 public class FunData extends Function {
 
-    public static final QName qnData = new QName("data", Function.BUILTIN_FUNCTION_NS);
+    public static final QName qnData = new QName("data", FnModule.NAMESPACE_URI);
 
     public final static FunctionSignature[] signatures = {
         new FunctionSignature(

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDateTime.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDateTime.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -52,7 +76,7 @@ public class FunDateTime extends BasicFunction {
 
     public final static FunctionSignature signature =
         new FunctionSignature(
-            new QName("dateTime", Function.BUILTIN_FUNCTION_NS, FnModule.PREFIX),
+            new QName("dateTime", FnModule.NAMESPACE_URI, FnModule.PREFIX),
             "Creates an xs:dateTime from an xs:date, $date, and an xs:time, $time.",
             new SequenceType[] {
                 new FunctionParameterSequenceType("date", Type.DATE,

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDeepEqual.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDeepEqual.java
@@ -90,7 +90,7 @@ public class FunDeepEqual extends CollatingFunction {
 
     public final static FunctionSignature[] signatures = {
         new FunctionSignature(
-            new QName("deep-equal", Function.BUILTIN_FUNCTION_NS),
+            new QName("deep-equal", FnModule.NAMESPACE_URI),
             "Returns true() iff every item in $items-1 is deep-equal to the item " +
             "at the same position in $items-2, false() otherwise. " +
             "If both $items-1 and $items-2 are the empty sequence, returns true(). ",
@@ -104,7 +104,7 @@ public class FunDeepEqual extends CollatingFunction {
                 "true() if the sequences are deep-equal, false() otherwise")
             ),
         new FunctionSignature(
-            new QName("deep-equal", Function.BUILTIN_FUNCTION_NS),
+            new QName("deep-equal", FnModule.NAMESPACE_URI),
             "Returns true() iff every item in $items-1 is deep-equal to the item " +
             "at the same position in $items-2, false() otherwise. " +
             "If both $items-1 and $items-2 are the empty sequence, returns true(). " +

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDefaultCollation.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDefaultCollation.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -44,7 +68,7 @@ public class FunDefaultCollation extends BasicFunction {
 
     public final static FunctionSignature signature =
         new FunctionSignature(
-            new QName("default-collation", Function.BUILTIN_FUNCTION_NS),
+            new QName("default-collation", FnModule.NAMESPACE_URI),
             "Returns the context's default collation. E.g. http://www.w3.org/" +
             "2005/xpath-functions/collation/codepoint.",
             null,

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDistinctValues.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDistinctValues.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -62,7 +86,7 @@ public class FunDistinctValues extends CollatingFunction {
 
     public final static FunctionSignature[] signatures = {
         new FunctionSignature(
-            new QName("distinct-values", Function.BUILTIN_FUNCTION_NS, FnModule.PREFIX),
+            new QName("distinct-values", FnModule.NAMESPACE_URI, FnModule.PREFIX),
             "Returns a sequence where duplicate values of $atomic-values, " +
             "based on value equality, have been deleted.",
             new SequenceType[] {
@@ -73,7 +97,7 @@ public class FunDistinctValues extends CollatingFunction {
                 "the distinct values sequence")
         ),
         new FunctionSignature(
-            new QName("distinct-values", Function.BUILTIN_FUNCTION_NS, FnModule.PREFIX),
+            new QName("distinct-values", FnModule.NAMESPACE_URI, FnModule.PREFIX),
             "Returns a sequence where duplicate values of $atomic-values, " +
             "based on value equality specified by collation $collation-uri, " + 
             "have been deleted.",

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDoc.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDoc.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -53,7 +77,7 @@ public class FunDoc extends Function {
 
     public final static FunctionSignature signature =
         new FunctionSignature(
-            new QName("doc", Function.BUILTIN_FUNCTION_NS),
+            new QName("doc", FnModule.NAMESPACE_URI),
             "Returns the document node of $document-uri. " +
             XMLDBModule.ANY_URI,
             new SequenceType[] {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunEmpty.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunEmpty.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -44,7 +68,7 @@ public class FunEmpty extends Function {
 
     public final static FunctionSignature signature =
         new FunctionSignature(
-            new QName("empty", Function.BUILTIN_FUNCTION_NS),
+            new QName("empty", FnModule.NAMESPACE_URI),
             "Returns true() if the value of $items is the empty sequence, false() otherwise.",
             new SequenceType[] {
                 new FunctionParameterSequenceType("items", Type.ITEM,

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunEncodeForURI.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunEncodeForURI.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -46,7 +70,7 @@ import org.exist.xquery.value.Type;
 public class FunEncodeForURI extends Function {
 
     public final static FunctionSignature signature = new FunctionSignature(
-        new QName("encode-for-uri", Function.BUILTIN_FUNCTION_NS),
+        new QName("encode-for-uri", FnModule.NAMESPACE_URI),
             "Escapes reserved characters in $uri-part by replacing it " +
                 "with its percent-encoded form as described in [RFC 3986]. " +
                 "If $uri-part is the empty sequence, returns the zero-length string.",

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunEndsWith.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunEndsWith.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -43,7 +67,7 @@ public class FunEndsWith extends CollatingFunction {
 
     public final static FunctionSignature[] signatures = {
         new FunctionSignature(
-            new QName("ends-with", Function.BUILTIN_FUNCTION_NS),
+            new QName("ends-with", FnModule.NAMESPACE_URI),
                 "Returns true() if the string value of $suffix is a suffix of the " +
                 "string value of $source-string, false() otherwise. " +
                 "If either $source-string or $suffix is the empty " +
@@ -58,7 +82,7 @@ public class FunEndsWith extends CollatingFunction {
                 "true() if $suffix is suffix of $source-string, false() otherwise")
         ),
         new FunctionSignature (
-            new QName("ends-with", Function.BUILTIN_FUNCTION_NS),
+            new QName("ends-with", FnModule.NAMESPACE_URI),
                 "Returns true() if the string value of $suffix is a suffix of the " +
                 "string value of $source-string using collation $collation-uri, " +
                 "false() otherwise. If either $source-string or $suffix is " +

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunEnvironment.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunEnvironment.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -45,14 +69,14 @@ public class FunEnvironment extends BasicFunction {
 
     public final static FunctionSignature[] signature = {
         new FunctionSignature(
-            new QName("available-environment-variables", Function.BUILTIN_FUNCTION_NS),
+            new QName("available-environment-variables", FnModule.NAMESPACE_URI),
             "Returns a list of environment variable names.",
             null,
             new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_MORE,
             "Returns a sequence of strings, being the names of the environment variables. User must be DBA.")
         ),
         new FunctionSignature(
-            new QName("environment-variable", Function.BUILTIN_FUNCTION_NS),
+            new QName("environment-variable", FnModule.NAMESPACE_URI),
             "Returns the value of a system environment variable, if it exists.",
             new SequenceType[] {
                 new FunctionParameterSequenceType("name", Type.STRING,

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunEquals.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunEquals.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -44,7 +68,7 @@ public class FunEquals extends CollatingFunction {
 
     public final static FunctionSignature[] signatures = {
         new FunctionSignature(
-            new QName("equals", Function.BUILTIN_FUNCTION_NS),
+            new QName("equals", FnModule.NAMESPACE_URI),
             "Returns an xs:boolean indicating whether or not the value of " +
             "$source-string  equals the collation units in the value of " +
             "$substring, according to the default collation. " +
@@ -60,7 +84,7 @@ public class FunEquals extends CollatingFunction {
                 "true() if $source-string equals $substring, false() otherwise")
         ),
         new FunctionSignature(
-            new QName("equals", Function.BUILTIN_FUNCTION_NS),
+            new QName("equals", FnModule.NAMESPACE_URI),
             "Returns an xs:boolean indicating whether or not the value of " +
             "$source-string equals the  collation units in the value of " +
             "$substring, according to the collation that is specified in " +

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunError.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunError.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -47,7 +71,7 @@ public class FunError extends BasicFunction {
 
     public final static FunctionSignature[] signature = {
         new FunctionSignature(
-            new QName("error", Function.BUILTIN_FUNCTION_NS),
+            new QName("error", FnModule.NAMESPACE_URI),
             "Indicates that an irrecoverable error has occurred. " +
             "The script will terminate immediately with an exception using " +
             "the default qname, 'http://www.w3.org/2004/07/xqt-errors#err:FOER0000', " +
@@ -56,7 +80,7 @@ public class FunError extends BasicFunction {
             new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
         ),
         new FunctionSignature(
-            new QName("error", Function.BUILTIN_FUNCTION_NS),
+            new QName("error", FnModule.NAMESPACE_URI),
             "Indicates that an irrecoverable error has occurred. " +
             "The script will terminate immediately with an exception using " +
             "$qname and the default message, 'An error has been raised by the query'.",
@@ -67,7 +91,7 @@ public class FunError extends BasicFunction {
             new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
         ),
         new FunctionSignature(
-            new QName("error", Function.BUILTIN_FUNCTION_NS),
+            new QName("error", FnModule.NAMESPACE_URI),
             "Indicates that an irrecoverable error has occurred. " +
             "The script will terminate immediately with an exception using " +
             "$qname and $message.",
@@ -79,7 +103,7 @@ public class FunError extends BasicFunction {
             },
             new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)),
         new FunctionSignature(
-            new QName("error", Function.BUILTIN_FUNCTION_NS),
+            new QName("error", FnModule.NAMESPACE_URI),
             "Indicates that an irrecoverable error has occurred. " +
             "The script will terminate immediately with an exception using " +
             "$qname and $message with $error-object appended.",

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunEscapeHTMLURI.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunEscapeHTMLURI.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -47,7 +71,7 @@ public class FunEscapeHTMLURI extends Function {
 
     public final static FunctionSignature signature =
         new FunctionSignature(
-            new QName("escape-html-uri", Function.BUILTIN_FUNCTION_NS),
+            new QName("escape-html-uri", FnModule.NAMESPACE_URI),
             "Replaces all non-printable ASCII characters in the string value of " +
             "$html-uri by an escape sequence represented as a hexadecimal octet " +
             "in the form %XX. If $html-uri is the empty sequence, " + 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunEscapeURI.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunEscapeURI.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -47,7 +71,7 @@ public class FunEscapeURI extends BasicFunction {
 
     public final static FunctionSignature signature =
         new FunctionSignature(
-            new QName("escape-uri", Function.BUILTIN_FUNCTION_NS),
+            new QName("escape-uri", FnModule.NAMESPACE_URI),
             "This function applies the URI escaping rules defined in section 2 " +
             "of [RFC 2396] as amended by [RFC 2732], with one exception, to " +
             "the string supplied as $uri, which typically represents all or part " +

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunExactlyOne.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunExactlyOne.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -49,7 +73,7 @@ public class FunExactlyOne extends Function {
 	protected static final Logger logger = LogManager.getLogger(FunExactlyOne.class);
 	public final static FunctionSignature signature =
 		new FunctionSignature(
-			new QName("exactly-one", Function.BUILTIN_FUNCTION_NS),
+			new QName("exactly-one", FnModule.NAMESPACE_URI),
 			"Returns the argument sequence, $items, if it contains exactly one item. Otherwise, " +
 			"raises an error.",
 			new SequenceType[] {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunExists.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunExists.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -46,7 +70,7 @@ public class FunExists extends Function {
 
 	public final static FunctionSignature signature =
 		new FunctionSignature(
-			new QName("exists", Function.BUILTIN_FUNCTION_NS),
+			new QName("exists", FnModule.NAMESPACE_URI),
 			"Returns true if the argument $items is not the empty sequence, " +
 			"false otherwise.",
 			new SequenceType[] {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunFloor.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunFloor.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -41,7 +65,7 @@ public class FunFloor extends Function {
 
 	public final static FunctionSignature signature =
 		new FunctionSignature(
-			new QName("floor", Function.BUILTIN_FUNCTION_NS),
+			new QName("floor", FnModule.NAMESPACE_URI),
 			"Returns the largest number not greater than the value of $number. " + 
 			"If $number is the empty sequence, returns the empty sequence.",
 			new SequenceType[] {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunGetDateComponent.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunGetDateComponent.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -57,7 +81,7 @@ public class FunGetDateComponent extends BasicFunction {
 	// ----- fromDate
 	public final static FunctionSignature fnDayFromDate =
 		new FunctionSignature(
-			new QName("day-from-date", Function.BUILTIN_FUNCTION_NS),
+			new QName("day-from-date", FnModule.NAMESPACE_URI),
 			"Returns an xs:integer between 1 and 31, both inclusive, representing " +
 			"the day component in the localized value of $date.",
 			new SequenceType[] {
@@ -67,7 +91,7 @@ public class FunGetDateComponent extends BasicFunction {
 	
 	public final static FunctionSignature fnMonthFromDate =
 		new FunctionSignature(
-			new QName("month-from-date", Function.BUILTIN_FUNCTION_NS),
+			new QName("month-from-date", FnModule.NAMESPACE_URI),
 			"Returns an xs:integer between 1 and 12, both inclusive, representing the month " +
 			"component in the localized value of $date.",
 			new SequenceType[] {
@@ -77,7 +101,7 @@ public class FunGetDateComponent extends BasicFunction {
 	
 	public final static FunctionSignature fnYearFromDate =
 		new FunctionSignature(
-			new QName("year-from-date", Function.BUILTIN_FUNCTION_NS),
+			new QName("year-from-date", FnModule.NAMESPACE_URI),
 			"Returns an xs:integer representing the year in the localized value of $date. The value may be negative.",
 			new SequenceType[] {
                 DATE_01_PARAM
@@ -86,7 +110,7 @@ public class FunGetDateComponent extends BasicFunction {
 	
 	public final static FunctionSignature fnTimezoneFromDate =
 		new FunctionSignature(
-			new QName("timezone-from-date", Function.BUILTIN_FUNCTION_NS),
+			new QName("timezone-from-date", FnModule.NAMESPACE_URI),
             "Returns the timezone component of $date if any. If $date has a timezone component, then the result is an xs:dayTimeDuration that indicates deviation from UTC; its value may range from +14:00 to -14:00 hours, both inclusive. Otherwise, the result is the empty sequence." +
             "If $date is the empty sequence, returns the empty sequence.",
 			new SequenceType[] {
@@ -97,7 +121,7 @@ public class FunGetDateComponent extends BasicFunction {
 	// ----- fromTime
 	public final static FunctionSignature fnHoursFromTime =
 		new FunctionSignature(
-			new QName("hours-from-time", Function.BUILTIN_FUNCTION_NS),
+			new QName("hours-from-time", FnModule.NAMESPACE_URI),
 			"Returns an xs:integer between 0 and 23, both inclusive, representing the " +
 			"value of the hours component in the localized value of $time.",
 			new SequenceType[] {
@@ -107,7 +131,7 @@ public class FunGetDateComponent extends BasicFunction {
 	
 	public final static FunctionSignature fnMinutesFromTime =
 		new FunctionSignature(
-			new QName("minutes-from-time", Function.BUILTIN_FUNCTION_NS),
+			new QName("minutes-from-time", FnModule.NAMESPACE_URI),
 			"Returns an xs:integer value between 0 to 59, both inclusive, representing the value of " +
 			"the minutes component in the localized value of $time.",
 			new SequenceType[] {
@@ -117,7 +141,7 @@ public class FunGetDateComponent extends BasicFunction {
 	
 	public final static FunctionSignature fnSecondsFromTime =
 		new FunctionSignature(
-			new QName("seconds-from-time", Function.BUILTIN_FUNCTION_NS),
+			new QName("seconds-from-time", FnModule.NAMESPACE_URI),
 			"Returns an xs:decimal value between 0 and 60.999..., both inclusive, representing the " +
 			"seconds and fractional seconds in the localized value of $date. Note that the value can be " +
 			"greater than 60 seconds to accommodate occasional leap seconds used to keep human time " +
@@ -129,7 +153,7 @@ public class FunGetDateComponent extends BasicFunction {
 	
 	public final static FunctionSignature fnTimezoneFromTime =
 		new FunctionSignature(
-			new QName("timezone-from-time", Function.BUILTIN_FUNCTION_NS),
+			new QName("timezone-from-time", FnModule.NAMESPACE_URI),
 			"Returns the timezone component of $time if any. If $time has a timezone component, " +
 			"then the result is an xdt:dayTimeDuration that indicates deviation from UTC; its value may " +
 			"range from +14:00 to -14:00 hours, both inclusive. Otherwise, the result is the empty sequence.",
@@ -142,7 +166,7 @@ public class FunGetDateComponent extends BasicFunction {
 	// ----- fromDateTime
 	public final static FunctionSignature fnDayFromDateTime =
 		new FunctionSignature(
-			new QName("day-from-dateTime", Function.BUILTIN_FUNCTION_NS),
+			new QName("day-from-dateTime", FnModule.NAMESPACE_URI),
 			"Returns an xs:integer between 1 and 31, both inclusive, representing " +
 			"the day component in the localized value of $date-time.",
 			new SequenceType[] {
@@ -152,7 +176,7 @@ public class FunGetDateComponent extends BasicFunction {
 	
 	public final static FunctionSignature fnMonthFromDateTime =
 		new FunctionSignature(
-			new QName("month-from-dateTime", Function.BUILTIN_FUNCTION_NS),
+			new QName("month-from-dateTime", FnModule.NAMESPACE_URI),
 			"Returns an xs:integer between 1 and 12, both inclusive, representing the month " +
 			"component in the localized value of $date-time.",
 			new SequenceType[] {
@@ -162,7 +186,7 @@ public class FunGetDateComponent extends BasicFunction {
 	
 	public final static FunctionSignature fnYearFromDateTime =
 		new FunctionSignature(
-			new QName("year-from-dateTime", Function.BUILTIN_FUNCTION_NS),
+			new QName("year-from-dateTime", FnModule.NAMESPACE_URI),
 			"Returns an xs:integer representing the year in the localized value of $date-time. The value may be negative.",
 			new SequenceType[] {
                 DATE_TIME_01_PARAM
@@ -171,7 +195,7 @@ public class FunGetDateComponent extends BasicFunction {
 	
 	public final static FunctionSignature fnHoursFromDateTime =
 		new FunctionSignature(
-			new QName("hours-from-dateTime", Function.BUILTIN_FUNCTION_NS),
+			new QName("hours-from-dateTime", FnModule.NAMESPACE_URI),
 			"Returns an xs:integer between 0 and 23, both inclusive, representing the " +
 			"value of the hours component in the localized value of $date-time.",
 			new SequenceType[] {
@@ -181,7 +205,7 @@ public class FunGetDateComponent extends BasicFunction {
 	
 	public final static FunctionSignature fnMinutesFromDateTime =
 		new FunctionSignature(
-			new QName("minutes-from-dateTime", Function.BUILTIN_FUNCTION_NS),
+			new QName("minutes-from-dateTime", FnModule.NAMESPACE_URI),
 			"Returns an xs:integer value between 0 to 59, both inclusive, representing the value of " +
 			"the minutes component in the localized value of $date-time.",
 			new SequenceType[] {
@@ -191,7 +215,7 @@ public class FunGetDateComponent extends BasicFunction {
 	
 	public final static FunctionSignature fnSecondsFromDateTime =
 		new FunctionSignature(
-			new QName("seconds-from-dateTime", Function.BUILTIN_FUNCTION_NS),
+			new QName("seconds-from-dateTime", FnModule.NAMESPACE_URI),
 			"Returns an xs:decimal value between 0 and 60.999..., both inclusive, representing the " +
 			"seconds and fractional seconds in the localized value of $date-time. Note that the value can be " +
 			"greater than 60 seconds to accommodate occasional leap seconds used to keep human time " +
@@ -203,7 +227,7 @@ public class FunGetDateComponent extends BasicFunction {
 	
 	public final static FunctionSignature fnTimezoneFromDateTime =
 		new FunctionSignature(
-			new QName("timezone-from-dateTime", Function.BUILTIN_FUNCTION_NS),
+			new QName("timezone-from-dateTime", FnModule.NAMESPACE_URI),
 			"Returns the timezone component of $date-time if any. If $date-time has a timezone component, " +
 			"then the result is an xdt:dayTimeDuration that indicates deviation from UTC; its value may " +
 			"range from +14:00 to -14:00 hours, both inclusive. Otherwise, the result is the empty sequence.",

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunGetDurationComponent.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunGetDurationComponent.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -60,7 +84,7 @@ public class FunGetDurationComponent extends BasicFunction {
 
 	public final static FunctionSignature fnDaysFromDuration =
 		new FunctionSignature(
-			new QName("days-from-duration", Function.BUILTIN_FUNCTION_NS),
+			new QName("days-from-duration", FnModule.NAMESPACE_URI),
 			"Returns an xs:integer representing the days component in the canonical lexical " +
 			"representation of the value of $duration. The result may be negative.",
 			new SequenceType[] {
@@ -70,7 +94,7 @@ public class FunGetDurationComponent extends BasicFunction {
 	
 	public final static FunctionSignature fnHoursFromDuration =
 		new FunctionSignature(
-			new QName("hours-from-duration", Function.BUILTIN_FUNCTION_NS),
+			new QName("hours-from-duration", FnModule.NAMESPACE_URI),
 			"Returns an xs:integer representing the hours component in the canonical lexical " +
 			"representation of the value of $duration. The result may be negative.",
 			new SequenceType[] {
@@ -80,7 +104,7 @@ public class FunGetDurationComponent extends BasicFunction {
 	
 	public final static FunctionSignature fnMinutesFromDuration =
 		new FunctionSignature(
-			new QName("minutes-from-duration", Function.BUILTIN_FUNCTION_NS),
+			new QName("minutes-from-duration", FnModule.NAMESPACE_URI),
 			"Returns an xs:integer representing the minutes component in the canonical " +
 			"lexical representation of the value of $duration. The result may be negative.",
 			new SequenceType[] {
@@ -90,7 +114,7 @@ public class FunGetDurationComponent extends BasicFunction {
 
 	public final static FunctionSignature fnSecondsFromDuration =
 		new FunctionSignature(
-			new QName("seconds-from-duration", Function.BUILTIN_FUNCTION_NS),
+			new QName("seconds-from-duration", FnModule.NAMESPACE_URI),
 			"Returns an xs:decimal representing the seconds component in the canonical lexical " +
 			"representation of the value of $duration. The result may be negative",
 			new SequenceType[] {
@@ -99,7 +123,7 @@ public class FunGetDurationComponent extends BasicFunction {
 			new FunctionReturnSequenceType(Type.DECIMAL, Cardinality.ZERO_OR_ONE, "the seconds component of $duration"));
 
    public final static FunctionSignature fnMonthsFromDuration = new FunctionSignature(
-			new QName("months-from-duration", Function.BUILTIN_FUNCTION_NS),
+			new QName("months-from-duration", FnModule.NAMESPACE_URI),
 			"Returns an xs:integer representing the months component in the canonical lexical " +
 			"representation of the value of $duration. The result may be negative.",
 			new SequenceType[] {
@@ -108,7 +132,7 @@ public class FunGetDurationComponent extends BasicFunction {
 			new FunctionReturnSequenceType(Type.INTEGER, Cardinality.ZERO_OR_ONE, "the months component of $duration"));
 
    public final static FunctionSignature fnYearsFromDuration = new FunctionSignature(
-			new QName("years-from-duration", Function.BUILTIN_FUNCTION_NS),
+			new QName("years-from-duration", FnModule.NAMESPACE_URI),
 			"Returns an xs:integer representing the years component in the canonical lexical " +
 			"representation of the value of $duration. The result may be negative.",
 			new SequenceType[] {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunHeadTail.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunHeadTail.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -40,7 +64,7 @@ public class FunHeadTail extends BasicFunction {
 
 	public final static FunctionSignature[] signatures = {
         new FunctionSignature(
-            new QName("head", Function.BUILTIN_FUNCTION_NS),
+            new QName("head", FnModule.NAMESPACE_URI),
             "The function returns the value of the expression $arg[1], i.e. the first item in the " +
             "passed in sequence.",
             new SequenceType[] {
@@ -48,7 +72,7 @@ public class FunHeadTail extends BasicFunction {
             },
             new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_ONE, "the first item or the empty sequence")),
         new FunctionSignature(
-                new QName("tail", Function.BUILTIN_FUNCTION_NS),
+                new QName("tail", FnModule.NAMESPACE_URI),
                 "The function returns the value of the expression subsequence($sequence, 2), i.e. a new sequence containing " +
                 "all items of the input sequence except the first.",
                 new SequenceType[] {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunHigherOrderFun.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunHigherOrderFun.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -39,7 +63,7 @@ import javax.annotation.Nullable;
 public class FunHigherOrderFun extends BasicFunction {
 
     public final static FunctionSignature FN_FOR_EACH = new FunctionSignature(
-            new QName("for-each", Function.BUILTIN_FUNCTION_NS),
+            new QName("for-each", FnModule.NAMESPACE_URI),
             "Applies the function item $function to every item from the sequence " +
                     "$sequence in turn, returning the concatenation of the resulting sequences in order.",
             new SequenceType[]{
@@ -50,7 +74,7 @@ public class FunHigherOrderFun extends BasicFunction {
     );
 
     public final static FunctionSignature FN_FOR_EACH_PAIR = new FunctionSignature(
-            new QName("for-each-pair", Function.BUILTIN_FUNCTION_NS),
+            new QName("for-each-pair", FnModule.NAMESPACE_URI),
             "Applies the function item $f to successive pairs of items taken one from $seq1 and one from $seq2, " +
                     "returning the concatenation of the resulting sequences in order.",
             new SequenceType[]{
@@ -62,7 +86,7 @@ public class FunHigherOrderFun extends BasicFunction {
     );
 
     public final static FunctionSignature FN_FILTER = new FunctionSignature(
-            new QName("filter", Function.BUILTIN_FUNCTION_NS),
+            new QName("filter", FnModule.NAMESPACE_URI),
             "Returns those items from the sequence $sequence for which the supplied function $function returns true.",
             new SequenceType[]{
                     new FunctionParameterSequenceType("sequence", Type.ITEM, Cardinality.ZERO_OR_MORE, "the sequence to filter"),
@@ -72,7 +96,7 @@ public class FunHigherOrderFun extends BasicFunction {
     );
 
     public final static FunctionSignature FN_FOLD_LEFT = new FunctionSignature(
-            new QName("fold-left", Function.BUILTIN_FUNCTION_NS),
+            new QName("fold-left", FnModule.NAMESPACE_URI),
             "Processes the supplied sequence from left to right, applying the supplied function repeatedly to each " +
                     "item in turn, together with an accumulated result value.",
             new SequenceType[]{
@@ -84,7 +108,7 @@ public class FunHigherOrderFun extends BasicFunction {
     );
 
     public final static FunctionSignature FN_FOLD_RIGHT = new FunctionSignature(
-            new QName("fold-right", Function.BUILTIN_FUNCTION_NS),
+            new QName("fold-right", FnModule.NAMESPACE_URI),
             "Processes the supplied sequence from right to left, applying the supplied function repeatedly to each " +
                     "item in turn, together with an accumulated result value.",
             new SequenceType[]{
@@ -96,7 +120,7 @@ public class FunHigherOrderFun extends BasicFunction {
     );
 
     public final static FunctionSignature FN_APPLY = new FunctionSignature(
-            new QName("apply", Function.BUILTIN_FUNCTION_NS),
+            new QName("apply", FnModule.NAMESPACE_URI),
             "Processes the supplied sequence from right to left, applying the supplied function repeatedly to each " +
                     "item in turn, together with an accumulated result value.",
             new SequenceType[]{

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunIRIToURI.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunIRIToURI.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -78,7 +102,7 @@ public class FunIRIToURI extends Function {
 
 	public final static FunctionSignature signature =
 		new FunctionSignature(
-			new QName("iri-to-uri", Function.BUILTIN_FUNCTION_NS),
+			new QName("iri-to-uri", FnModule.NAMESPACE_URI),
 			FUNCTION_DESCRIPTION,
 			new SequenceType[] { new FunctionParameterSequenceType("iri", Type.STRING, Cardinality.ZERO_OR_ONE, "The IRI") },
 			new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the URI"));

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunId.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunId.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -47,7 +71,7 @@ public class FunId extends Function {
 	protected static final Logger logger = LogManager.getLogger(FunId.class);
 	public final static FunctionSignature[] signature = {
 			new FunctionSignature(
-				new QName("id", Function.BUILTIN_FUNCTION_NS),
+				new QName("id", FnModule.NAMESPACE_URI),
 				"Returns the sequence of element nodes that have an ID value " +
 				"matching the value of one or more of the IDREF values supplied in $idrefs. " +
 				"If none is matching or $idrefs is the empty sequence, returns the empty sequence.",
@@ -56,7 +80,7 @@ public class FunId extends Function {
                 },
 				new FunctionReturnSequenceType(Type.ELEMENT, Cardinality.ZERO_OR_MORE, "the elements with IDs  matching IDREFs from $idref-sequence")),
             new FunctionSignature(
-                    new QName("id", Function.BUILTIN_FUNCTION_NS),
+                    new QName("id", FnModule.NAMESPACE_URI),
                     "Returns the sequence of element nodes that have an ID value " +
                     "matching the value of one or more of the IDREF values supplied in $idrefs and is in the same document as $node-in-document. " +
                     "If none is matching or $idrefs is the empty sequence, returns the empty sequence.",

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunIdRef.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunIdRef.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -67,7 +91,7 @@ public class FunIdRef extends Function {
 	protected static final Logger logger = LogManager.getLogger(FunIdRef.class);
 	public final static FunctionSignature[] signature = {
 		new FunctionSignature(
-			new QName("idref", Function.BUILTIN_FUNCTION_NS),
+			new QName("idref", FnModule.NAMESPACE_URI),
 			"Returns the sequence of element or attributes nodes with an IDREF value matching the " +
 			"value of one or more of the ID values supplied in $ids. " +
 			"If none is matching or $ids is the empty sequence, returns the empty sequence.",
@@ -77,7 +101,7 @@ public class FunIdRef extends Function {
 			new FunctionReturnSequenceType(Type.NODE, Cardinality.ZERO_OR_MORE, "the elements with matching IDREF values from IDs in $ids")),
 
         new FunctionSignature(
-            new QName("idref", Function.BUILTIN_FUNCTION_NS),
+            new QName("idref", FnModule.NAMESPACE_URI),
 			"Returns the sequence of element or attributes nodes with an IDREF value matching the " +
 			"value of one or more of the ID values supplied in $ids. " +
             "If none is matching or $ids is the empty sequence, returns the empty sequence.",

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunImplicitTimezone.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunImplicitTimezone.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -45,7 +69,7 @@ public class FunImplicitTimezone extends Function {
 
 	public final static FunctionSignature signature =
 		new FunctionSignature(
-			new QName("implicit-timezone", Function.BUILTIN_FUNCTION_NS),
+			new QName("implicit-timezone", FnModule.NAMESPACE_URI),
 			"Returns the value of the implicit timezone property from the dynamic context.",
 			null,
 			new FunctionReturnSequenceType(Type.DAY_TIME_DURATION, Cardinality.EXACTLY_ONE, "the implicit timezone daytime-duration from the dynamic context"));

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunInScopePrefixes.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunInScopePrefixes.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -53,7 +77,7 @@ public class FunInScopePrefixes extends BasicFunction {
 
     public final static FunctionSignature signature =
             new FunctionSignature(
-                    new QName("in-scope-prefixes", Function.BUILTIN_FUNCTION_NS),
+                    new QName("in-scope-prefixes", FnModule.NAMESPACE_URI),
                     "Returns the prefixes of the in-scope namespaces for $element. " +
                             "For namespaces that have a prefix, it returns the prefix as an " +
                             "xs:NCName. For the default namespace, which has no prefix, " +

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunIndexOf.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunIndexOf.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -85,7 +109,7 @@ public class FunIndexOf extends BasicFunction {
 
 	public final static FunctionSignature[] fnIndexOf = {
 			new FunctionSignature(
-					new QName("index-of", Function.BUILTIN_FUNCTION_NS),
+					new QName("index-of", FnModule.NAMESPACE_URI),
 					FUNCTION_DESCRIPTION,
 					new SequenceType[] {
 						SEQ_PARAM,
@@ -94,7 +118,7 @@ public class FunIndexOf extends BasicFunction {
 					RETURN_TYPE
 			),
 			new FunctionSignature(
-					new QName("index-of", Function.BUILTIN_FUNCTION_NS),
+					new QName("index-of", FnModule.NAMESPACE_URI),
 					FUNCTION_DESCRIPTION +
                     " " + CollatingFunction.THIRD_REL_COLLATION_ARG_EXAMPLE,
 					new SequenceType[] {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunInsertBefore.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunInsertBefore.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -66,7 +90,7 @@ public class FunInsertBefore extends Function {
 
 	public final static FunctionSignature signature =
 		new FunctionSignature(
-			new QName("insert-before", Function.BUILTIN_FUNCTION_NS),
+			new QName("insert-before", FnModule.NAMESPACE_URI),
 			FUNCTION_DESCRIPTION,
 			new SequenceType[] {
 					new FunctionParameterSequenceType("target", Type.ITEM, Cardinality.ZERO_OR_MORE, "The target"),

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunLang.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunLang.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -74,7 +98,7 @@ public class FunLang extends Function {
 
 	public final static FunctionSignature[] signatures = {
 		new FunctionSignature(
-			new QName("lang", Function.BUILTIN_FUNCTION_NS),
+			new QName("lang", FnModule.NAMESPACE_URI),
 			FUNCTION_DESCRIPTION_1_PARAM + FUNCTION_DESCRIPTION_BOTH,
 			new SequenceType[] {
 				 new FunctionParameterSequenceType("lang", Type.STRING, Cardinality.ZERO_OR_ONE, "The language code")
@@ -82,7 +106,7 @@ public class FunLang extends Function {
 			new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE, "true if the language code matches, false otherwise")
 		),
 		new FunctionSignature(
-				new QName("lang", Function.BUILTIN_FUNCTION_NS),
+				new QName("lang", FnModule.NAMESPACE_URI),
 				FUNCTION_DESCRIPTION_2_PARAMS + FUNCTION_DESCRIPTION_BOTH,
 				new SequenceType[] {
 					 new FunctionParameterSequenceType("lang", Type.STRING, Cardinality.ZERO_OR_ONE, "The language code"),

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunLast.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunLast.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -45,7 +69,7 @@ public class FunLast extends Function {
 
 	public final static FunctionSignature signature =
 		new FunctionSignature(
-			new QName("last", Function.BUILTIN_FUNCTION_NS),
+			new QName("last", FnModule.NAMESPACE_URI),
 			"Returns the context size from the dynamic context. " + 
 			"If the context item is undefined, an error is raised.",
 			null,

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunLocalName.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunLocalName.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -65,13 +89,13 @@ public class FunLocalName extends Function {
 
     public static final FunctionSignature[] signatures = {
             new FunctionSignature(
-                    new QName("local-name", Function.BUILTIN_FUNCTION_NS),
+                    new QName("local-name", FnModule.NAMESPACE_URI),
                     FUNCTION_DESCRIPTION,
                     null,
                     new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the local name")
             ),
             new FunctionSignature(
-                    new QName("local-name", Function.BUILTIN_FUNCTION_NS),
+                    new QName("local-name", FnModule.NAMESPACE_URI),
                     FUNCTION_DESCRIPTION,
                     new SequenceType[] {
                             new FunctionParameterSequenceType("arg", Type.NODE, Cardinality.ZERO_OR_ONE, "The node to retrieve the local name from")

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunMax.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunMax.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -91,7 +115,7 @@ public class FunMax extends CollatingFunction {
 
 	public final static FunctionSignature[] signatures = {
 			new FunctionSignature(
-					new QName("max", Function.BUILTIN_FUNCTION_NS),
+					new QName("max", FnModule.NAMESPACE_URI),
 					FUNCTION_DESCRIPTION_COMMON_1 +
                     FUNCTION_DESCRIPTION_COMMON_2,
 					new SequenceType[] {
@@ -100,7 +124,7 @@ public class FunMax extends CollatingFunction {
 					new FunctionReturnSequenceType(Type.ATOMIC, Cardinality.ZERO_OR_ONE, "the max value")
 			),
 			new FunctionSignature(
-					new QName("max", Function.BUILTIN_FUNCTION_NS),
+					new QName("max", FnModule.NAMESPACE_URI),
 					FUNCTION_DESCRIPTION_COMMON_1  + FUNCTION_DESCRIPTION_2_PARAM +
                     FUNCTION_DESCRIPTION_COMMON_2,
 					new SequenceType[] {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunMin.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunMin.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -96,14 +120,14 @@ public class FunMin extends CollatingFunction {
 
 	public final static FunctionSignature[] signatures = {
 		new FunctionSignature(
-			new QName("min", Function.BUILTIN_FUNCTION_NS),
+			new QName("min", FnModule.NAMESPACE_URI),
             FUNCTION_DESCRIPTION_COMMON_1 +
             FUNCTION_DESCRIPTION_COMMON_2,
 			new SequenceType[] { new FunctionParameterSequenceType("arg", Type.ATOMIC, Cardinality.ZERO_OR_MORE, "The input sequence")},
 			new FunctionReturnSequenceType(Type.ATOMIC, Cardinality.ZERO_OR_ONE, "the minimum value")
 		),
 		new FunctionSignature(
-			new QName("min", Function.BUILTIN_FUNCTION_NS),
+			new QName("min", FnModule.NAMESPACE_URI),
             FUNCTION_DESCRIPTION_COMMON_1  + FUNCTION_DESCRIPTION_2_PARAM +
             FUNCTION_DESCRIPTION_COMMON_2,
 			new SequenceType[] { 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunName.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunName.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -71,13 +95,13 @@ public class FunName extends Function {
 
     public final static FunctionSignature[] signatures = {
             new FunctionSignature(
-                    new QName("name", Function.BUILTIN_FUNCTION_NS),
+                    new QName("name", FnModule.NAMESPACE_URI),
                     FUNCTION_DESCRIPTION_0_PARAM + FUNCTION_DESCRIPTION_COMMON,
                     new SequenceType[0],
                     new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the name")
             ),
             new FunctionSignature(
-                    new QName("name", Function.BUILTIN_FUNCTION_NS),
+                    new QName("name", FnModule.NAMESPACE_URI),
                     FUNCTION_DESCRIPTION_1_PARAM + FUNCTION_DESCRIPTION_COMMON,
                     new SequenceType[] {
                             new FunctionParameterSequenceType("arg", Type.NODE, Cardinality.ZERO_OR_ONE, "The input node")

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNamespaceURI.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNamespaceURI.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -68,13 +92,13 @@ public class FunNamespaceURI extends Function {
 
     public final static FunctionSignature[] signatures = {
             new FunctionSignature(
-                    new QName("namespace-uri", Function.BUILTIN_FUNCTION_NS),
+                    new QName("namespace-uri", FnModule.NAMESPACE_URI),
                     FUNCTION_DESCRIPTION_0_PARAM + FUNCTION_DESCRIPTION_COMMON,
                     new SequenceType[0],
                     new FunctionReturnSequenceType(Type.ANY_URI, Cardinality.EXACTLY_ONE, "the namespace URI"),
                     false),
             new FunctionSignature(
-                    new QName("namespace-uri", Function.BUILTIN_FUNCTION_NS),
+                    new QName("namespace-uri", FnModule.NAMESPACE_URI),
                     FUNCTION_DESCRIPTION_1_PARAM + FUNCTION_DESCRIPTION_COMMON,
                     new SequenceType[] {
                             new FunctionParameterSequenceType("arg", Type.NODE, Cardinality.ZERO_OR_ONE, "The input node")

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNamespaceURIForPrefix.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNamespaceURIForPrefix.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -58,7 +82,7 @@ public class FunNamespaceURIForPrefix extends BasicFunction {
 
 	public final static FunctionSignature signature =
 		new FunctionSignature(
-			new QName("namespace-uri-for-prefix", Function.BUILTIN_FUNCTION_NS),
+			new QName("namespace-uri-for-prefix", FnModule.NAMESPACE_URI),
 			FUNCTION_DESCRIPTION,
 			new SequenceType[] { 
 				new FunctionParameterSequenceType("prefix", Type.STRING, Cardinality.ZERO_OR_ONE, "The namespace prefix"),

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNodeName.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNodeName.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -51,7 +75,7 @@ public class FunNodeName extends Function {
 
     public final static FunctionSignature[] signatures = {
             new FunctionSignature(
-                    new QName("node-name", Function.BUILTIN_FUNCTION_NS),
+                    new QName("node-name", FnModule.NAMESPACE_URI),
                     "Returns an expanded-QName for node kinds that can have names. For other kinds " +
                             "of nodes it returns the empty sequence. If the context item is the empty sequence, the " +
                             "empty sequence is returned.",
@@ -59,7 +83,7 @@ public class FunNodeName extends Function {
                     new FunctionReturnSequenceType(Type.QNAME, Cardinality.ZERO_OR_ONE, "the expanded QName")),
 
             new FunctionSignature(
-                    new QName("node-name", Function.BUILTIN_FUNCTION_NS),
+                    new QName("node-name", FnModule.NAMESPACE_URI),
                     "Returns an expanded-QName for node kinds that can have names. For other kinds " +
                             "of nodes it returns the empty sequence. If $arg is the empty sequence, the " +
                             "empty sequence is returned.",

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNormalizeSpace.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNormalizeSpace.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -68,14 +92,14 @@ public class FunNormalizeSpace extends Function {
 
     public static final FunctionSignature[] signatures = {
             new FunctionSignature(
-                    new QName("normalize-space", Function.BUILTIN_FUNCTION_NS),
+                    new QName("normalize-space", FnModule.NAMESPACE_URI),
                     FUNCTION_DESCRIPTION_0_PARAM + FUNCTION_DESCRIPTION_COMMON_1 +
                             FUNCTION_DESCRIPTION_COMMON_2,
                     new SequenceType[0],
                     RETURN_TYPE
             ),
             new FunctionSignature(
-                    new QName("normalize-space", Function.BUILTIN_FUNCTION_NS),
+                    new QName("normalize-space", FnModule.NAMESPACE_URI),
                     FUNCTION_DESCRIPTION_1_PARAM + FUNCTION_DESCRIPTION_COMMON_1 +
                             FUNCTION_DESCRIPTION_1_PARAM_1 + FUNCTION_DESCRIPTION_COMMON_2,
                     new SequenceType[]{new FunctionParameterSequenceType("arg", Type.STRING, Cardinality.ZERO_OR_ONE, "The string to normalize")},

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNormalizeUnicode.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNormalizeUnicode.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -19,7 +43,6 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-
 package org.exist.xquery.functions.fn;
 
 import org.apache.logging.log4j.LogManager;
@@ -90,13 +113,13 @@ public class FunNormalizeUnicode extends Function {
 
 	public final static FunctionSignature[] signatures = {
     	new FunctionSignature(
-	      new QName("normalize-unicode", Function.BUILTIN_FUNCTION_NS),
+	      new QName("normalize-unicode", FnModule.NAMESPACE_URI),
 	      FUNCTION_DESCRIPTION_0_PARAM,
 	      new SequenceType[] { ARG_PARAM },
 	      RETURN_TYPE
 	    ),
 	    new FunctionSignature (
-  	      new QName("normalize-unicode", Function.BUILTIN_FUNCTION_NS),
+  	      new QName("normalize-unicode", FnModule.NAMESPACE_URI),
 	      FUNCTION_DESCRIPTION_1_PARAM,
 	      new SequenceType[] { ARG_PARAM, NF_PARAM },
 	      RETURN_TYPE

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNot.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNot.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -46,7 +70,7 @@ public class FunNot extends Function {
 
 	public final static FunctionSignature signature =
 		new FunctionSignature(
-			new QName("not", Function.BUILTIN_FUNCTION_NS),
+			new QName("not", FnModule.NAMESPACE_URI),
 			" Returns true if the effective boolean " +
 			"value is false, and false if the effective boolean value is true. \n\n $arg is reduced to an effective boolean value by applying " +
 			"the fn:boolean() function.",

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNumber.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNumber.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -72,13 +96,13 @@ public class FunNumber extends Function {
 
     public final static FunctionSignature[] signatures = {
         new FunctionSignature(
-            new QName("number", Function.BUILTIN_FUNCTION_NS),
+            new QName("number", FnModule.NAMESPACE_URI),
             FUNCTION_DESCRIPTION_0_PARAM,
             new SequenceType[0],
             RETURN_TYPE
         ),
         new FunctionSignature(
-            new QName("number", Function.BUILTIN_FUNCTION_NS),
+            new QName("number", FnModule.NAMESPACE_URI),
             FUNCTION_DESCRIPTION_1_PARAM,
             new SequenceType[] { ARG_PARAM },
             RETURN_TYPE

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunOnFunctions.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunOnFunctions.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -37,7 +61,7 @@ public class FunOnFunctions extends BasicFunction {
 
 	public final static FunctionSignature[] signatures = {
         new FunctionSignature(
-            new QName("function-lookup", Function.BUILTIN_FUNCTION_NS),
+            new QName("function-lookup", FnModule.NAMESPACE_URI),
             "Returns a reference to the function having a given name and arity, if there is one," +
             " the empty sequence otherwise",
             new SequenceType[] {
@@ -46,7 +70,7 @@ public class FunOnFunctions extends BasicFunction {
             },
             new FunctionReturnSequenceType(Type.FUNCTION_REFERENCE, Cardinality.ZERO_OR_ONE, "The function if found, empty sequence otherwise")),
         new FunctionSignature(
-            new QName("function-name", Function.BUILTIN_FUNCTION_NS),
+            new QName("function-name", FnModule.NAMESPACE_URI),
             "Returns the name of the function identified by a function item.",
             new SequenceType[] {
                 new FunctionParameterSequenceType("function", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "The function item")
@@ -54,7 +78,7 @@ public class FunOnFunctions extends BasicFunction {
             new FunctionReturnSequenceType(Type.QNAME, Cardinality.ZERO_OR_ONE,
             		"The name of the function or the empty sequence if $function is an anonymous function.")),
 		new FunctionSignature(
-            new QName("function-arity", Function.BUILTIN_FUNCTION_NS),
+            new QName("function-arity", FnModule.NAMESPACE_URI),
             "Returns the arity of the function identified by a function item.",
             new SequenceType[] {
                 new FunctionParameterSequenceType("function", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "The function item")

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunOneOrMore.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunOneOrMore.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -46,7 +70,7 @@ public class FunOneOrMore extends Function {
 
 	public final static FunctionSignature signature =
 		new FunctionSignature(
-			new QName("one-or-more", Function.BUILTIN_FUNCTION_NS),
+			new QName("one-or-more", FnModule.NAMESPACE_URI),
 			"Returns $arg if it contains one or more items. Otherwise, " +
 			"raises an error.",
 			new SequenceType[] {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunParseIetfDate.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunParseIetfDate.java
@@ -79,7 +79,7 @@ public class FunParseIetfDate extends BasicFunction {
 
 
     public final static FunctionSignature FNS_PARSE_IETF_DATE = new FunctionSignature(
-            new QName("parse-ietf-date", Function.BUILTIN_FUNCTION_NS),
+            new QName("parse-ietf-date", FnModule.NAMESPACE_URI),
             "Parses a string containing the date and time in IETF format,\n" +
                     "returning the corresponding xs:dateTime value.",
             new SequenceType[]{IETF_DATE},

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunPath.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunPath.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -19,7 +43,6 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-
 package org.exist.xquery.functions.fn;
 
 import org.exist.Namespaces;
@@ -37,7 +60,7 @@ import static org.exist.xquery.FunctionDSL.functionSignature;
 
 public class FunPath extends BasicFunction {
 
-    private static final QName FN_PATH_NAME = new QName("path", Function.BUILTIN_FUNCTION_NS);
+    private static final QName FN_PATH_NAME = new QName("path", FnModule.NAMESPACE_URI);
     private static final String FN_PATH_DESCRIPTION =
             "Returns a path expression that can be used to select the supplied node " +
                     "relative to the root of its containing document.";

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunPosition.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunPosition.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -44,7 +68,7 @@ public class FunPosition extends Function {
 
 	public final static FunctionSignature signature =
 		new FunctionSignature(
-			new QName("position", Function.BUILTIN_FUNCTION_NS),
+			new QName("position", FnModule.NAMESPACE_URI),
 			"Returns the context position from the dynamic context. " +
 			"If the context item is undefined, raises an error.",
 			null,

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunQName.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunQName.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -49,7 +73,7 @@ public class FunQName extends BasicFunction {
 
 	public final static FunctionSignature signature =
 		new FunctionSignature(
-			new QName("QName", Function.BUILTIN_FUNCTION_NS),
+			new QName("QName", FnModule.NAMESPACE_URI),
 			"Returns an xs:QName with the namespace URI given in $uri. If $uri is " +
 			"the zero-length string or the empty sequence, it represents \"no namespace\"; in " +
 			"this case, if the value of $qname contains a colon (:), an error is " +

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunRemove.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunRemove.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -49,7 +73,7 @@ public class FunRemove extends Function {
 
 	public final static FunctionSignature signature =
 		new FunctionSignature(
-			new QName("remove", Function.BUILTIN_FUNCTION_NS),
+			new QName("remove", FnModule.NAMESPACE_URI),
 			"Returns a new sequence constructed from the value of $target with the item " +
 			"at $position removed.\n\nIf $position " +
 			"is less than 1 or greater than the number of items in $target, $target is returned. " +

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunReplace.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunReplace.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -43,7 +67,7 @@ import static org.exist.xquery.regex.RegexUtil.*;
  */
 public class FunReplace extends BasicFunction {
 
-	private static final QName FS_REPLACE_NAME = new QName("replace", Function.BUILTIN_FUNCTION_NS);
+	private static final QName FS_REPLACE_NAME = new QName("replace", FnModule.NAMESPACE_URI);
 
 	private static final String FS_REPLACE_DESCRIPTION =
         "The function returns the xs:string that is obtained by replacing each non-overlapping substring " +

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunResolveQName.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunResolveQName.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -53,7 +77,7 @@ import static org.exist.dom.QName.Validity.VALID;
 public class FunResolveQName extends BasicFunction {
 
     public final static FunctionSignature signature = 
-    	new FunctionSignature(new QName("resolve-QName", Function.BUILTIN_FUNCTION_NS), 
+    	new FunctionSignature(new QName("resolve-QName", FnModule.NAMESPACE_URI), 
     			"Returns an xs:QName value (that is, an expanded-QName) by taking an xs:string that has the lexical " +
     			"form of an xs:QName (a string in the form \"prefix:local-name\" or \"local-name\") and resolving it " +
     			"using the in-scope namespaces for a given element.\n\nIf $qname does not have the correct lexical " +

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunResolveURI.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunResolveURI.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -74,13 +98,13 @@ public class FunResolveURI extends Function {
 	
     public final static FunctionSignature[] signatures = {
     	new FunctionSignature(
-    		      new QName("resolve-uri", Function.BUILTIN_FUNCTION_NS),
+    		      new QName("resolve-uri", FnModule.NAMESPACE_URI),
     		      FUNCTION_DESCRIPTION_1_PARAM + FUNCTION_DESCRIPTION_COMMON,
 	      new SequenceType[] { RELATIVE_ARG },
 	      RETURN_TYPE
 	    ),
 	    new FunctionSignature (
-	  	      new QName("resolve-uri", Function.BUILTIN_FUNCTION_NS),
+	  	      new QName("resolve-uri", FnModule.NAMESPACE_URI),
 		      FUNCTION_DESCRIPTION_2_PARAM + FUNCTION_DESCRIPTION_COMMON,
 		      new SequenceType[] { RELATIVE_ARG, BASE_ARG },
 		      RETURN_TYPE

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunReverse.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunReverse.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -41,7 +65,7 @@ public class FunReverse extends Function {
 
 	public final static FunctionSignature signature =
 		new FunctionSignature(
-			new QName("reverse", Function.BUILTIN_FUNCTION_NS),
+			new QName("reverse", FnModule.NAMESPACE_URI),
 			"Reverses the order of items in a sequence.  If the argument is an empty" +
 			"sequence, the empty sequence is returned.",
 			new SequenceType[] {new FunctionParameterSequenceType("arg", Type.ITEM, Cardinality.ZERO_OR_MORE, "The sequence to reverse")},

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunRoot.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunRoot.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -63,13 +87,13 @@ public class FunRoot extends Function {
 
     public final static FunctionSignature[] signatures = {
             new FunctionSignature(
-                    new QName("root", Function.BUILTIN_FUNCTION_NS),
+                    new QName("root", FnModule.NAMESPACE_URI),
                     FUNCTION_DESCRIPTION_0_PARAM,
                     new SequenceType[0],
                     new FunctionReturnSequenceType(Type.NODE, Cardinality.EXACTLY_ONE, "the root node of the tree to which the context node belongs")
             ),
             new FunctionSignature(
-                    new QName("root", Function.BUILTIN_FUNCTION_NS),
+                    new QName("root", FnModule.NAMESPACE_URI),
                     FUNCTION_DESCRIPTION_1_PARAM,
                     new SequenceType[]{new FunctionParameterSequenceType("arg", Type.NODE, Cardinality.ZERO_OR_ONE, "The input node")},
                     new FunctionReturnSequenceType(Type.NODE, Cardinality.ZERO_OR_ONE, "the root node of the tree to which $arg belongs")

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
@@ -70,7 +70,7 @@ public class FunSerialize extends BasicFunction {
 
     public final static FunctionSignature[] signatures = {
         new FunctionSignature(
-                new QName("serialize", Function.BUILTIN_FUNCTION_NS, FnModule.PREFIX),
+                new QName("serialize", FnModule.NAMESPACE_URI, FnModule.PREFIX),
                 "This function serializes the supplied input sequence $arg as described in XSLT and XQuery Serialization 3.0, returning the " +
                         "serialized representation of the sequence as a string.",
                 new SequenceType[] {
@@ -79,7 +79,7 @@ public class FunSerialize extends BasicFunction {
                 new FunctionParameterSequenceType("result", Type.STRING, Cardinality.EXACTLY_ONE, "the string containing the serialized node set.")
         ),
         new FunctionSignature(
-                new QName("serialize", Function.BUILTIN_FUNCTION_NS, FnModule.PREFIX),
+                new QName("serialize", FnModule.NAMESPACE_URI, FnModule.PREFIX),
                 "This function serializes the supplied input sequence $arg as described in XSLT and XQuery Serialization 3.0, returning the " +
                         "serialized representation of the sequence as a string.",
                 new SequenceType[] {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSort.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSort.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -44,7 +68,7 @@ public class FunSort extends BasicFunction {
 
   public final static FunctionSignature[] signatures = {
     new FunctionSignature(
-      new QName("sort", Function.BUILTIN_FUNCTION_NS),
+      new QName("sort", FnModule.NAMESPACE_URI),
         "Sorts a supplied sequence.",
       new SequenceType[] {
         new FunctionParameterSequenceType("input", Type.ITEM, Cardinality.ZERO_OR_MORE, "")
@@ -52,7 +76,7 @@ public class FunSort extends BasicFunction {
       new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE, "the first item or the empty sequence")
     ),
     new FunctionSignature(
-      new QName("sort", Function.BUILTIN_FUNCTION_NS),
+      new QName("sort", FnModule.NAMESPACE_URI),
         "Sorts a supplied sequence, based on the value of a sort key supplied as a function.",
       new SequenceType[] {
           new FunctionParameterSequenceType("input", Type.ITEM, Cardinality.ZERO_OR_MORE, ""),
@@ -61,7 +85,7 @@ public class FunSort extends BasicFunction {
       new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE, "the resulting sequence")
     ),
     new FunctionSignature(
-        new QName("sort", Function.BUILTIN_FUNCTION_NS),
+        new QName("sort", FnModule.NAMESPACE_URI),
         "Sorts a supplied sequence, based on the value of a sort key supplied as a function.",
         new SequenceType[] {
             new FunctionParameterSequenceType("input", Type.ITEM, Cardinality.ZERO_OR_MORE, ""),

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunStartsWith.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunStartsWith.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -67,12 +91,12 @@ public class FunStartsWith extends CollatingFunction {
 	
     public final static FunctionSignature[] signatures = {
 	new FunctionSignature (
-			       new QName("starts-with", Function.BUILTIN_FUNCTION_NS),
+			       new QName("starts-with", FnModule.NAMESPACE_URI),
 			       FUNCTION_DESCRIPTION,
 			       new SequenceType[] { ARG1_PARAM, ARG2_PARAM },
 			       RETURN_TYPE),
 	new FunctionSignature (
-			       new QName("starts-with", Function.BUILTIN_FUNCTION_NS),
+			       new QName("starts-with", FnModule.NAMESPACE_URI),
 			       FUNCTION_DESCRIPTION + THIRD_REL_COLLATION_ARG_EXAMPLE,
 			       new SequenceType[] { ARG1_PARAM, ARG2_PARAM, COLLATION_PARAM },
 			       RETURN_TYPE)

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunStrLength.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunStrLength.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -43,14 +67,14 @@ public class FunStrLength extends Function {
 
     public final static FunctionSignature[] signatures = {
             new FunctionSignature(
-                    new QName("string-length", Function.BUILTIN_FUNCTION_NS),
+                    new QName("string-length", FnModule.NAMESPACE_URI),
                     "Returns an xs:integer equal to the length in characters of the value of the context item.\n" +
                             "If the context item is undefined an error is raised. ",
                     new SequenceType[0],
                     new FunctionReturnSequenceType(Type.INTEGER, Cardinality.EXACTLY_ONE, "the length in characters")
             ),
             new FunctionSignature(
-                    new QName("string-length", Function.BUILTIN_FUNCTION_NS),
+                    new QName("string-length", FnModule.NAMESPACE_URI),
                     "Returns an xs:integer equal to the length in characters of the value of $arg.\n" +
                             "If the value of $arg is the empty sequence, the xs:integer 0 is returned.\n" +
                             "If no argument is supplied, $arg defaults to the string value (calculated using fn:string()) of the context item (.). If no argument is supplied or if the argument is the context item and the context item is undefined an error is raised",

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunString.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunString.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -46,14 +70,14 @@ public class FunString extends Function {
 
 	public final static FunctionSignature[] signatures = {
 		new FunctionSignature(
-			new QName("string", Function.BUILTIN_FUNCTION_NS),
+			new QName("string", FnModule.NAMESPACE_URI),
 			"Returns the value of the context item as xs:string. " +
 			"If the context item is undefined, an error is raised.",
 			new SequenceType[0],
 			new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the value of the context item as an xs:string")
 		),
 		new FunctionSignature(
-			new QName("string", Function.BUILTIN_FUNCTION_NS),
+			new QName("string", FnModule.NAMESPACE_URI),
 			"Returns the value of $arg as xs:string. " +
 			"If the value of $arg is the empty sequence, the zero-length string is returned. " +
 			"If the context item of $arg is undefined, an error is raised.",

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunStringJoin.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunStringJoin.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -48,7 +72,7 @@ public class FunStringJoin extends BasicFunction {
 
 	public final static FunctionSignature[] signatures = {
         new FunctionSignature(
-            new QName("string-join", Function.BUILTIN_FUNCTION_NS),
+            new QName("string-join", FnModule.NAMESPACE_URI),
             "Returns a xs:string created by concatenating the members of the " +
             "$arg sequence using $separator as a separator. If the value of the separator is the zero-length " +
             "string, then the members of the sequence are concatenated without a separator. " +
@@ -61,7 +85,7 @@ public class FunStringJoin extends BasicFunction {
             },
             new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the joined string")),
 		new FunctionSignature(
-            new QName("string-join", Function.BUILTIN_FUNCTION_NS),
+            new QName("string-join", FnModule.NAMESPACE_URI),
             "Returns a xs:string created by concatenating the members of the " +
             "$arg sequence using $separator as a separator. If the value of the separator is the zero-length " +
             "string, then the members of the sequence are concatenated without a separator.",

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunStringToCodepoints.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunStringToCodepoints.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -37,7 +61,7 @@ public class FunStringToCodepoints extends BasicFunction {
 
 	public final static FunctionSignature signature =
 		new FunctionSignature(
-				new QName("string-to-codepoints", Function.BUILTIN_FUNCTION_NS),
+				new QName("string-to-codepoints", FnModule.NAMESPACE_URI),
 				"Returns the sequence of unicode code points that constitute an xs:string. If $arg is a zero-length " +
 				"string or the empty sequence, the empty sequence is returned.",
 				new SequenceType[] {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSubSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSubSequence.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -36,7 +60,7 @@ public class FunSubSequence extends Function {
 
     public static final FunctionSignature[] signatures = {
             new FunctionSignature(
-                    new QName("subsequence", Function.BUILTIN_FUNCTION_NS),
+                    new QName("subsequence", FnModule.NAMESPACE_URI),
                     "Returns a subsequence of the items in $source-sequence, "
                             + "items starting at the position, $starting-at, "
                             + "up to the end of the sequence are included.",
@@ -46,7 +70,7 @@ public class FunSubSequence extends Function {
                     },
                     new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE, "the subsequence")),
             new FunctionSignature(
-                    new QName("subsequence", Function.BUILTIN_FUNCTION_NS),
+                    new QName("subsequence", FnModule.NAMESPACE_URI),
                     "Returns a subsequence of the items in $source, "
                             + "starting at the position, $starting-at,  "
                             + "including the number of items indicated by $length.",

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSubstring.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSubstring.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -51,7 +75,7 @@ public class FunSubstring extends Function {
 	
 	public final static FunctionSignature[] signatures = {
 			new FunctionSignature(
-				new QName("substring", Function.BUILTIN_FUNCTION_NS),
+				new QName("substring", FnModule.NAMESPACE_URI),
 				"Returns the portion of the value of $source beginning at the position indicated " +
 				"by the value of $starting-at and continuing to the end of $source. " +
 				"The characters returned do not extend beyond the end of $source. If $starting-at " +
@@ -64,7 +88,7 @@ public class FunSubstring extends Function {
 				new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the substring")
 			),
 			new FunctionSignature(
-				new QName("substring", Function.BUILTIN_FUNCTION_NS),
+				new QName("substring", FnModule.NAMESPACE_URI),
 				"Returns the portion of the value of $source beginning at the position indicated by the value of $starting-at " +
 				"and continuing for the number of characters indicated by the value of $length. The characters returned do not extend " +
 				"beyond the end of $source. If $starting-at is zero or negative, only those characters in positions greater " +

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSubstringAfter.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSubstringAfter.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -52,7 +76,7 @@ public class FunSubstringAfter extends CollatingFunction {
 	protected static final FunctionParameterSequenceType SOURCE_ARG = new FunctionParameterSequenceType("source", Type.STRING, Cardinality.ZERO_OR_ONE, "The input string");
 	public final static FunctionSignature[] signatures = {
 		new FunctionSignature(
-			new QName("substring-after", Function.BUILTIN_FUNCTION_NS),
+			new QName("substring-after", FnModule.NAMESPACE_URI),
 			"Returns the substring of the value of $source that follows the first occurrence " +
 			"of a sequence of the value of $search. If the value of $source or $search is the empty " +
 			"sequence it is interpreted as the zero-length string. If the value of " +
@@ -65,7 +89,7 @@ public class FunSubstringAfter extends CollatingFunction {
 			},
 			new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the substring after $search")),
 		new FunctionSignature(
-				new QName("substring-after", Function.BUILTIN_FUNCTION_NS),
+				new QName("substring-after", FnModule.NAMESPACE_URI),
 				"Returns the substring of the value of $source that follows the first occurrence " +
 				"of a sequence of the value of $search in the collation $collation-uri. If the value of $source or $search is the empty " +
 				"sequence it is interpreted as the zero-length string. If the value of " +

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSubstringBefore.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSubstringBefore.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -52,7 +76,7 @@ public class FunSubstringBefore extends CollatingFunction {
 	protected static final FunctionParameterSequenceType SOURCE_ARG = new FunctionParameterSequenceType("source", Type.STRING, Cardinality.ZERO_OR_ONE, "The input string");
 	public final static FunctionSignature[] signatures = {
 		new FunctionSignature(
-			new QName("substring-before", Function.BUILTIN_FUNCTION_NS),
+			new QName("substring-before", FnModule.NAMESPACE_URI),
 			"Returns the substring of the value of $source that precedes the first occurrence " +
 			"of a sequence of the value of $search. If the value of $source or $search is the empty " +
 			"sequence it is interpreted as the zero-length string. If the value of " +
@@ -65,7 +89,7 @@ public class FunSubstringBefore extends CollatingFunction {
 				},
 				new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the substring before $search")),
 		new FunctionSignature(
-				new QName("substring-before", Function.BUILTIN_FUNCTION_NS),
+				new QName("substring-before", FnModule.NAMESPACE_URI),
 			"Returns the substring of the value of $source that precedes the first occurrence " +
 			"of a sequence of the value of $search in the collation $collation-uri. If the value of $source or $search is the empty " +
 			"sequence it is interpreted as the zero-length string. If the value of " +

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSum.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSum.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -51,7 +75,7 @@ public class FunSum extends Function {
 
 	public final static FunctionSignature[] signatures = {
 		new FunctionSignature(
-			new QName("sum", Function.BUILTIN_FUNCTION_NS),
+			new QName("sum", FnModule.NAMESPACE_URI),
 			"Returns a value obtained by adding together the values in $arg. " +
             "If $arg is the the empty sequence the xs:double value 0.0e0 is returned.",
 			new SequenceType[] {
@@ -59,7 +83,7 @@ public class FunSum extends Function {
 			new FunctionReturnSequenceType(Type.ATOMIC, Cardinality.EXACTLY_ONE, "the sum of all numbers in $arg")
 		),
 		new FunctionSignature(
-			new QName("sum", Function.BUILTIN_FUNCTION_NS),
+			new QName("sum", FnModule.NAMESPACE_URI),
 			"Returns a value obtained by adding together the values in $arg. " +
             "If $arg is the the empty sequence then $default is returned.",
 			new SequenceType[] {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunTokenize.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunTokenize.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -42,7 +66,7 @@ import static org.exist.xquery.regex.RegexUtil.*;
  */
 public class FunTokenize extends BasicFunction {
 
-    private static final QName FS_TOKENIZE_NAME = new QName("tokenize", Function.BUILTIN_FUNCTION_NS);
+    private static final QName FS_TOKENIZE_NAME = new QName("tokenize", FnModule.NAMESPACE_URI);
 
     private final static FunctionParameterSequenceType FS_TOKENIZE_PARAM_INPUT = optParam("input", Type.STRING, "The input string");
     private final static FunctionParameterSequenceType FS_TOKENIZE_PARAM_PATTERN = param("pattern", Type.STRING, "The tokenization pattern");

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunTranslate.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunTranslate.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -47,7 +71,7 @@ public class FunTranslate extends Function {
 
 	public final static FunctionSignature signature =
 		new FunctionSignature(
-			new QName("translate", Function.BUILTIN_FUNCTION_NS),
+			new QName("translate", FnModule.NAMESPACE_URI),
 			"Returns the value of $arg modified so that every character in the value of $arg that occurs at some position N in the " +
 			"value of $map has been replaced by the character that occurs at position N in the value of $trans.\n\n" +
 			"If the value of $arg is the empty sequence, the zero-length string is returned.\n\n" +

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunTrueOrFalse.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunTrueOrFalse.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -38,14 +62,14 @@ public class FunTrueOrFalse extends BasicFunction {
 
 	public final static FunctionSignature fnTrue =
 			new FunctionSignature(
-				new QName("true", Function.BUILTIN_FUNCTION_NS),
+				new QName("true", FnModule.NAMESPACE_URI),
                 "Always returns the boolean value true",
 				null,
 				new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE, "true"));
 	
 	public final static FunctionSignature fnFalse =
 		new FunctionSignature(
-			new QName("false", Function.BUILTIN_FUNCTION_NS),
+			new QName("false", FnModule.NAMESPACE_URI),
             "Always returns the boolean value false",
 			null,
 			new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE, "false"));

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunUnordered.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunUnordered.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -48,7 +72,7 @@ public class FunUnordered extends Function {
 
     public final static FunctionSignature signature =
 		new FunctionSignature(
-			new QName("unordered", Function.BUILTIN_FUNCTION_NS),
+			new QName("unordered", FnModule.NAMESPACE_URI),
 			"Takes a sequence $arg as input and returns an arbitrary implementation dependent permutation " +
 			"of it. Currently, this has no effect in eXist, but it might be used for future optimizations.",
 			new SequenceType[] {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunUnparsedText.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunUnparsedText.java
@@ -72,7 +72,7 @@ public class FunUnparsedText extends BasicFunction {
     private final static FunctionParameterSequenceType PARAM_ENCODING = param("encoding", Type.STRING, "character encoding of the resource");
 
     static final FunctionSignature [] FS_UNPARSED_TEXT = functionSignatures(
-        new QName("unparsed-text", Function.BUILTIN_FUNCTION_NS),
+        new QName("unparsed-text", FnModule.NAMESPACE_URI),
         "reads an external resource (for example, a file) and returns a string representation of the resource",
         returnsOpt(Type.STRING),
         arities(
@@ -81,7 +81,7 @@ public class FunUnparsedText extends BasicFunction {
         ));
 
     static final FunctionSignature[] FS_UNPARSED_TEXT_LINES = functionSignatures(
-        new QName("unparsed-text-lines", Function.BUILTIN_FUNCTION_NS),
+        new QName("unparsed-text-lines", FnModule.NAMESPACE_URI),
         "reads an external resource (for example, a file) and returns its contents as a sequence of strings, one for each line of text in the string representation of the resource",
         returnsOptMany(Type.STRING),
         arities(
@@ -90,7 +90,7 @@ public class FunUnparsedText extends BasicFunction {
         ));
 
     static final FunctionSignature [] FS_UNPARSED_TEXT_AVAILABLE = functionSignatures(
-        new QName("unparsed-text-available", Function.BUILTIN_FUNCTION_NS),
+        new QName("unparsed-text-available", FnModule.NAMESPACE_URI),
         "determines whether a call on the fn:unparsed-text function with identical arguments would return a string",
         returns(Type.BOOLEAN),
         arities(

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunUpperOrLowerCase.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunUpperOrLowerCase.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -44,14 +68,14 @@ public class FunUpperOrLowerCase extends Function {
 
 	public final static FunctionSignature fnUpperCase =
 		new FunctionSignature(
-			new QName("upper-case", Function.BUILTIN_FUNCTION_NS),
+			new QName("upper-case", FnModule.NAMESPACE_URI),
 			"Returns the value of $arg after translating every character to its upper-case correspondent as defined in the appropriate case mappings section in the Unicode standard. For versions of Unicode beginning with the 2.1.8 update, only locale-insensitive case mappings should be applied. Beginning with version 3.2.0 (and likely future versions) of Unicode, precise mappings are described in default case operations, which are full case mappings in the absence of tailoring for particular languages and environments. Every lower-case character that does not have an upper-case correspondent, as well as every upper-case character, is included in the returned value in its original form.",
 			new SequenceType[] { new FunctionParameterSequenceType("arg", Type.STRING, Cardinality.ZERO_OR_ONE, "The text to be converted to all upper-case characters") },
 			new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the resulting upper-case text"));
 	
 	public final static FunctionSignature fnLowerCase =
 		new FunctionSignature(
-			new QName("lower-case", Function.BUILTIN_FUNCTION_NS),
+			new QName("lower-case", FnModule.NAMESPACE_URI),
 			"Returns the value of $arg after translating every character to its lower-case correspondent as defined in the appropriate case mappings section in the Unicode standard. For versions of Unicode beginning with the 2.1.8 update, only locale-insensitive case mappings should be applied. Beginning with version 3.2.0 (and likely future versions) of Unicode, precise mappings are described in default case operations, which are full case mappings in the absence of tailoring for particular languages and environments. Every upper-case character that does not have a lower-case correspondent, as well as every lower-case character, is included in the returned value in its original form.",
 			new SequenceType[] { new FunctionParameterSequenceType("arg", Type.STRING, Cardinality.ZERO_OR_ONE, "The text to be converted to all lower-case characters") },
 			new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the resulting lower-case text"));

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunXmlToJson.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunXmlToJson.java
@@ -74,7 +74,7 @@ public class FunXmlToJson extends BasicFunction {
     private static final FunctionParameterSequenceType FS_XML_TO_JSON_OPT_PARAM_NODE = optParam("node", Type.NODE, "The input node");
     private static final FunctionParameterSequenceType FS_XML_TO_JSON_OPT_PARAM_OPTIONS = optParam("options", Type.MAP, "The options map");
     static final FunctionSignature[] FS_XML_TO_JSON = functionSignatures(
-            new QName(FS_XML_TO_JSON_NAME, Function.BUILTIN_FUNCTION_NS),
+            new QName(FS_XML_TO_JSON_NAME, FnModule.NAMESPACE_URI),
             "Converts an XML tree (in w3c 'XML Representation of JSON' format) into a string conforming to the JSON grammar. Basic string (un)escaping.",
             returnsOpt(Type.STRING, "The JSON representation of the input node"),
             arities(
@@ -273,9 +273,9 @@ public class FunXmlToJson extends BasicFunction {
     }
 
     private void checkNamespace(final String namespaceUri) throws XPathException {
-        if (!Function.BUILTIN_FUNCTION_NS.equals(namespaceUri)) {
-//            throw new XPathException(this, ErrorCodes.FOJS0006, "Element was in namespace: " + namespaceUri + ", but should have been in namespace: " + Function.BUILTIN_FUNCTION_NS);
-            LOG.warn(ErrorCodes.FOJS0006.getErrorQName() + ": Element was in namespace: " + namespaceUri + ", but should have been in namespace: " + Function.BUILTIN_FUNCTION_NS);
+        if (!FnModule.NAMESPACE_URI.equals(namespaceUri)) {
+//            throw new XPathException(this, ErrorCodes.FOJS0006, "Element was in namespace: " + namespaceUri + ", but should have been in namespace: " + FnModule.NAMESPACE_URI);
+            LOG.warn(ErrorCodes.FOJS0006.getErrorQName() + ": Element was in namespace: " + namespaceUri + ", but should have been in namespace: " + FnModule.NAMESPACE_URI);
         }
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunZeroOrOne.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunZeroOrOne.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -46,7 +70,7 @@ public class FunZeroOrOne extends Function {
 
 	public final static FunctionSignature signature =
 		new FunctionSignature(
-			new QName("zero-or-one", Function.BUILTIN_FUNCTION_NS),
+			new QName("zero-or-one", FnModule.NAMESPACE_URI),
 			"Returns the argument sequence $arg if it contains zero or one items. Otherwise, " +
 			"raises an error.",
 			new SequenceType[] {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/LoadXQueryModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/LoadXQueryModule.java
@@ -74,7 +74,7 @@ import static org.exist.xquery.functions.map.MapType.newLinearMap;
 public class LoadXQueryModule extends BasicFunction {
 
     public final static FunctionSignature LOAD_XQUERY_MODULE_1 = new FunctionSignature(
-            new QName("load-xquery-module", Function.BUILTIN_FUNCTION_NS, FnModule.PREFIX),
+            new QName("load-xquery-module", FnModule.NAMESPACE_URI, FnModule.PREFIX),
             "Provides access to the public functions and global variables of a dynamically-loaded XQuery library module.",
             new SequenceType[] {
                     new FunctionParameterSequenceType("module-uri", Type.STRING,
@@ -95,7 +95,7 @@ public class LoadXQueryModule extends BasicFunction {
     );
 
     public final static FunctionSignature LOAD_XQUERY_MODULE_2 = new FunctionSignature(
-            new QName("load-xquery-module", Function.BUILTIN_FUNCTION_NS, FnModule.PREFIX),
+            new QName("load-xquery-module", FnModule.NAMESPACE_URI, FnModule.PREFIX),
             "Provides access to the public functions and global variables of a dynamically-loaded XQuery library module.",
             new SequenceType[] {
                     new FunctionParameterSequenceType("module-uri", Type.STRING,

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/ParsingFunctions.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/ParsingFunctions.java
@@ -83,12 +83,12 @@ public class ParsingFunctions extends BasicFunction {
 
 	public final static FunctionSignature[] signatures = {
 			new FunctionSignature(
-					new QName("parse-xml", Function.BUILTIN_FUNCTION_NS),
+					new QName("parse-xml", FnModule.NAMESPACE_URI),
 					"This function takes as input an XML document represented as a string,"
 							+ " and returns the document node at the root of an XDM tree representing the parsed document.",
 					new SequenceType[] { TO_BE_PARSED_PARAMETER }, RESULT_TYPE_FOR_PARSE_XML),
 			new FunctionSignature(
-					new QName("parse-xml-fragment", Function.BUILTIN_FUNCTION_NS),
+					new QName("parse-xml-fragment", FnModule.NAMESPACE_URI),
 					"This function takes as input an XML external entity represented as a string," +
 					"and returns the document node at the root of an XDM tree representing the parsed document fragment.",
 					new SequenceType[] { TO_BE_PARSED_PARAMETER }, RESULT_TYPE_FOR_PARSE_XML_FRAGMENT) };

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/QNameFunctions.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/QNameFunctions.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -47,7 +71,7 @@ public class QNameFunctions extends BasicFunction {
 
 	public final static FunctionSignature prefixFromQName =
 		new FunctionSignature(
-				new QName("prefix-from-QName", Function.BUILTIN_FUNCTION_NS),
+				new QName("prefix-from-QName", FnModule.NAMESPACE_URI),
 				"Returns an xs:NCName representing the prefix of $arg. If $arg is the empty " +
 				"sequence, returns the empty sequence.",
 				new SequenceType[] {
@@ -57,7 +81,7 @@ public class QNameFunctions extends BasicFunction {
 	
 	public final static FunctionSignature localNameFromQName =
 		new FunctionSignature(
-				new QName("local-name-from-QName", Function.BUILTIN_FUNCTION_NS),
+				new QName("local-name-from-QName", FnModule.NAMESPACE_URI),
 				"Returns an xs:NCName representing the local part of $arg. If $arg is the empty " +
 				"sequence, returns the empty sequence.",
 				new SequenceType[] {
@@ -67,7 +91,7 @@ public class QNameFunctions extends BasicFunction {
 	
 	public final static FunctionSignature namespaceURIFromQName =
 		new FunctionSignature(
-				new QName("namespace-uri-from-QName", Function.BUILTIN_FUNCTION_NS),
+				new QName("namespace-uri-from-QName", FnModule.NAMESPACE_URI),
 				"Returns the namespace URI for $arg. If $arg is the empty " +
 				"sequence, returns the empty sequence.",
 				new SequenceType[] {


### PR DESCRIPTION
Backport of https://github.com/evolvedbinary/elemental/pull/84

Previously XPath standard library functions did not show their namespace prefix in the profiling output. This PR makes the profiling output a little less confusing.