### PR TITLE
[6.x.x] Processing Instruction persistent DOM nodes must return their target as their node name

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -691,6 +691,7 @@
                             <header>${project.parent.relativePath}/../elemental-parent/elemental-LGPL-21-ONLY-license.template.txt</header>
                             <includes>
                                 <include>project-suppression.xml</include>
+                                <include>src/test/xquery/pi.xqm</include>
                                 <include>src/test/xquery/securitymanager/acl.xqm</include>
                                 <include>src/main/java/org/exist/dom/memtree/DocumentTypeImpl.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/reference/AbstractReferenceCharacterData.java</include>
@@ -1174,6 +1175,7 @@
                                 <exclude>src/test/resources-filtered/conf.xml</exclude>
                                 <exclude>src/test/resources/standalone-webapp/WEB-INF/web.xml</exclude>
                                 <exclude>src/test/xquery/binary-value.xqm</exclude>
+                                <exclude>src/test/xquery/pi.xqm</exclude>
                                 <exclude>src/test/xquery/tail-recursion.xml</exclude>
                                 <exclude>src/test/xquery/maps/maps.xqm</exclude>
                                 <exclude>src/test/xquery/securitymanager/acl.xqm</exclude>

--- a/exist-core/src/main/java/org/exist/dom/persistent/ProcessingInstructionImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/ProcessingInstructionImpl.java
@@ -45,6 +45,7 @@
  */
 package org.exist.dom.persistent;
 
+import org.exist.dom.QName;
 import org.exist.numbering.NodeId;
 import org.exist.storage.Signatures;
 import org.exist.util.ByteConversion;
@@ -61,7 +62,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  *
  * @author wolf
  */
-public class ProcessingInstructionImpl extends StoredNode<ProcessingInstructionImpl> implements ProcessingInstruction {
+public class ProcessingInstructionImpl extends NamedNode<ProcessingInstructionImpl> implements ProcessingInstruction {
 
     public static final int LENGTH_TARGET_DATA = 4; //Sizeof int;
 
@@ -81,7 +82,7 @@ public class ProcessingInstructionImpl extends StoredNode<ProcessingInstructionI
     }
 
     public ProcessingInstructionImpl(final Expression expression, final NodeId nodeId, final String target, final String data) {
-        super(expression, Node.PROCESSING_INSTRUCTION_NODE, nodeId);
+        super(expression, Node.PROCESSING_INSTRUCTION_NODE, nodeId, new QName(target, null));
         this.target = target;
         this.data = data;
     }
@@ -98,6 +99,7 @@ public class ProcessingInstructionImpl extends StoredNode<ProcessingInstructionI
     public void clear() {
         super.clear();
         target = null;
+        setQName(null);
         data = null;
     }
 
@@ -118,6 +120,7 @@ public class ProcessingInstructionImpl extends StoredNode<ProcessingInstructionI
      */
     public void setTarget(final String target) {
         this.target = target;
+        setQName(new QName(target, null));
     }
 
     @Override

--- a/exist-core/src/test/xquery/pi.xqm
+++ b/exist-core/src/test/xquery/pi.xqm
@@ -1,0 +1,61 @@
+(:
+ : Elemental
+ : Copyright (C) 2024, Evolved Binary Ltd
+ :
+ : admin@evolvedbinary.com
+ : https://www.evolvedbinary.com | https://www.elemental.xyz
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; version 2.1.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.0";
+
+(:~
+ : Tests for Processing Instruction nodes.
+ :
+ : @author Adam Retter
+ :)
+module namespace pi = "http://exist-db.org/xquery/test/pi";
+
+import module namespace test = "http://exist-db.org/xquery/xqsuite";
+
+declare %private variable $pi:doc1 := document {
+    <?my-pi my-pi-content ?>,
+    <x/>
+};
+
+declare
+    %test:setUp
+function pi:setup() {
+  let $test-collection := xmldb:create-collection("/db", "pi-test")
+  return
+    xmldb:store($test-collection, "doc1.xml", $pi:doc1)
+};
+
+declare
+    %test:tearDown
+function pi:tearDown() {
+  xmldb:remove("/db/pi-test")
+};
+
+declare
+    %test:assertEquals("my-pi")
+function pi:in-memory-dom-pi-name() {
+    $pi:doc1/processing-instruction()/name()
+};
+
+declare
+    %test:assertEquals("my-pi")
+function pi:persistent-dom-pi-name() {
+    doc("/db/pi-test/doc1.xml")/processing-instruction()/name()
+};


### PR DESCRIPTION
Backport of https://github.com/evolvedbinary/elemental/pull/110

Previously Processing Instruction persistent DOM nodes were treated as un-named nodes, they now return their target as their name.
Closes https://github.com/eXist-db/exist/issues/5923