### PR TITLE
[7.x.x] Fix an issue with de-serialization of Maps in the Configurator

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -773,6 +773,7 @@
                                 <include>src/test/java/org/exist/xquery/functions/fn/ParsingFunctionsTest.java</include>
                                 <include>src/test/java/org/exist/xquery/functions/fn/transform/ConvertTest.java</include>
                                 <include>src/test/java/org/exist/xquery/functions/fn/transform/FunTransformITTest.java</include>
+                                <include>src/test/java/org/exist/xquery/functions/securitymanager/SecurityManagerTestUtil.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/system/FunctionAvailable.java</include>
                                 <include>src/test/java/org/exist/xquery/functions/xmldb/XMLDBStoreTest.java</include>
                                 <include>src/test/java/org/exist/xquery/functions/xquery3/SerializeTest.java</include>
@@ -1147,6 +1148,11 @@
                                 <include>src/main/java/org/exist/xquery/functions/fn/transform/Transform.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/transform/TreeUtils.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/integer/WordPicture.java</include>
+                                <include>src/test/java/org/exist/xquery/functions/securitymanager/GetPermissionsTest.java</include>
+                                <include>src/test/java/org/exist/xquery/functions/securitymanager/GroupManagementFunctionRemoveGroupTest.java</include>
+                                <include>src/test/java/org/exist/xquery/functions/securitymanager/GroupMembershipFunctionRemoveGroupMemberTest.java</include>
+                                <include>src/test/java/org/exist/xquery/functions/securitymanager/PermissionsFunctionChmodTest.java</include>
+                                <include>src/test/java/org/exist/xquery/functions/securitymanager/PermissionsFunctionChownTest.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/system/GetUptime.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/system/Shutdown.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/system/SystemModule.java</include>
@@ -1682,6 +1688,12 @@
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/transform/TreeUtils.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/integer/WordPicture.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/map/MapType.java</exclude>
+                                <exclude>src/test/java/org/exist/xquery/functions/securitymanager/GetPermissionsTest.java</exclude>
+                                <exclude>src/test/java/org/exist/xquery/functions/securitymanager/GroupManagementFunctionRemoveGroupTest.java</exclude>
+                                <exclude>src/test/java/org/exist/xquery/functions/securitymanager/GroupMembershipFunctionRemoveGroupMemberTest.java</exclude>
+                                <exclude>src/test/java/org/exist/xquery/functions/securitymanager/PermissionsFunctionChmodTest.java</exclude>
+                                <exclude>src/test/java/org/exist/xquery/functions/securitymanager/PermissionsFunctionChownTest.java</exclude>
+                                <exclude>src/test/java/org/exist/xquery/functions/securitymanager/SecurityManagerTestUtil.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/session/AbstractSessionTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/session/AttributeTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/system/FunctionAvailable.java</exclude>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -773,6 +773,7 @@
                                 <include>src/test/java/org/exist/xquery/functions/fn/ParsingFunctionsTest.java</include>
                                 <include>src/test/java/org/exist/xquery/functions/fn/transform/ConvertTest.java</include>
                                 <include>src/test/java/org/exist/xquery/functions/fn/transform/FunTransformITTest.java</include>
+                                <include>src/test/java/org/exist/xquery/functions/securitymanager/AccountMetadataFunctionsTest.java</include>
                                 <include>src/test/java/org/exist/xquery/functions/securitymanager/SecurityManagerTestUtil.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/system/FunctionAvailable.java</include>
                                 <include>src/test/java/org/exist/xquery/functions/xmldb/XMLDBStoreTest.java</include>
@@ -1688,6 +1689,7 @@
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/transform/TreeUtils.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/integer/WordPicture.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/map/MapType.java</exclude>
+                                <exclude>src/test/java/org/exist/xquery/functions/securitymanager/AccountMetadataFunctionsTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/securitymanager/GetPermissionsTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/securitymanager/GroupManagementFunctionRemoveGroupTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/securitymanager/GroupMembershipFunctionRemoveGroupMemberTest.java</exclude>

--- a/exist-core/src/main/java/org/exist/config/ConfigurationImpl.java
+++ b/exist-core/src/main/java/org/exist/config/ConfigurationImpl.java
@@ -146,20 +146,20 @@ public class ConfigurationImpl implements Configuration {
         Node child = element.getFirstChild();
         while (child != null) {
             
-            if (child.getNodeType() == Node.ELEMENT_NODE) {
+            if (child instanceof Element) {
+                final Element childElement = (Element) child;
 
-                final String ns = child.getNamespaceURI();
-                if (ns != null && NS.equals(ns)) {
+                final String ns = childElement.getNamespaceURI();
+                if (NS.equals(ns)) {
                     
-                    String name = child.getLocalName();
-                    
+                    final String name = childElement.getLocalName();
+
                     if (names.contains(name)) {
-                        
-                        if (props.containsKey(name)) {
-                            props.remove(name);
-                        }
+                        props.remove(name);
                     } else {
-                        props.put(name, child.getTextContent());
+                        if (!childElement.hasAttribute("key")) {  // NOTE(AR) Skip Map entries
+                            props.put(name, childElement.getTextContent());
+                        }
                         names.add(name);
                     }
                 }

--- a/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/AccountMetadataFunctionsTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/AccountMetadataFunctionsTest.java
@@ -1,0 +1,142 @@
+/*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.securitymanager;
+
+import org.exist.EXistException;
+import org.exist.collections.Collection;
+import org.exist.security.AXSchemaType;
+import org.exist.security.PermissionDeniedException;
+import org.exist.security.SecurityManager;
+import org.exist.security.internal.RealmImpl;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQuery;
+import org.exist.xquery.value.Sequence;
+import org.junit.Rule;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
+import static org.exist.xquery.functions.securitymanager.SecurityManagerTestUtil.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class AccountMetadataFunctionsTest {
+
+    private static final String USER1_NAME = "User 1";
+    private static final String USER1_UID = "user1";
+    private static final String USER1_PWD = USER1_UID;
+
+    @Rule
+    public final ExistEmbeddedServer existWebServer = new ExistEmbeddedServer(true, true);
+
+    /**
+     * Creates a new user programmatically and tries to retrieve their name
+     * from the user's metadata.
+     *
+     * See: <a href="https://github.com/eXist-db/exist/issues/5904">[BUG] Security Account Metadata is lost</a>
+     */
+    @Test
+    public void getAccountNameMetadataViaObject() throws PermissionDeniedException, EXistException, XPathException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final SecurityManager sm = pool.getSecurityManager();
+
+        // 1. Create user
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            createUser(broker, sm, USER1_UID, USER1_PWD, Arrays.asList(Tuple(AXSchemaType.FULLNAME, USER1_NAME)));
+            transaction.commit();
+        }
+
+        // 2. Try and retrieve the user's metadata from XQuery
+        final String query =
+                "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
+                "sm:get-account-metadata('" + USER1_UID + "', xs:anyURI('http://axschema.org/namePerson'))";
+
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            final XQuery xquery = existWebServer.getBrokerPool().getXQueryService();
+            final Sequence result = xquery.execute(broker, query, null);
+            assertNotNull(result);
+            assertEquals(USER1_NAME, result.itemAt(0).getStringValue());
+        }
+    }
+
+    /**
+     * Creates a new user by storing their account document into the security collection
+     * and tries to retrieve their name from the user's metadata.
+     *
+     * See: <a href="https://github.com/eXist-db/exist/issues/5904">[BUG] Security Account Metadata is lost</a>
+     */
+    @Test
+    public void getAccountNameMetadataViaDocument() throws PermissionDeniedException, EXistException, XPathException, LockException, IOException, SAXException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final SecurityManager sm = pool.getSecurityManager();
+
+        final XmldbURI accountDocumentUri = XmldbURI.create(USER1_UID + ".xml");
+        final String accountDocument =
+                "<account xmlns=\"http://exist-db.org/Configuration\" id=\"15\">\n" +
+                "    <group name=\"nogroup\"/>\n" +
+                "    <password>{RIPEMD160}q2VXP75jMi+d8E5VAsEr6pD8V5w=</password>\n" +
+                "    <expired>false</expired>\n" +
+                "    <enabled>true</enabled>\n" +
+                "    <umask>022</umask>\n" +
+                "    <metadata key=\"http://axschema.org/namePerson\">" + USER1_NAME + "</metadata>\n" +
+                "    <name>" + USER1_UID + "</name>\n" +
+                "</account>";
+
+        // 1. Create user
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+
+            // /db/system/security/exist/accounts
+
+            final XmldbURI accountsCollectionUri = SecurityManager.SECURITY_COLLECTION_URI.append(RealmImpl.ID).append(SecurityManager.ACCOUNTS_COLLECTION_URI);
+
+            try (final Collection accountsCollection = broker.getCollection(accountsCollectionUri)) {
+                accountsCollection.storeDocument(transaction, broker, accountDocumentUri, new StringInputSource(accountDocument), MimeType.XML_TYPE);
+            }
+            transaction.commit();
+        }
+
+        // 2. Try and retrieve the user's metadata from XQuery
+        final String query =
+                "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
+                "sm:get-account-metadata('" + USER1_UID + "', xs:anyURI('http://axschema.org/namePerson'))";
+
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            final XQuery xquery = existWebServer.getBrokerPool().getXQueryService();
+            final Sequence result = xquery.execute(broker, query, null);
+            assertNotNull(result);
+            assertEquals(USER1_NAME, result.itemAt(0).getStringValue());
+        }
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/GetPermissionsTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/GetPermissionsTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *

--- a/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/GroupManagementFunctionRemoveGroupTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/GroupManagementFunctionRemoveGroupTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -21,23 +45,19 @@
  */
 package org.exist.xquery.functions.securitymanager;
 
-import com.evolvedbinary.j8fu.function.Runnable3E;
 import org.exist.EXistException;
 import org.exist.security.*;
 import org.exist.security.SecurityManager;
-import org.exist.security.internal.aider.GroupAider;
-import org.exist.security.internal.aider.UserAider;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.xquery.XPathException;
-import org.exist.xquery.XQuery;
-import org.exist.xquery.value.Sequence;
 import org.junit.*;
 
 import java.util.Optional;
 
+import static org.exist.xquery.functions.securitymanager.SecurityManagerTestUtil.*;
 import static org.junit.Assert.*;
 
 public class GroupManagementFunctionRemoveGroupTest {
@@ -55,17 +75,23 @@ public class GroupManagementFunctionRemoveGroupTest {
 
     @Test(expected = PermissionDeniedException.class)
     public void cannotDeleteDbaGroup() throws XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> xqueryRemoveGroup(SecurityManager.DBA_GROUP));
+        extractPermissionDenied(() -> {
+            xqueryRemoveGroup(existWebServer.getBrokerPool(), SecurityManager.DBA_GROUP);
+        });
     }
 
     @Test(expected = PermissionDeniedException.class)
     public void cannotDeleteGuestGroup() throws XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> xqueryRemoveGroup(SecurityManager.GUEST_GROUP));
+        extractPermissionDenied(() -> {
+            xqueryRemoveGroup(existWebServer.getBrokerPool(), SecurityManager.GUEST_GROUP);
+        });
     }
 
     @Test(expected = PermissionDeniedException.class)
     public void cannotDeleteUnknownGroup() throws XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> xqueryRemoveGroup(SecurityManager.UNKNOWN_GROUP));
+        extractPermissionDenied(() -> {
+            xqueryRemoveGroup(existWebServer.getBrokerPool(), SecurityManager.UNKNOWN_GROUP);
+        });
     }
 
     @Test
@@ -256,71 +282,6 @@ public class GroupManagementFunctionRemoveGroupTest {
             sm.deleteGroup(primaryGroup);
 
             transaction.commit();
-        }
-    }
-
-    private static Account createUser(final DBBroker broker, final SecurityManager sm, final String username, final String password) throws PermissionDeniedException, EXistException {
-        Group userGroup = new GroupAider(username);
-        sm.addGroup(broker, userGroup);
-        final Account user = new UserAider(username);
-        user.setPassword(password);
-        user.setPrimaryGroup(userGroup);
-        sm.addAccount(user);
-
-        userGroup = sm.getGroup(username);
-        userGroup.addManager(sm.getAccount(username));
-        sm.updateGroup(userGroup);
-
-        return user;
-    }
-
-    private static Group createGroup(final DBBroker broker, final SecurityManager sm, final String groupName) throws PermissionDeniedException, EXistException {
-        final Group otherGroup = new GroupAider(groupName);
-        return sm.addGroup(broker, otherGroup);
-    }
-
-    private static void addUserToGroup(final SecurityManager sm, final Account user, final Group group) throws PermissionDeniedException, EXistException {
-        user.addGroup(group.getName());
-        sm.updateAccount(user);
-    }
-
-    private static void setPrimaryGroup(final SecurityManager sm, final Account user, final Group group) throws PermissionDeniedException, EXistException {
-        user.setPrimaryGroup(group);
-        sm.updateAccount(user);
-    }
-
-    private static void removeUser(final SecurityManager sm, final String username) throws PermissionDeniedException, EXistException {
-        sm.deleteAccount(username);
-        removeGroup(sm, username);
-    }
-
-    private static void removeGroup(final SecurityManager sm, final String groupname) throws PermissionDeniedException, EXistException {
-        sm.deleteGroup(groupname);
-    }
-
-    private Sequence xqueryRemoveGroup(final String groupname) throws EXistException, PermissionDeniedException, XPathException {
-            final BrokerPool pool = existWebServer.getBrokerPool();
-
-        final String query =
-                "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
-                        "sm:remove-group('" + groupname + "')";
-
-        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-            final XQuery xquery = existWebServer.getBrokerPool().getXQueryService();
-            final Sequence result = xquery.execute(broker, query, null);
-            return result;
-        }
-    }
-
-    private static void extractPermissionDenied(final Runnable3E<XPathException, PermissionDeniedException, EXistException> runnable) throws XPathException, PermissionDeniedException, EXistException {
-        try {
-            runnable.run();
-        } catch (final XPathException e) {
-            if (e.getCause() != null && e.getCause() instanceof PermissionDeniedException) {
-                throw (PermissionDeniedException)e.getCause();
-            } else {
-                throw e;
-            }
         }
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/GroupMembershipFunctionRemoveGroupMemberTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/GroupMembershipFunctionRemoveGroupMemberTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -21,26 +45,22 @@
  */
 package org.exist.xquery.functions.securitymanager;
 
-import com.evolvedbinary.j8fu.function.Runnable3E;
 import org.exist.EXistException;
 import org.exist.TestUtils;
 import org.exist.security.*;
 import org.exist.security.SecurityManager;
-import org.exist.security.internal.aider.GroupAider;
-import org.exist.security.internal.aider.UserAider;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.xquery.XPathException;
-import org.exist.xquery.XQuery;
-import org.exist.xquery.value.Sequence;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.Optional;
 
+import static org.exist.xquery.functions.securitymanager.SecurityManagerTestUtil.*;
 import static org.junit.Assert.*;
 
 public class GroupMembershipFunctionRemoveGroupMemberTest {
@@ -59,9 +79,9 @@ public class GroupMembershipFunctionRemoveGroupMemberTest {
         final BrokerPool pool = existWebServer.getBrokerPool();
         final Subject owner = pool.getSecurityManager().authenticate(USER1_NAME, USER1_NAME);
         extractPermissionDenied(() -> {
-            xqueryRemoveUserFromGroup(USER1_NAME, OTHER_GROUP2_NAME, Optional.of(owner));
-            xqueryRemoveUserFromGroup(USER1_NAME, OTHER_GROUP1_NAME, Optional.of(owner));
-            xqueryRemoveUserFromGroup(USER1_NAME, USER1_NAME, Optional.of(owner));
+            xqueryRemoveUserFromGroup(pool, USER1_NAME, OTHER_GROUP2_NAME, Optional.of(owner));
+            xqueryRemoveUserFromGroup(pool, USER1_NAME, OTHER_GROUP1_NAME, Optional.of(owner));
+            xqueryRemoveUserFromGroup(pool, USER1_NAME, USER1_NAME, Optional.of(owner));
         });
     }
 
@@ -70,9 +90,9 @@ public class GroupMembershipFunctionRemoveGroupMemberTest {
         final BrokerPool pool = existWebServer.getBrokerPool();
         final Subject admin = pool.getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
         extractPermissionDenied(() -> {
-            xqueryRemoveUserFromGroup(USER1_NAME, OTHER_GROUP2_NAME, Optional.of(admin));
-            xqueryRemoveUserFromGroup(USER1_NAME, OTHER_GROUP1_NAME, Optional.of(admin));
-            xqueryRemoveUserFromGroup(USER1_NAME, USER1_NAME, Optional.of(admin));
+            xqueryRemoveUserFromGroup(pool, USER1_NAME, OTHER_GROUP2_NAME, Optional.of(admin));
+            xqueryRemoveUserFromGroup(pool, USER1_NAME, OTHER_GROUP1_NAME, Optional.of(admin));
+            xqueryRemoveUserFromGroup(pool, USER1_NAME, USER1_NAME, Optional.of(admin));
         });
     }
 
@@ -88,11 +108,11 @@ public class GroupMembershipFunctionRemoveGroupMemberTest {
 
             final Group otherGroup1 = createGroup(broker, sm, OTHER_GROUP1_NAME);
             addUserToGroup(sm, user1, otherGroup1);
-            addUserAsGroupManager(USER1_NAME, OTHER_GROUP1_NAME);
+            xqueryAddUserAsGroupManager(pool, USER1_NAME, OTHER_GROUP1_NAME);
 
             final Group otherGroup2 = createGroup(broker, sm, OTHER_GROUP2_NAME);
             addUserToGroup(sm, user1, otherGroup2);
-            addUserAsGroupManager(USER1_NAME, OTHER_GROUP2_NAME);
+            xqueryAddUserAsGroupManager(pool, USER1_NAME, OTHER_GROUP2_NAME);
 
             transaction.commit();
         }
@@ -108,77 +128,6 @@ public class GroupMembershipFunctionRemoveGroupMemberTest {
                 assertNotNull(sm.getGroup(user1Group));
             }
             transaction.commit();
-        }
-    }
-
-    private Sequence xqueryRemoveUserFromGroup(final String username, final String groupname) throws XPathException, PermissionDeniedException, EXistException {
-        final BrokerPool pool = existWebServer.getBrokerPool();
-        final Optional<Subject> asUser = Optional.of(pool.getSecurityManager().getSystemSubject());
-        return xqueryRemoveUserFromGroup(username, groupname, asUser);
-    }
-
-    private Sequence xqueryRemoveUserFromGroup(final String username, final String groupname, final Optional<Subject> asUser) throws EXistException, PermissionDeniedException, XPathException {
-        final BrokerPool pool = existWebServer.getBrokerPool();
-
-        final String query =
-                "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
-                        "sm:remove-group-member('" + groupname + "', '" + username + "')";
-
-        try (final DBBroker broker = pool.get(asUser)) {
-            final XQuery xquery = existWebServer.getBrokerPool().getXQueryService();
-            final Sequence result = xquery.execute(broker, query, null);
-            return result;
-        }
-    }
-
-    private Sequence addUserAsGroupManager(final String username, final String groupname) throws EXistException, PermissionDeniedException, XPathException {
-        final BrokerPool pool = existWebServer.getBrokerPool();
-
-        final String query =
-                "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
-                        "sm:add-group-manager('" + groupname + "', '" + username + "')";
-
-        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-            final XQuery xquery = existWebServer.getBrokerPool().getXQueryService();
-            final Sequence result = xquery.execute(broker, query, null);
-            return result;
-        }
-    }
-
-    private static Account createUser(final DBBroker broker, final SecurityManager sm, final String username, final String password) throws PermissionDeniedException, EXistException {
-        Group userGroup = new GroupAider(username);
-        sm.addGroup(broker, userGroup);
-        final Account user = new UserAider(username);
-        user.setPassword(password);
-        user.setPrimaryGroup(userGroup);
-        sm.addAccount(user);
-
-        userGroup = sm.getGroup(username);
-        userGroup.addManager(sm.getAccount(username));
-        sm.updateGroup(userGroup);
-
-        return user;
-    }
-
-    private static Group createGroup(final DBBroker broker, final SecurityManager sm, final String groupName) throws PermissionDeniedException, EXistException {
-        final Group otherGroup = new GroupAider(groupName);
-        return sm.addGroup(broker, otherGroup);
-    }
-
-    private static void addUserToGroup(final SecurityManager sm, final Account user, final Group group) throws PermissionDeniedException, EXistException {
-        user.addGroup(group.getName());
-        sm.updateAccount(user);
-    }
-
-    private static void extractPermissionDenied(final Runnable3E<XPathException, PermissionDeniedException, EXistException> runnable) throws XPathException, PermissionDeniedException, EXistException {
-        try {
-            runnable.run();
-        } catch (final XPathException e) {
-            if (e.getCause() != null && e.getCause() instanceof PermissionDeniedException) {
-                throw (PermissionDeniedException)e.getCause();
-            } else {
-                throw e;
-            }
         }
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/PermissionsFunctionChmodTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/PermissionsFunctionChmodTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -19,20 +43,15 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-
 package org.exist.xquery.functions.securitymanager;
 
-import com.evolvedbinary.j8fu.function.Runnable4E;
 import org.exist.EXistException;
 import org.exist.TestUtils;
 import org.exist.collections.Collection;
 import org.exist.collections.triggers.TriggerException;
-import org.exist.dom.persistent.DocumentImpl;
-import org.exist.dom.persistent.LockedDocument;
 import org.exist.security.*;
 import org.exist.security.SecurityManager;
 import org.exist.security.internal.aider.GroupAider;
-import org.exist.security.internal.aider.UserAider;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.lock.Lock;
@@ -44,8 +63,6 @@ import org.exist.util.MimeType;
 import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
-import org.exist.xquery.XQuery;
-import org.exist.xquery.value.Sequence;
 import org.junit.*;
 import org.xml.sax.SAXException;
 
@@ -53,9 +70,7 @@ import java.io.IOException;
 import java.util.Optional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.exist.xquery.functions.securitymanager.SecurityManagerTestUtil.*;
 
 public class PermissionsFunctionChmodTest {
 
@@ -83,148 +98,142 @@ public class PermissionsFunctionChmodTest {
 
     @Test
     public void changeDocumentModeAsDBA() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
-        changeMode(adminUser, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), RWXRWXRWX);
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final Subject adminUser = pool.getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        xqueryChangeMode(pool, adminUser, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), RWXRWXRWX);
     }
 
     @Test
     public void changeCollectionModeAsDBA() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
-        changeMode(adminUser, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), RWXRWXRWX);
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final Subject adminUser = pool.getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        xqueryChangeMode(pool, adminUser, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), RWXRWXRWX);
     }
 
     @Test
     public void changeDocumentModeAsNonDBAOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
-        changeMode(user1, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), RWXRWXRWX);
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final Subject user1 = pool.getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        xqueryChangeMode(pool, user1, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), RWXRWXRWX);
     }
 
     @Test
     public void changeCollectionModeAsNonDBAOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
-        changeMode(user1, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), RWXRWXRWX);
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final Subject user1 = pool.getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        xqueryChangeMode(pool, user1, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), RWXRWXRWX);
     }
 
     @Test(expected=PermissionDeniedException.class)
     public void changeDocumentModeAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final Subject user2 = pool.getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
         extractPermissionDenied(() ->
-                changeMode(user2, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), RWXRWXRWX)
+            xqueryChangeMode(pool, user2, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), RWXRWXRWX)
         );
     }
 
     @Test(expected=PermissionDeniedException.class)
     public void changeCollectionModeAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final Subject user2 = pool.getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
         extractPermissionDenied(() ->
-            changeMode(user2, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), RWXRWXRWX)
+            xqueryChangeMode(pool, user2, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), RWXRWXRWX)
         );
     }
 
     @Test
-    public void changeDocumentModeAsDBA_preservesSetGid() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException { ;
-        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+    public void changeDocumentModeAsDBA_preservesSetGid() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final Subject adminUser = pool.getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
 
         // check the setGid bit is set before we begin
-        assertDocumentSetGid(adminUser, TestConstants.TEST_COLLECTION_URI.append(USER1_XQUERY1), IS_SET);
+        assertDocumentSetGid(pool, adminUser, TestConstants.TEST_COLLECTION_URI.append(USER1_XQUERY1), IS_SET);
 
         // change the mode
-        changeMode(adminUser, TestConstants.TEST_COLLECTION_URI.append(USER1_XQUERY1), RWXRWS__);
+        xqueryChangeMode(pool, adminUser, TestConstants.TEST_COLLECTION_URI.append(USER1_XQUERY1), RWXRWS__);
 
         // check the setGid bit still set
-        assertDocumentSetGid(adminUser, TestConstants.TEST_COLLECTION_URI.append(USER1_XQUERY1), IS_SET);
+        assertDocumentSetGid(pool, adminUser, TestConstants.TEST_COLLECTION_URI.append(USER1_XQUERY1), IS_SET);
     }
 
     @Test
     public void changeCollectionModeAsDBA_preservesSetGid() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
-        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final Subject adminUser = pool.getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
 
         // check the setGid bit is set before we begin
-        assertCollectionSetGid(adminUser, TestConstants.TEST_COLLECTION_URI.append(USER1_COL2), IS_SET);
+        assertCollectionSetGid(pool, adminUser, TestConstants.TEST_COLLECTION_URI.append(USER1_COL2), IS_SET);
 
         // change the mode
-        changeMode(adminUser, TestConstants.TEST_COLLECTION_URI.append(USER1_COL2), RWXRWS__);
+        xqueryChangeMode(pool, adminUser, TestConstants.TEST_COLLECTION_URI.append(USER1_COL2), RWXRWS__);
 
         // check the setGid bit still set
-        assertCollectionSetGid(adminUser, TestConstants.TEST_COLLECTION_URI.append(USER1_COL2), IS_SET);
+        assertCollectionSetGid(pool, adminUser, TestConstants.TEST_COLLECTION_URI.append(USER1_COL2), IS_SET);
     }
 
     @Test
     public void changeDocumentModeAsNonDBAOwner_preservesSetGid() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
-        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final Subject user1 = pool.getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
 
         // check the setGid bit is set before we begin
-        assertDocumentSetGid(user1, TestConstants.TEST_COLLECTION_URI.append(USER1_XQUERY1), IS_SET);
+        assertDocumentSetGid(pool, user1, TestConstants.TEST_COLLECTION_URI.append(USER1_XQUERY1), IS_SET);
 
         // change the mode
-        changeMode(user1, TestConstants.TEST_COLLECTION_URI.append(USER1_XQUERY1), RWXRWS__);
+        xqueryChangeMode(pool, user1, TestConstants.TEST_COLLECTION_URI.append(USER1_XQUERY1), RWXRWS__);
 
         // check the setGid bit still set
-        assertDocumentSetGid(user1, TestConstants.TEST_COLLECTION_URI.append(USER1_XQUERY1), IS_SET);
+        assertDocumentSetGid(pool, user1, TestConstants.TEST_COLLECTION_URI.append(USER1_XQUERY1), IS_SET);
     }
 
     @Test
     public void changeCollectionModeAsNonDBAOwner_preservesSetGid() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
-        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final Subject user1 = pool.getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
 
         // check the setGid bit is set before we begin
-        assertCollectionSetGid(user1, TestConstants.TEST_COLLECTION_URI.append(USER1_COL2), IS_SET);
+        assertCollectionSetGid(pool, user1, TestConstants.TEST_COLLECTION_URI.append(USER1_COL2), IS_SET);
 
         // change the mode
-        changeMode(user1, TestConstants.TEST_COLLECTION_URI.append(USER1_COL2), RWXRWS__);
+        xqueryChangeMode(pool, user1, TestConstants.TEST_COLLECTION_URI.append(USER1_COL2), RWXRWS__);
 
         // check the setGid bit still set
-        assertCollectionSetGid(user1, TestConstants.TEST_COLLECTION_URI.append(USER1_COL2), IS_SET);
+        assertCollectionSetGid(pool, user1, TestConstants.TEST_COLLECTION_URI.append(USER1_COL2), IS_SET);
     }
 
     @Test(expected=PermissionDeniedException.class)
     public void changeDocumentModeAsNonOwner_clearsSetGid() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
-        final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final Subject user2 = pool.getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
 
         // check the setGid bit is set before we begin
-        assertDocumentSetGid(user2, TestConstants.TEST_COLLECTION_URI.append(USER1_XQUERY1), IS_SET);
+        assertDocumentSetGid(pool, user2, TestConstants.TEST_COLLECTION_URI.append(USER1_XQUERY1), IS_SET);
 
         // change the mode
         extractPermissionDenied(() ->
-            changeMode(user2, TestConstants.TEST_COLLECTION_URI.append(USER1_XQUERY1), RWXRWSRWX)
+            xqueryChangeMode(pool, user2, TestConstants.TEST_COLLECTION_URI.append(USER1_XQUERY1), RWXRWSRWX)
         );
 
         // check the setGid bit still set
-        assertDocumentSetGid(user2, TestConstants.TEST_COLLECTION_URI.append(USER1_XQUERY1), NOT_SET);
+        assertDocumentSetGid(pool, user2, TestConstants.TEST_COLLECTION_URI.append(USER1_XQUERY1), NOT_SET);
     }
 
     @Test(expected=PermissionDeniedException.class)
     public void changeCollectionModeAsNonOwner_clearsSetGid() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
-        final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final Subject user2 = pool.getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
 
         // check the setGid bit is set before we begin
-        assertCollectionSetGid(user2, TestConstants.TEST_COLLECTION_URI.append(USER1_COL2), IS_SET);
+        assertCollectionSetGid(pool, user2, TestConstants.TEST_COLLECTION_URI.append(USER1_COL2), IS_SET);
 
         // change the mode
         extractPermissionDenied(() ->
-                changeMode(user2, TestConstants.TEST_COLLECTION_URI.append(USER1_COL2), RWXRWSRWX)
+            xqueryChangeMode(pool, user2, TestConstants.TEST_COLLECTION_URI.append(USER1_COL2), RWXRWSRWX)
         );
 
         // check the setGid bit still set
-        assertCollectionSetGid(user2, TestConstants.TEST_COLLECTION_URI.append(USER1_COL2), NOT_SET);
-    }
-
-    private void changeMode(final Subject execAsUser, final XmldbURI uri, final String newMode) throws EXistException, PermissionDeniedException, XPathException {
-        final BrokerPool pool = existWebServer.getBrokerPool();
-
-        final String query =
-                "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
-                        "sm:chmod(xs:anyURI('" + uri.getRawCollectionPath() + "'), '" + newMode + "'),\n" +
-                        "sm:get-permissions(xs:anyURI('" + uri.getRawCollectionPath() + "'))/sm:permission/string(@mode)";
-
-        try (final DBBroker broker = pool.get(Optional.of(execAsUser))) {
-
-            final XQuery xquery = existWebServer.getBrokerPool().getXQueryService();
-            final Sequence result = xquery.execute(broker, query, null);
-
-            assertEquals(1, result.getItemCount());
-            assertEquals(newMode, result.itemAt(0).getStringValue());
-        }
+        assertCollectionSetGid(pool, user2, TestConstants.TEST_COLLECTION_URI.append(USER1_COL2), NOT_SET);
     }
 
     @BeforeClass
@@ -275,7 +284,7 @@ public class PermissionsFunctionChmodTest {
 
             final String xquery1 =
                     "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
-                            "sm:id()";
+                    "sm:id()";
             broker.storeDocument(transaction, USER1_XQUERY1, new StringInputSource(xquery1.getBytes(UTF_8)), MimeType.XQUERY_TYPE, collection);
             PermissionFactory.chmod_str(broker, transaction, collection.getURI().append(USER1_XQUERY1), Optional.of("u+s,g+s"), Optional.empty());
 
@@ -311,75 +320,5 @@ public class PermissionsFunctionChmodTest {
 
             transaction.commit();
         }
-    }
-
-    private static void assertDocumentSetGid(final Subject execAsUser, final XmldbURI uri, final boolean isSet) throws EXistException, PermissionDeniedException {
-        final BrokerPool pool = existWebServer.getBrokerPool();
-        try (final DBBroker broker = pool.get(Optional.of(execAsUser));
-                final LockedDocument lockedDoc = broker.getXMLResource(uri, Lock.LockMode.READ_LOCK)) {
-
-            final DocumentImpl doc = lockedDoc.getDocument();
-            if (isSet) {
-                assertTrue(doc.getPermissions().isSetGid());
-            } else {
-                assertFalse(doc.getPermissions().isSetGid());
-            }
-        }
-    }
-
-    private static void assertCollectionSetGid(final Subject execAsUser, final XmldbURI uri, final boolean isSet) throws EXistException, PermissionDeniedException {
-        final BrokerPool pool = existWebServer.getBrokerPool();
-        try (final DBBroker broker = pool.get(Optional.of(execAsUser))) {
-            try (final Collection col = broker.openCollection(uri, Lock.LockMode.READ_LOCK)) {
-                if (isSet) {
-                    assertTrue(col.getPermissions().isSetGid());
-                } else {
-                    assertFalse(col.getPermissions().isSetGid());
-                }
-            }
-        }
-    }
-
-    private static void extractPermissionDenied(final Runnable4E<AuthenticationException, XPathException, PermissionDeniedException, EXistException> runnable) throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        try {
-            runnable.run();
-        } catch (final XPathException e) {
-            if (e.getCause() != null && e.getCause() instanceof PermissionDeniedException) {
-                throw (PermissionDeniedException)e.getCause();
-            } else {
-                throw e;
-            }
-        }
-    }
-
-    private static void removeDocument(final DBBroker broker, final Txn transaction, final XmldbURI documentUri) throws PermissionDeniedException, LockException, IOException, TriggerException {
-        try (final Collection collection = broker.openCollection(documentUri.removeLastSegment(), Lock.LockMode.WRITE_LOCK)) {
-            collection.removeXMLResource(transaction, broker, documentUri.lastSegment());
-            broker.saveCollection(transaction, collection);
-        }
-    }
-
-    private static void removeCollection(final DBBroker broker, final Txn transaction, final XmldbURI collectionUri) throws PermissionDeniedException, IOException, TriggerException {
-        try (final Collection collection = broker.openCollection(collectionUri, Lock.LockMode.WRITE_LOCK)) {
-            broker.removeCollection(transaction, collection);
-        }
-    }
-
-    private static void createUser(final DBBroker broker, final SecurityManager sm, final String username, final String password) throws PermissionDeniedException, EXistException {
-        Group userGroup = new GroupAider(username);
-        sm.addGroup(broker, userGroup);
-        final Account user = new UserAider(username);
-        user.setPassword(password);
-        user.setPrimaryGroup(userGroup);
-        sm.addAccount(user);
-
-        userGroup = sm.getGroup(username);
-        userGroup.addManager(sm.getAccount(username));
-        sm.updateGroup(userGroup);
-    }
-
-    private static void removeUser(final SecurityManager sm, final String username) throws PermissionDeniedException, EXistException {
-        sm.deleteAccount(username);
-        sm.deleteGroup(username);
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/PermissionsFunctionChownTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/PermissionsFunctionChownTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -19,10 +43,8 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-
 package org.exist.xquery.functions.securitymanager;
 
-import com.evolvedbinary.j8fu.function.Runnable4E;
 import com.evolvedbinary.j8fu.tuple.Tuple2;
 import org.exist.EXistException;
 import org.exist.TestUtils;
@@ -33,7 +55,6 @@ import org.exist.dom.persistent.LockedDocument;
 import org.exist.security.*;
 import org.exist.security.SecurityManager;
 import org.exist.security.internal.aider.GroupAider;
-import org.exist.security.internal.aider.UserAider;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.lock.Lock;
@@ -56,6 +77,7 @@ import java.util.Optional;
 
 import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.exist.xquery.functions.securitymanager.SecurityManagerTestUtil.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -251,7 +273,7 @@ public class PermissionsFunctionChownTest {
      */
     @Test(expected=PermissionDeniedException.class)
     public void changeDocumentOwnerAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
             changeOwner(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USER2_NAME);
         });
@@ -273,7 +295,7 @@ public class PermissionsFunctionChownTest {
      */
     @Test(expected=PermissionDeniedException.class)
     public void changeCollectionOwnerAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
             changeOwner(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USER2_NAME);
         });
@@ -295,7 +317,7 @@ public class PermissionsFunctionChownTest {
      */
     @Test(expected=PermissionDeniedException.class)
     public void changeDocumentOwnerAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeOwner(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USER2_NAME);
         });
@@ -307,7 +329,7 @@ public class PermissionsFunctionChownTest {
      */
     @Test(expected=PermissionDeniedException.class)
     public void changeDocumentOwnerAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeOwner(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USER2_NAME);
         });
@@ -319,7 +341,7 @@ public class PermissionsFunctionChownTest {
      */
     @Test(expected=PermissionDeniedException.class)
     public void changeCollectionOwnerAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeOwner(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USER2_NAME);
         });
@@ -331,7 +353,7 @@ public class PermissionsFunctionChownTest {
      */
     @Test(expected=PermissionDeniedException.class)
     public void changeCollectionOwnerAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeOwner(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USER2_NAME);
         });
@@ -663,7 +685,7 @@ public class PermissionsFunctionChownTest {
      */
     @Test(expected=PermissionDeniedException.class)
     public void changeDocumentGroupAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
             changeGroup(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USER2_NAME);
         });
@@ -685,7 +707,7 @@ public class PermissionsFunctionChownTest {
      */
     @Test(expected=PermissionDeniedException.class)
     public void changeCollectionGroupAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
             changeGroup(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USER2_NAME);
         });
@@ -707,7 +729,7 @@ public class PermissionsFunctionChownTest {
      */
     @Test(expected=PermissionDeniedException.class)
     public void changeDocumentGroupAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeGroup(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USER2_NAME);
         });
@@ -719,7 +741,7 @@ public class PermissionsFunctionChownTest {
      */
     @Test(expected=PermissionDeniedException.class)
     public void changeDocumentGroupAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeGroup(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USER2_NAME);
         });
@@ -731,7 +753,7 @@ public class PermissionsFunctionChownTest {
      */
     @Test(expected=PermissionDeniedException.class)
     public void changeCollectionGroupAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeGroup(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USER2_NAME);
         });
@@ -743,7 +765,7 @@ public class PermissionsFunctionChownTest {
      */
     @Test(expected=PermissionDeniedException.class)
     public void changeCollectionGroupAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeGroup(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USER2_NAME);
         });
@@ -795,7 +817,7 @@ public class PermissionsFunctionChownTest {
      */
     @Test(expected=PermissionDeniedException.class)
     public void changeDocumentGroupToMemberGroupAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeGroup(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), OTHER_GROUP_NAME);
         });
@@ -819,7 +841,7 @@ public class PermissionsFunctionChownTest {
      */
     @Test(expected=PermissionDeniedException.class)
     public void changeCollectionGroupToMemberGroupAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeGroup(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), OTHER_GROUP_NAME);
         });
@@ -1048,7 +1070,7 @@ public class PermissionsFunctionChownTest {
      */
     @Test(expected=PermissionDeniedException.class)
     public void changeCollectionOwnerToRemovedUserAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
             changeOwner(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USERRM_NAME, USER1_NAME);
         });
@@ -1056,7 +1078,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void changeCollectionOwnerToNonExistentAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeOwner(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), "no-such-user", USER1_NAME);
         });
@@ -1064,7 +1086,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void changeCollectionOwnerToNonExistentAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeOwner(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), "no-such-user", USER1_NAME);
         });
@@ -1072,7 +1094,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void changeCollectionOwnerToRemovedUserAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeOwner(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USERRM_NAME, USER1_NAME);
         });
@@ -1080,7 +1102,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void changeCollectionOwnerToRemovedUserAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeOwner(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USERRM_NAME, USER1_NAME);
         });
@@ -1136,7 +1158,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void changeCollectionGroupToNonExistentAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeGroup(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), "no-such-group", USER1_NAME);
         });
@@ -1144,7 +1166,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void changeCollectionGroupToNonExistentAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeGroup(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), "no-such-group", USER1_NAME);
         });
@@ -1152,7 +1174,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void changeCollectionGroupToRemovedGroupAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeGroup(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USERRM_NAME, USER1_NAME);
         });
@@ -1160,7 +1182,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void changeCollectionGroupToRemovedGroupAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeGroup(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USERRM_NAME, USER1_NAME);
         });
@@ -1202,7 +1224,7 @@ public class PermissionsFunctionChownTest {
      */
     @Test(expected=PermissionDeniedException.class)
     public void changeDocumentOwnerToNonExistentAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
             changeOwner(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), "no-such-user", USER1_NAME);
         });
@@ -1220,7 +1242,7 @@ public class PermissionsFunctionChownTest {
      */
     @Test(expected=PermissionDeniedException.class)
     public void changeDocumentOwnerToRemovedUserAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
             changeOwner(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USERRM_NAME, USER1_NAME);
         });
@@ -1228,7 +1250,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void changeDocumentOwnerToNonExistentAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeOwner(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), "no-such-user", USER1_NAME);
         });
@@ -1236,7 +1258,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void changeDocumentOwnerToNonExistentAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeOwner(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), "no-such-user", USER1_NAME);
         });
@@ -1244,7 +1266,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void changeDocumentOwnerToRemovedUserAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeOwner(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USERRM_NAME, USER1_NAME);
         });
@@ -1252,7 +1274,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void changeDocumentOwnerToRemovedUserAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeOwner(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USERRM_NAME, USER1_NAME);
         });
@@ -1308,7 +1330,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void changeDocumentGroupToNonExistentAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeGroup(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), "no-such-group", USER1_NAME);
         });
@@ -1316,7 +1338,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void changeDocumentGroupToNonExistentAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeGroup(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), "no-such-group", USER1_NAME);
         });
@@ -1324,7 +1346,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void changeDocumentGroupToRemovedGroupAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeGroup(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USERRM_NAME, USER1_NAME);
         });
@@ -1332,7 +1354,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void changeDocumentGroupToRemovedGroupAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeGroup(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USERRM_NAME, USER1_NAME);
         });
@@ -1391,7 +1413,7 @@ public class PermissionsFunctionChownTest {
      */
     @Test(expected=PermissionDeniedException.class)
     public void ChangeCollectionOwnerAndGroupToRemovedAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
             changeOwner(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), Tuple(USERRM_NAME, USERRM_NAME), Tuple(USER1_NAME, USER1_NAME));
         });
@@ -1399,7 +1421,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void ChangeCollectionOwnerAndGroupToNonExistentAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeOwner(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), Tuple("no-such-user", "no-such-group"), Tuple(USER1_NAME, USER1_NAME));
         });
@@ -1407,7 +1429,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void ChangeCollectionOwnerAndGroupToNonExistentAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeOwner(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), Tuple("no-such-user", "no-such-group"), Tuple(USER1_NAME, USER1_NAME));
         });
@@ -1415,7 +1437,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void ChangeCollectionOwnerAndGroupToRemovedAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeOwner(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), Tuple(USERRM_NAME, USERRM_NAME), Tuple(USER1_NAME, USER1_NAME));
         });
@@ -1423,7 +1445,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void ChangeCollectionOwnerAndGroupToRemovedAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeOwner(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), Tuple(USERRM_NAME, USERRM_NAME), Tuple(USER1_NAME, USER1_NAME));
         });
@@ -1465,7 +1487,7 @@ public class PermissionsFunctionChownTest {
      */
     @Test(expected=PermissionDeniedException.class)
     public void ChangeDocumentOwnerAndGroupToNonExistentAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
             changeOwner(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), Tuple("no-such-user", "no-such-group"), Tuple(USER1_NAME, USER1_NAME));
         });
@@ -1483,7 +1505,7 @@ public class PermissionsFunctionChownTest {
      */
     @Test(expected=PermissionDeniedException.class)
     public void ChangeDocumentOwnerAndGroupToRemovedAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
             changeOwner(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), Tuple(USERRM_NAME, USERRM_NAME), Tuple(USER1_NAME, USER1_NAME));
         });
@@ -1491,7 +1513,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void ChangeDocumentOwnerAndGroupToNonExistentAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeOwner(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), Tuple("no-such-user", "no-such-group"), Tuple(USER1_NAME, USER1_NAME));
         });
@@ -1499,7 +1521,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void ChangeDocumentOwnerAndGroupToNonExistentAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeOwner(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), Tuple("no-such-user", "no-such-group"), Tuple(USER1_NAME, USER1_NAME));
         });
@@ -1507,7 +1529,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void ChangeDocumentOwnerAndGroupToRemovedAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeOwner(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), Tuple(USERRM_NAME, USERRM_NAME), Tuple(USER1_NAME, USER1_NAME));
         });
@@ -1515,7 +1537,7 @@ public class PermissionsFunctionChownTest {
 
     @Test(expected=PermissionDeniedException.class)
     public void ChangeDocumentOwnerAndGroupToRemovedAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        extractPermissionDenied(() -> {
+        extractPermissionDeniedWithAuth(() -> {
             final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
             changeOwner(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), Tuple(USERRM_NAME, USERRM_NAME), Tuple(USER1_NAME, USER1_NAME));
         });
@@ -1713,53 +1735,6 @@ public class PermissionsFunctionChownTest {
 
             transaction.commit();
         }
-    }
-
-    private static void extractPermissionDenied(final Runnable4E<AuthenticationException, XPathException, PermissionDeniedException, EXistException> runnable) throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
-        try {
-            runnable.run();
-        } catch (final XPathException e) {
-            if (e.getCause() != null && e.getCause() instanceof PermissionDeniedException) {
-                throw (PermissionDeniedException)e.getCause();
-            } else {
-                throw e;
-            }
-        }
-    }
-
-    private static void removeDocument(final DBBroker broker, final Txn transaction, final XmldbURI documentUri) throws PermissionDeniedException, LockException, IOException, TriggerException {
-        try (final Collection collection = broker.openCollection(documentUri.removeLastSegment(), Lock.LockMode.WRITE_LOCK)) {
-            collection.removeXMLResource(transaction, broker, documentUri.lastSegment());
-            broker.saveCollection(transaction, collection);
-        }
-    }
-
-    private static void removeCollection(final DBBroker broker, final Txn transaction, final XmldbURI collectionUri) throws PermissionDeniedException, IOException, TriggerException {
-        try (final Collection collection = broker.openCollection(collectionUri, Lock.LockMode.WRITE_LOCK)) {
-            broker.removeCollection(transaction, collection);
-        }
-    }
-
-    private static void createUser(final DBBroker broker, final SecurityManager sm, final String username, final String password) throws PermissionDeniedException, EXistException {
-        Group userGroup = new GroupAider(username);
-        sm.addGroup(broker, userGroup);
-        final Account user = new UserAider(username);
-        user.setPassword(password);
-        user.setPrimaryGroup(userGroup);
-        sm.addAccount(user);
-
-        userGroup = sm.getGroup(username);
-        userGroup.addManager(sm.getAccount(username));
-        sm.updateGroup(userGroup);
-    }
-
-    private static void removeUser(final SecurityManager sm, final String username) throws PermissionDeniedException, EXistException {
-        sm.deleteAccount(username);
-        removeGroup(sm, username);
-    }
-
-    private static void removeGroup(final SecurityManager sm, final String groupname) throws PermissionDeniedException, EXistException {
-        sm.deleteGroup(groupname);
     }
 
     /**

--- a/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/SecurityManagerTestUtil.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/SecurityManagerTestUtil.java
@@ -1,0 +1,224 @@
+/*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.securitymanager;
+
+import com.evolvedbinary.j8fu.function.Runnable3E;
+import com.evolvedbinary.j8fu.function.Runnable4E;
+import com.evolvedbinary.j8fu.tuple.Tuple2;
+import org.exist.EXistException;
+import org.exist.collections.Collection;
+import org.exist.collections.triggers.TriggerException;
+import org.exist.dom.persistent.DocumentImpl;
+import org.exist.dom.persistent.LockedDocument;
+import org.exist.security.*;
+import org.exist.security.SecurityManager;
+import org.exist.security.internal.aider.GroupAider;
+import org.exist.security.internal.aider.UserAider;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.lock.Lock;
+import org.exist.storage.txn.Txn;
+import org.exist.util.LockException;
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQuery;
+import org.exist.xquery.value.Sequence;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+class SecurityManagerTestUtil {
+
+    static Account createUser(final DBBroker broker, final org.exist.security.SecurityManager sm, final String username, final String password) throws PermissionDeniedException, EXistException {
+        return createUser(broker, sm, username, password, null);
+    }
+
+    static Account createUser(final DBBroker broker, final org.exist.security.SecurityManager sm, final String username, final String password, @Nullable final List<Tuple2<SchemaType, String>> metadata) throws PermissionDeniedException, EXistException {
+        Group userGroup = new GroupAider(username);
+        sm.addGroup(broker, userGroup);
+        final Account user = new UserAider(username);
+        user.setPassword(password);
+        user.setPrimaryGroup(userGroup);
+
+        if (metadata != null) {
+            for (final Tuple2<SchemaType, String> metadataEntry : metadata) {
+                user.setMetadataValue(metadataEntry._1, metadataEntry._2);
+            }
+        }
+
+        sm.addAccount(user);
+
+        userGroup = sm.getGroup(username);
+        userGroup.addManager(sm.getAccount(username));
+        sm.updateGroup(userGroup);
+
+        return user;
+    }
+
+    static Group createGroup(final DBBroker broker, final org.exist.security.SecurityManager sm, final String groupName) throws PermissionDeniedException, EXistException {
+        final Group otherGroup = new GroupAider(groupName);
+        return sm.addGroup(broker, otherGroup);
+    }
+
+    static void addUserToGroup(final org.exist.security.SecurityManager sm, final Account user, final Group group) throws PermissionDeniedException, EXistException {
+        user.addGroup(group.getName());
+        sm.updateAccount(user);
+    }
+
+    static void setPrimaryGroup(final org.exist.security.SecurityManager sm, final Account user, final Group group) throws PermissionDeniedException, EXistException {
+        user.setPrimaryGroup(group);
+        sm.updateAccount(user);
+    }
+
+    static void removeUser(final org.exist.security.SecurityManager sm, final String username) throws PermissionDeniedException, EXistException {
+        sm.deleteAccount(username);
+        removeGroup(sm, username);
+    }
+
+    static void removeGroup(final SecurityManager sm, final String groupname) throws PermissionDeniedException, EXistException {
+        sm.deleteGroup(groupname);
+    }
+
+    static Sequence xqueryAddUserAsGroupManager(final BrokerPool pool, final String username, final String groupname) throws EXistException, PermissionDeniedException, XPathException {
+        final String query =
+            "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
+                "sm:add-group-manager('" + groupname + "', '" + username + "')";
+
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            final XQuery xquery = pool.getXQueryService();
+            final Sequence result = xquery.execute(broker, query, null);
+            return result;
+        }
+    }
+
+    static Sequence xqueryRemoveUserFromGroup(final BrokerPool pool, final String username, final String groupname) throws XPathException, PermissionDeniedException, EXistException {
+        final Optional<Subject> asUser = Optional.of(pool.getSecurityManager().getSystemSubject());
+        return xqueryRemoveUserFromGroup(pool, username, groupname, asUser);
+    }
+
+    static Sequence xqueryRemoveUserFromGroup(final BrokerPool pool, final String username, final String groupname, final Optional<Subject> asUser) throws EXistException, PermissionDeniedException, XPathException {
+        final String query =
+                "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
+                "sm:remove-group-member('" + groupname + "', '" + username + "')";
+
+        try (final DBBroker broker = pool.get(asUser)) {
+            final XQuery xquery = pool.getXQueryService();
+            final Sequence result = xquery.execute(broker, query, null);
+            return result;
+        }
+    }
+
+    static Sequence xqueryRemoveGroup(final BrokerPool pool, final String groupname) throws EXistException, PermissionDeniedException, XPathException {
+        final String query =
+                "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
+                "sm:remove-group('" + groupname + "')";
+
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            final XQuery xquery = pool.getXQueryService();
+            final Sequence result = xquery.execute(broker, query, null);
+            return result;
+        }
+    }
+
+    static void xqueryChangeMode(final BrokerPool pool, final Subject execAsUser, final XmldbURI uri, final String newMode) throws EXistException, PermissionDeniedException, XPathException {
+        final String query =
+                "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
+                "sm:chmod(xs:anyURI('" + uri.getRawCollectionPath() + "'), '" + newMode + "'),\n" +
+                "sm:get-permissions(xs:anyURI('" + uri.getRawCollectionPath() + "'))/sm:permission/string(@mode)";
+
+        try (final DBBroker broker = pool.get(Optional.of(execAsUser))) {
+
+            final XQuery xquery = pool.getXQueryService();
+            final Sequence result = xquery.execute(broker, query, null);
+
+            assertEquals(1, result.getItemCount());
+            assertEquals(newMode, result.itemAt(0).getStringValue());
+        }
+    }
+
+    static void removeDocument(final DBBroker broker, final Txn transaction, final XmldbURI documentUri) throws PermissionDeniedException, LockException, IOException, TriggerException {
+        try (final Collection collection = broker.openCollection(documentUri.removeLastSegment(), Lock.LockMode.WRITE_LOCK)) {
+            collection.removeXMLResource(transaction, broker, documentUri.lastSegment());
+            broker.saveCollection(transaction, collection);
+        }
+    }
+
+    static void removeCollection(final DBBroker broker, final Txn transaction, final XmldbURI collectionUri) throws PermissionDeniedException, IOException, TriggerException {
+        try (final Collection collection = broker.openCollection(collectionUri, Lock.LockMode.WRITE_LOCK)) {
+            broker.removeCollection(transaction, collection);
+        }
+    }
+
+    static void extractPermissionDenied(final Runnable3E<XPathException, PermissionDeniedException, EXistException> runnable) throws XPathException, PermissionDeniedException, EXistException {
+        try {
+            runnable.run();
+        } catch (final XPathException e) {
+            if (e.getCause() != null && e.getCause() instanceof PermissionDeniedException) {
+                throw (PermissionDeniedException)e.getCause();
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    static void extractPermissionDeniedWithAuth(final Runnable4E<XPathException, AuthenticationException, PermissionDeniedException, EXistException> runnable) throws XPathException, AuthenticationException, PermissionDeniedException, EXistException {
+        try {
+            runnable.run();
+        } catch (final XPathException e) {
+            if (e.getCause() != null && e.getCause() instanceof PermissionDeniedException) {
+                throw (PermissionDeniedException)e.getCause();
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    static void assertDocumentSetGid(final BrokerPool pool, final Subject execAsUser, final XmldbURI uri, final boolean isSet) throws EXistException, PermissionDeniedException {
+        try (final DBBroker broker = pool.get(Optional.of(execAsUser));
+             final LockedDocument lockedDoc = broker.getXMLResource(uri, Lock.LockMode.READ_LOCK)) {
+
+            final DocumentImpl doc = lockedDoc.getDocument();
+            if (isSet) {
+                assertTrue(doc.getPermissions().isSetGid());
+            } else {
+                assertFalse(doc.getPermissions().isSetGid());
+            }
+        }
+    }
+
+    static void assertCollectionSetGid(final BrokerPool pool, final Subject execAsUser, final XmldbURI uri, final boolean isSet) throws EXistException, PermissionDeniedException {
+        try (final DBBroker broker = pool.get(Optional.of(execAsUser))) {
+            try (final Collection col = broker.openCollection(uri, Lock.LockMode.READ_LOCK)) {
+                if (isSet) {
+                    assertTrue(col.getPermissions().isSetGid());
+                } else {
+                    assertFalse(col.getPermissions().isSetGid());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This fixes an issue where the Configurator was previously not correctly deserializing Maps when they only had a single entry.

Closes https://github.com/eXist-db/exist/issues/5904