### PR TITLE
[6.x.x] Reduce memory use and improve NodeSet sizing

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -800,7 +800,7 @@
                                 <include>src/main/java/org/exist/config/Configurator.java</include>
                                 <include>src/main/java/org/exist/dom/NodeListImpl.java</include>
                                 <include>src/main/java/org/exist/dom/QName.java</include>
-                                <exclude>src/main/java/org/exist/dom/memtree/AbstractCharacterData.java</exclude>
+                                <include>src/main/java/org/exist/dom/memtree/AbstractCharacterData.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/AttrImpl.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/DocumentImpl.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/DOMIndexer.java</include>
@@ -808,9 +808,9 @@
                                 <include>src/test/java/org/exist/dom/memtree/DOMTest.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/ElementImpl.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/MemTreeBuilder.java</include>
-                                <exclude>src/main/java/org/exist/dom/memtree/NamespaceNode.java</exclude>
+                                <include>src/main/java/org/exist/dom/memtree/NamespaceNode.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/NodeImpl.java</include>
-                                <exclude>src/main/java/org/exist/dom/memtree/ProcessingInstructionImpl.java</exclude>
+                                <include>src/main/java/org/exist/dom/memtree/ProcessingInstructionImpl.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/AbstractArrayNodeSet.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/AbstractCharacterData.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/AttrImpl.java</include>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -811,6 +811,7 @@
                                 <exclude>src/main/java/org/exist/dom/memtree/NamespaceNode.java</exclude>
                                 <include>src/main/java/org/exist/dom/memtree/NodeImpl.java</include>
                                 <exclude>src/main/java/org/exist/dom/memtree/ProcessingInstructionImpl.java</exclude>
+                                <include>src/main/java/org/exist/dom/persistent/AbstractArrayNodeSet.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/AbstractCharacterData.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/AttrImpl.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/BinaryDocument.java</include>
@@ -823,6 +824,7 @@
                                 <include>src/main/java/org/exist/dom/persistent/Match.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/NodeProxy.java</include>
+                                <include>src/main/java/org/exist/dom/persistent/NodeSet.java</include>
                                 <include>src/test/java/org/exist/dom/persistent/NodeTest.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/LockToken.java</include>
                                 <include>src/test/java/org/exist/dom/persistent/PersistentDomTest.java</include>
@@ -1245,6 +1247,7 @@
                                 <exclude>src/main/java/org/exist/dom/memtree/reference/ElementReferenceImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/reference/ProcessingInstructionReferenceImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/reference/TextReferenceImpl.java</exclude>
+                                <exclude>src/main/java/org/exist/dom/persistent/AbstractArrayNodeSet.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/AbstractCharacterData.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/AttrImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/BinaryDocument.java</exclude>
@@ -1257,6 +1260,7 @@
                                 <exclude>src/main/java/org/exist/dom/persistent/Match.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/NodeProxy.java</exclude>
+                                <exclude>src/main/java/org/exist/dom/persistent/NodeSet.java</exclude>
                                 <exclude>src/test/java/org/exist/dom/persistent/NodeTest.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/LockToken.java</exclude>
                                 <exclude>src/test/java/org/exist/dom/persistent/PersistentDomTest.java</exclude>

--- a/exist-core/src/main/java/org/exist/dom/persistent/AbstractArrayNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/AbstractArrayNodeSet.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *

--- a/exist-core/src/main/java/org/exist/dom/persistent/AbstractNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/AbstractNodeSet.java
@@ -547,7 +547,7 @@ public abstract class AbstractNodeSet extends AbstractSequence implements NodeSe
                     if (Expression.NO_CONTEXT_ID != contextId) {
                         context.addContextNode(contextId, context);
                     }
-                    if (lastDoc != null && lastDoc.getDocId() != context.getOwnerDocument().getDocId()) {
+                    if (lastDoc == null || lastDoc.getDocId() != context.getOwnerDocument().getDocId()) {
                         lastDoc = context.getOwnerDocument();
                         result.add(context, getSizeHint(lastDoc));
                     } else {

--- a/exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java
@@ -65,7 +65,12 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
 import javax.annotation.Nullable;
-import java.util.*;
+import java.lang.ref.WeakReference;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Set;
 
 /**
  * A fast node set implementation, based on arrays to store nodes and documents.
@@ -91,7 +96,7 @@ import java.util.*;
  */
 public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet, DocumentSet {
 
-    private Set<Collection> cachedCollections = null;
+    @Nullable private WeakReference<Set<Collection>> cachedCollectionsRef = null;
 
     private int documentCount = 0;
 
@@ -1038,16 +1043,27 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
 
     @Override
     public Iterator<Collection> getCollectionIterator() {
-        sort();
-        if(cachedCollections == null) {
-            cachedCollections = new HashSet<>();
-            for(int i = 0; i < documentCount; i++) {
-                final DocumentImpl doc = nodes[documentNodesOffset[i]].getOwnerDocument();
-                if(!cachedCollections.contains(doc.getCollection())) {
-                    cachedCollections.add(doc.getCollection());
-                }
+        // First, try and retrieve from Cache
+        Set<Collection> cachedCollections;
+        if (this.cachedCollectionsRef != null) {
+            cachedCollections = this.cachedCollectionsRef.get();
+            if (cachedCollections != null) {
+                return cachedCollections.iterator();
             }
         }
+
+        sort();
+
+        // Second, Cache is empty, so create a Cache and return
+        cachedCollections = new HashSet<>();
+        for (int i = 0; i < documentCount; i++) {
+            final DocumentImpl doc = nodes[documentNodesOffset[i]].getOwnerDocument();
+            final Collection collection = doc.getCollection();
+            cachedCollections.add(collection);
+        }
+
+        this.cachedCollectionsRef = new WeakReference<>(cachedCollections);
+
         return cachedCollections.iterator();
     }
 

--- a/exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java
@@ -964,10 +964,10 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
                 if(contextNode.getContextId() == contextId) {
                     final NodeProxy context = contextNode.getNode();
                     context.addMatches(current);
-                    if(Expression.NO_CONTEXT_ID != contextId) {
+                    if (Expression.NO_CONTEXT_ID != contextId) {
                         context.addContextNode(contextId, context);
                     }
-                    if(lastDoc != null && lastDoc.getDocId() != context.getOwnerDocument().getDocId()) {
+                    if (lastDoc == null || lastDoc.getDocId() != context.getOwnerDocument().getDocId()) {
                         lastDoc = context.getOwnerDocument();
                         result.add(context, getSizeHint(lastDoc));
                     } else {

--- a/exist-core/src/main/java/org/exist/dom/persistent/NodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NodeSet.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -377,7 +401,7 @@ public interface NodeSet extends Sequence, NodeList, Iterable<NodeProxy> {
      *
      * @param contextId used to track context nodes when evaluating predicate
      *                  expressions. If contextId != {@link org.exist.xquery.Expression#NO_CONTEXT_ID}, the current context
-     *                  will be added to each result of the of the selection.
+     *                  will be added to each result of the selection.
      * @return all context nodes associated with the nodes in this node set.
      */
     NodeSet getContextNodes(int contextId);


### PR DESCRIPTION
Backport of https://github.com/evolvedbinary/elemental/pull/112

Potentially reduces the memory use of `NewArrayNodeSet` when there is memory pressure by allowing its Collection Cache to be dropped and also improves the size hinting when creating/copying `NodeSet`s.