### PR TITLE
[6.x.x] Stabilise Build

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -2279,7 +2279,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <excludePackageNames>org.exist.xquery.parser:org.exist.xquery.xqdoc.parser</excludePackageNames>
+                    <sourcepath>${project.build.sourceDirectory}:${project.build.directory}/generated-sources/annotations:${project.build.directory}/generated-sources/antlr</sourcepath>
                 </configuration>
             </plugin>
 

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -156,7 +156,8 @@
             <artifactId>jing</artifactId>
             <version>20241231</version>
             <exclusions>
-                <exclusion> <!-- conflicts with Xerces dependency on xml-apis -->
+                <exclusion>
+                    <!-- NOTE(AR): conflicts with com.evolvedbinary.thirdparty.xml-apis:xml-apis -->
                     <groupId>xml-apis</groupId>
                     <artifactId>xml-apis</artifactId>
                 </exclusion>
@@ -321,6 +322,7 @@
             <groupId>com.evolvedbinary.thirdparty.xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
         </dependency>
+
         <dependency>
             <groupId>com.evolvedbinary.thirdparty.org.apache.ws.commons.util</groupId>
             <artifactId>ws-commons-util</artifactId>
@@ -342,6 +344,11 @@
             <version>${xmlresolver.version}</version>
             <exclusions>
                 <exclusion>
+                    <!-- NOTE(AR): conflicts with com.evolvedbinary.thirdparty.xml-apis:xml-apis -->
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+                <exclusion>
                     <!-- NOTE(AR): conflicts with com.evolvedbinary.thirdparty.xerces:xercesImpl -->
                     <groupId>xerces</groupId>
                     <artifactId>xercesImpl</artifactId>
@@ -356,6 +363,11 @@
             <classifier>data</classifier>
             <scope>runtime</scope>
             <exclusions>
+                <exclusion>
+                    <!-- NOTE(AR): conflicts with com.evolvedbinary.thirdparty.xml-apis:xml-apis -->
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
                 <exclusion>
                     <!-- NOTE(AR): conflicts with com.evolvedbinary.thirdparty.xerces:xercesImpl -->
                     <groupId>xerces</groupId>

--- a/extensions/indexes/ngram/pom.xml
+++ b/extensions/indexes/ngram/pom.xml
@@ -87,6 +87,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.evolvedbinary.j8fu</groupId>
+            <artifactId>j8fu</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>test</scope>
@@ -101,6 +107,12 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/extensions/modules/expathrepo/pom.xml
+++ b/extensions/modules/expathrepo/pom.xml
@@ -92,6 +92,11 @@
             <artifactId>xml-apis</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+
         <!-- test -->
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Backport of https://github.com/evolvedbinary/elemental/pull/117

Just a couple of small things to stabilise the build:
1. Fixing transitive dependencies
2. Fixing JavaDoc generation