### PR TITLE
[6.x.x] Add namespace declarations to the JavaDoc comments

### DIFF
--- a/exist-core/src/main/java/org/exist/http/RESTServerParameter.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServerParameter.java
@@ -66,7 +66,8 @@ enum RESTServerParameter {
      * The value of this parameter used in the body of POST requests
      * has the following format:
      * 
-     * <exist:query start? = number
+     * <exist:query xmlns:exist="http://exist.sourceforge.net/NS/exist"
+     *  start? = number
      *  max? = number
      *  cache? = ("yes" | "no")
      *  session? = string
@@ -117,7 +118,7 @@ enum RESTServerParameter {
      *       exist:namespace?)
      *  </exist:qname>
      * 
-     *  <sx:sequence>
+     *  <sx:sequence xmlns:sx="http://exist-db.org/xquery/types/serialized">
      *      (sx:value+)
      *  </sx:sequence>
      * 


### PR DESCRIPTION
Backport of https://github.com/evolvedbinary/elemental/pull/66

The documentation for POSTing queries to the REST API says very little about how external variables should be bound. The comments in this file are helpful, but only if you know the namespace declarations!