### PR TITLE
[7.x.x] Switch back to Squareup Java Poet from Palantir

### DIFF
--- a/exist-core-build-tools/pom.xml
+++ b/exist-core-build-tools/pom.xml
@@ -49,10 +49,17 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>
+        <!--
         <dependency>
             <groupId>com.palantir.javapoet</groupId>
             <artifactId>javapoet</artifactId>
             <version>0.7.0</version>
+        </dependency>
+        -->
+        <dependency>
+            <groupId>com.squareup</groupId>
+            <artifactId>javapoet</artifactId>
+            <version>1.13.0</version>
         </dependency>
     </dependencies>
 

--- a/exist-core-build-tools/src/main/java/xyz/elemental/build/tools/spoon/processors/PermissionRequiredProcessor.java
+++ b/exist-core-build-tools/src/main/java/xyz/elemental/build/tools/spoon/processors/PermissionRequiredProcessor.java
@@ -20,12 +20,12 @@
  */
 package xyz.elemental.build.tools.spoon.processors;
 
-import com.palantir.javapoet.ClassName;
-import com.palantir.javapoet.CodeBlock;
-import com.palantir.javapoet.JavaFile;
-import com.palantir.javapoet.MethodSpec;
-import com.palantir.javapoet.ParameterSpec;
-import com.palantir.javapoet.TypeSpec;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterSpec;
+import com.squareup.javapoet.TypeSpec;
 
 import javax.annotation.Nullable;
 import javax.annotation.processing.AbstractProcessor;


### PR DESCRIPTION
The newer Palantir version (0.7.0) of Java Poet was not usable in our CI system.
See https://github.com/palantir/gradle-consistent-versions/issues/1468
Closes https://github.com/evolvedbinary/elemental/pull/94