### PR TITLE
[7.x.x] Cleanup and reduce the memory use of the XUpdate Implementation

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1332,9 +1332,15 @@
                                 <include>src/main/java/org/exist/xquery/value/Type.java</include>
                                 <include>src/main/java/org/exist/xslt/EXistURIResolver.java</include>
                                 <include>src/main/java/org/exist/xslt/XsltURIResolverHelper.java</include>
+                                <include>src/main/java/org/exist/xupdate/Append.java</include>
                                 <include>src/main/java/org/exist/xupdate/Conditional.java</include>
+                                <include>src/main/java/org/exist/xupdate/Insert.java</include>
                                 <include>src/main/java/org/exist/xupdate/Modification.java</include>
+                                <include>src/main/java/org/exist/xupdate/Remove.java</include>
                                 <include>src/test/java/org/exist/xupdate/RemoveAppendTest.java</include>
+                                <include>src/main/java/org/exist/xupdate/Rename.java</include>
+                                <include>src/main/java/org/exist/xupdate/Replace.java</include>
+                                <include>src/main/java/org/exist/xupdate/Update.java</include>
                                 <include>src/main/java/org/exist/xupdate/XUpdateProcessor.java</include>
                                 <include>src/test/java/org/exist/xupdate/XUpdateTest.java</include>
                             </includes>
@@ -2044,9 +2050,15 @@
                                 <exclude>src/main/java/org/exist/xquery/value/YearMonthDurationValue.java</exclude>
                                 <exclude>src/main/java/org/exist/xslt/EXistURIResolver.java</exclude>
                                 <exclude>src/main/java/org/exist/xslt/XsltURIResolverHelper.java</exclude>
+                                <exclude>src/main/java/org/exist/xupdate/Append.java</exclude>
                                 <exclude>src/main/java/org/exist/xupdate/Conditional.java</exclude>
+                                <exclude>src/main/java/org/exist/xupdate/Insert.java</exclude>
                                 <exclude>src/main/java/org/exist/xupdate/Modification.java</exclude>
+                                <exclude>src/main/java/org/exist/xupdate/Remove.java</exclude>
                                 <exclude>src/test/java/org/exist/xupdate/RemoveAppendTest.java</exclude>
+                                <exclude>src/main/java/org/exist/xupdate/Rename.java</exclude>
+                                <exclude>src/main/java/org/exist/xupdate/Replace.java</exclude>
+                                <exclude>src/main/java/org/exist/xupdate/Update.java</exclude>
                                 <exclude>src/main/java/org/exist/xupdate/XUpdateProcessor.java</exclude>
                                 <exclude>src/test/java/org/exist/xupdate/XUpdateTest.java</exclude>
 

--- a/exist-core/src/main/java/org/exist/xupdate/Append.java
+++ b/exist-core/src/main/java/org/exist/xupdate/Append.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -38,6 +62,8 @@ import org.exist.util.LockException;
 import org.exist.xquery.XPathException;
 import org.w3c.dom.NodeList;
 
+import javax.annotation.Nullable;
+
 /**
  * Implements an XUpate append statement.
  * 
@@ -60,24 +86,24 @@ public class Append extends Modification {
 	 * @param namespaces the namespaces.
 	 * @param variables the variables.
 	 */
-	public Append(DBBroker broker, DocumentSet docs, String selectStmt, 
-	        String childAttr, Map<String, String> namespaces, Map<String, Object> variables) {
+	public Append(final DBBroker broker, final DocumentSet docs, final String selectStmt, final String childAttr, @Nullable final Map<String, String> namespaces, @Nullable final Map<String, Object> variables) {
 		super(broker, docs, selectStmt, namespaces, variables);
-		if(childAttr == null || "last()".equals(childAttr))
-		    {child = -1;}
-		else
-		    {child = Integer.parseInt(childAttr);}
+		if (childAttr == null || "last()".equals(childAttr)) {
+            child = -1;
+        } else {
+            child = Integer.parseInt(childAttr);
+        }
 	}
 
 	@Override
-	public long process(Txn transaction) throws PermissionDeniedException, LockException,
-		EXistException, XPathException, TriggerException {
+	public long process(final Txn transaction) throws PermissionDeniedException, LockException, EXistException, XPathException, TriggerException {
 	    final NodeList children = content;
-	    if(children.getLength() == 0)
-	        {return 0;}
+	    if (children.getLength() == 0) {
+            return 0;
+        }
 		
 	    try {
-	        final StoredNode ql[] = selectAndLock(transaction);
+	        final StoredNode[] ql = selectAndLock(transaction);
 			final NotificationService notifier = broker.getBrokerPool().getNotificationService();
 			for (final StoredNode node : ql) {
 				final DocumentImpl doc = node.getOwnerDocument();
@@ -86,11 +112,11 @@ public class Append extends Modification {
 				}
 				node.appendChildren(transaction, children, child);
 				doc.setLastModified(System.currentTimeMillis());
-				modifiedDocuments.add(doc);
+                addModifiedDocument(doc);
 				broker.storeXMLResource(transaction, doc);
 				notifier.notifyUpdate(doc, UpdateListener.UPDATE);
 			}
-			checkFragmentation(transaction, modifiedDocuments);
+			checkFragmentation(transaction);
 			return ql.length;
 	    } finally {
 	        // release all acquired locks

--- a/exist-core/src/main/java/org/exist/xupdate/Conditional.java
+++ b/exist-core/src/main/java/org/exist/xupdate/Conditional.java
@@ -82,8 +82,7 @@ public class Conditional extends Modification {
 	 * @param namespaces the namespaces.
 	 * @param variables the variables.
 	 */
-	public Conditional(DBBroker broker, DocumentSet docs, String selectStmt,
-			Map<String, String> namespaces, Map<String, Object> variables) {
+	public Conditional(final DBBroker broker, final DocumentSet docs, final String selectStmt, @Nullable final Map<String, String> namespaces, @Nullable final Map<String, Object> variables) {
 		super(broker, docs, selectStmt, namespaces, variables);
 	}
 
@@ -92,9 +91,11 @@ public class Conditional extends Modification {
 	}
 	
 	@Override
-	public long process(Txn transaction) throws PermissionDeniedException, LockException,
-			EXistException, XPathException, TriggerException {
-		LOG.debug("Processing xupdate:if ...");
+	public long process(final Txn transaction) throws PermissionDeniedException, LockException, EXistException, XPathException, TriggerException {
+		if (LOG.isDebugEnabled()) {
+            LOG.debug("Processing xupdate:if ...");
+        }
+
 		final XQuery xquery = broker.getBrokerPool().getXQueryService();
 		final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
 		final Source source = new StringSource(selectStmt);

--- a/exist-core/src/main/java/org/exist/xupdate/Insert.java
+++ b/exist-core/src/main/java/org/exist/xupdate/Insert.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -39,6 +63,8 @@ import org.exist.util.LockException;
 import org.exist.xquery.XPathException;
 import org.w3c.dom.NodeList;
 
+import javax.annotation.Nullable;
+
 /**
  * Implements an XUpdate insert-after or insert-before modification.
  * 
@@ -61,8 +87,7 @@ public class Insert extends Modification {
      * @param namespaces the namespaces.
      * @param variables the variables.
      */
-    public Insert(DBBroker broker, DocumentSet docs, String selectStmt,
-            Map<String, String> namespaces, Map<String, Object> variables) {
+    public Insert(final DBBroker broker, final DocumentSet docs, final String selectStmt, @Nullable final Map<String, String> namespaces, @Nullable final Map<String, Object> variables) {
         super(broker, docs, selectStmt, namespaces,  variables);
     }
 
@@ -76,44 +101,50 @@ public class Insert extends Modification {
      * @param namespaces the namespaces.
      * @param variables the variables.
      */
-    public Insert(DBBroker broker, DocumentSet docs, String selectStmt,
-            int mode, Map<String, String> namespaces, Map<String, Object> variables) {
+    public Insert(final DBBroker broker, final DocumentSet docs, final String selectStmt, final int mode, @Nullable final Map<String, String> namespaces, @Nullable final Map<String, Object> variables) {
         this(broker, docs, selectStmt, namespaces, variables);
         this.mode = mode;
     }
 
     @Override
-    public long process(Txn transaction) throws PermissionDeniedException, LockException,
-            EXistException, XPathException, TriggerException {
+    public long process(final Txn transaction) throws PermissionDeniedException, LockException, EXistException, XPathException, TriggerException {
         final NodeList children = content;
-        if (children.getLength() == 0) {return 0;}
+        if (children.getLength() == 0) {
+            return 0;
+        }
+
         try {
             final StoredNode[] ql = selectAndLock(transaction);
             final NotificationService notifier = broker.getBrokerPool().getNotificationService();
             final int len = children.getLength();
-            if (LOG.isDebugEnabled())
-                {
-                    LOG.debug("found {} nodes to insert", len);}
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("found {} nodes to insert", len);
+            }
+
             for (final StoredNode node : ql) {
                 final DocumentImpl doc = node.getOwnerDocument();
                 if (!doc.getPermissions().validate(broker.getCurrentSubject(), Permission.WRITE)) {
                     throw new PermissionDeniedException("permission to update document denied");
                 }
+
                 final NodeImpl parent = (NodeImpl) getParent(node);
                 switch (mode) {
+
                     case INSERT_BEFORE:
                         parent.insertBefore(transaction, children, node);
                         break;
+
                     case INSERT_AFTER:
                         parent.insertAfter(transaction, children, node);
                         break;
                 }
+
                 doc.setLastModified(System.currentTimeMillis());
-                modifiedDocuments.add(doc);
+                addModifiedDocument(doc);
                 broker.storeXMLResource(transaction, doc);
                 notifier.notifyUpdate(doc, UpdateListener.UPDATE);
             }
-            checkFragmentation(transaction, modifiedDocuments);
+            checkFragmentation(transaction);
             return ql.length;
         } finally {
             unlockDocuments(transaction);

--- a/exist-core/src/main/java/org/exist/xupdate/Modification.java
+++ b/exist-core/src/main/java/org/exist/xupdate/Modification.java
@@ -46,13 +46,13 @@
 package org.exist.xupdate;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.TreeMap;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectRBTreeMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.EXistException;
@@ -109,15 +109,17 @@ public abstract class Modification {
 	protected DBBroker broker;
 	/** Documents concerned by this XUpdate modification,
 	 * i.e. the set of documents to which this XUpdate might apply. */
-	protected DocumentSet docs;
-	protected Map<String, String> namespaces;
-	protected Map<String, Object> variables;
-	protected ManagedLocks<ManagedDocumentLock> lockedDocumentsLocks = null;
-	protected MutableDocumentSet modifiedDocuments = new DefaultDocumentSet();
-    protected Int2ObjectMap<DocumentTrigger> triggers;
+	@Nullable protected final DocumentSet docs;
+	@Nullable private Map<String, String> namespaces = null;
+	@Nullable private Map<String, Object> variables = null;
+	@Nullable private ManagedLocks<ManagedDocumentLock> lockedDocumentsLocks = null;
+	@Nullable private MutableDocumentSet modifiedDocuments = null;
+    @Nullable private Int2ObjectMap<DocumentTrigger> triggers = null;
 
 	@SuppressWarnings("unused")
-	private Modification() {}
+	private Modification() {
+        this.docs = null;
+    }
 
 	/**
 	 * Constructor for Modification.
@@ -128,15 +130,16 @@ public abstract class Modification {
 	 * @param namespaces the namespace bindings
 	 * @param variables the variable bindings
 	 */
-	public Modification(DBBroker broker, DocumentSet docs, String selectStmt,
-	        Map<String, String> namespaces, Map<String, Object> variables) {
+	public Modification(final DBBroker broker, final DocumentSet docs, final String selectStmt, @Nullable final Map<String, String> namespaces, @Nullable final Map<String, Object> variables) {
 		this.selectStmt = selectStmt;
 		this.broker = broker;
 		this.docs = docs;
-		this.namespaces = new HashMap<>(namespaces);
-		this.variables = new TreeMap<>(variables);
-        this.triggers = new Int2ObjectOpenHashMap<>();
-        // DESIGN_QUESTION : wouldn't that be nice to apply selectStmt right here ?
+        if (namespaces != null) {
+            this.namespaces = new Object2ObjectArrayMap<>(namespaces);
+        }
+        if (variables != null) {
+            this.variables = new Object2ObjectRBTreeMap<>(variables);
+        }
 	}
 
 	/**
@@ -152,13 +155,12 @@ public abstract class Modification {
      * @throws XPathException if the XPath raises an error
 	 * @throws TriggerException if a trigger raises an error
 	 */
-	public abstract long process(Txn transaction) throws PermissionDeniedException, LockException, 
-		EXistException, XPathException, TriggerException;
+	public abstract long process(final Txn transaction) throws PermissionDeniedException, LockException, EXistException, XPathException, TriggerException;
 
 	public abstract String getName();
 
-	public void setContent(NodeList nodes) {
-		content = nodes;
+	public void setContent(final NodeList nodes) {
+		this.content = nodes;
 	}
 
 	/**
@@ -172,8 +174,7 @@ public abstract class Modification {
 	 * @throws EXistException if the database raises an error
 	 * @throws XPathException if the XPath raises an error
 	 */
-	protected NodeList select(DocumentSet docs)
-		throws PermissionDeniedException, EXistException, XPathException {
+	protected NodeList select(final DocumentSet docs) throws PermissionDeniedException, EXistException, XPathException {
 		final XQuery xquery = broker.getBrokerPool().getXQueryService();
 		final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
 		final Source source = new StringSource(selectStmt);
@@ -229,9 +230,11 @@ public abstract class Modification {
 	 * @param context the xquery context
 	 * @throws XPathException if an error occurs whilst declaring the variables
 	 */
-	protected void declareVariables(XQueryContext context) throws XPathException {
-        for (final Map.Entry<String, Object> entry : variables.entrySet()) {
-            context.declareVariable(entry.getKey(), true, entry.getValue());
+	protected void declareVariables(final XQueryContext context) throws XPathException {
+        if (variables != null) {
+            for (final Map.Entry<String, Object> entry : variables.entrySet()) {
+                context.declareVariable(entry.getKey(), true, entry.getValue());
+            }
         }
 	}
 
@@ -239,10 +242,11 @@ public abstract class Modification {
 	 * @param context the xquery context
 	 * @throws XPathException if an error occurs whilst declaring the namespaces
 	 */
-	protected void declareNamespaces(XQueryContext context) throws XPathException {
-
-        for (Map.Entry<String, String> entry : namespaces.entrySet()) {
-            context.declareNamespace(entry.getKey(), entry.getValue());
+	protected void declareNamespaces(final XQueryContext context) throws XPathException {
+        if (namespaces != null) {
+            for (final Map.Entry<String, String> entry : namespaces.entrySet()) {
+                context.declareNamespace(entry.getKey(), entry.getValue());
+            }
         }
 	}
 
@@ -263,9 +267,7 @@ public abstract class Modification {
 	 * @throws XPathException if the XPath raises an error
 	 * @throws TriggerException if a trigger raises an error
 	 */
-	protected final StoredNode[] selectAndLock(Txn transaction)
-			throws LockException, PermissionDeniedException, EXistException,
-			XPathException, TriggerException {
+	protected final StoredNode[] selectAndLock(final Txn transaction) throws LockException, PermissionDeniedException, EXistException, XPathException, TriggerException {
 		final java.util.concurrent.locks.Lock globalLock = broker.getBrokerPool().getGlobalUpdateLock();
 		globalLock.lock();
 	    try {
@@ -277,9 +279,9 @@ public abstract class Modification {
 	        // during the modification
 	        lockedDocumentsLocks = lockedDocuments.lock(broker, true);
 	        
-		    final StoredNode ql[] = new StoredNode[nl.getLength()];		    
+		    final StoredNode[] ql = new StoredNode[nl.getLength()];
 			for (int i = 0; i < ql.length; i++) {
-				ql[i] = (StoredNode)nl.item(i);
+				ql[i] = (StoredNode) nl.item(i);
 				final DocumentImpl doc = ql[i].getOwnerDocument();
 				
 				// call the eventual triggers
@@ -304,25 +306,32 @@ public abstract class Modification {
 	 *
 	 * @throws TriggerException if a trigger raises an error
 	 */
-	protected final void unlockDocuments(final Txn transaction) throws TriggerException
-	{
-		if(lockedDocumentsLocks == null) {
+	protected final void unlockDocuments(final Txn transaction) throws TriggerException {
+		if (lockedDocumentsLocks == null) {
 			return;
 		}
 
 		try {
 			//finish Trigger
-			final Iterator<DocumentImpl> iterator = modifiedDocuments.getDocumentIterator();
-			while (iterator.hasNext()) {
-				finishTrigger(transaction, iterator.next());
-			}
+            if (modifiedDocuments != null) {
+                final Iterator<DocumentImpl> iterator = modifiedDocuments.getDocumentIterator();
+                while (iterator.hasNext()) {
+                    finishTrigger(transaction, iterator.next());
+                }
+            }
 		} finally {
-			triggers.clear();
-			modifiedDocuments.clear();
+            if (triggers != null) {
+                triggers.clear();
+            }
+            if (modifiedDocuments != null) {
+                modifiedDocuments.clear();
+            }
 
 			//unlock documents
-	        lockedDocumentsLocks.close();
-	        lockedDocumentsLocks = null;
+            if (lockedDocumentsLocks != null) {
+                lockedDocumentsLocks.close();
+                lockedDocumentsLocks = null;
+            }
 		}
 	}
 	
@@ -333,21 +342,25 @@ public abstract class Modification {
 	 * document exceeds the limit defined in the configuration file.
 	 *
 	 * @param transaction the database transaction.
-	 * @param docs the documents
 	 *
 	 * @throws EXistException if an error occurs
 	 */
-	protected void checkFragmentation(Txn transaction, DocumentSet docs) throws EXistException {
+	protected void checkFragmentation(final Txn transaction) throws EXistException {
         int fragmentationLimit = -1;
         final Object property = broker.getBrokerPool().getConfiguration().getProperty(DBBroker.PROPERTY_XUPDATE_FRAGMENTATION_FACTOR);
-        if (property != null)
-	        {fragmentationLimit = (Integer) property;}
-	    for(final Iterator<DocumentImpl> i = docs.getDocumentIterator(); i.hasNext(); ) {
-	        final DocumentImpl next = i.next();
-	        if(next.getSplitCount() > fragmentationLimit)
-	            {broker.defragXMLResource(transaction, next);}
-	        broker.checkXMLResourceConsistency(next);
-	    }
+        if (property != null) {
+            fragmentationLimit = (Integer) property;
+        }
+
+        if (modifiedDocuments != null) {
+            for (final Iterator<DocumentImpl> i = modifiedDocuments.getDocumentIterator(); i.hasNext(); ) {
+                final DocumentImpl next = i.next();
+                if (next.getSplitCount() > fragmentationLimit) {
+                    broker.defragXMLResource(transaction, next);
+                }
+                broker.checkXMLResourceConsistency(next);
+            }
+        }
 	}
 	
 	/**
@@ -358,14 +371,14 @@ public abstract class Modification {
 	 *
 	 * @throws TriggerException if a trigger raises an error
 	 */
-	private void prepareTrigger(Txn transaction, DocumentImpl doc) throws TriggerException {
-            
+	private void prepareTrigger(final Txn transaction, final DocumentImpl doc) throws TriggerException {
 	    final Collection col = doc.getCollection();
-	        
-            final DocumentTrigger trigger = new DocumentTriggers(broker, transaction, col);
-            
-            trigger.beforeUpdateDocument(broker, transaction, doc);
-            triggers.put(doc.getDocId(), trigger);
+        final DocumentTrigger trigger = new DocumentTriggers(broker, transaction, col);
+        trigger.beforeUpdateDocument(broker, transaction, doc);
+        if (triggers == null) {
+            triggers = new Int2ObjectOpenHashMap<>();
+        }
+        triggers.put(doc.getDocId(), trigger);
 	}
 	
 	/** 
@@ -376,12 +389,16 @@ public abstract class Modification {
 	 *
 	 * @throws TriggerException if a trigger raises an error
 	 */
-	private void finishTrigger(Txn transaction, DocumentImpl doc) throws TriggerException {
-        final DocumentTrigger trigger = triggers.get(doc.getDocId());
-        if(trigger != null)
-            {trigger.afterUpdateDocument(broker, transaction, doc);}
+	private void finishTrigger(final Txn transaction, final DocumentImpl doc) throws TriggerException {
+        if (triggers != null) {
+            final DocumentTrigger trigger = triggers.get(doc.getDocId());
+            if (trigger != null) {
+                trigger.afterUpdateDocument(broker, transaction, doc);
+            }
+        }
 	}
-	
+
+    @Override
 	public String toString() {
 		//		buf.append(XMLUtil.dump(content));
 		return "<xu:" + getName() + " select=\"" + selectStmt + "\">" + "</xu:" +	getName() +	">";
@@ -403,4 +420,11 @@ public abstract class Modification {
 			return node.getParentNode();
 		}
 	}
+
+    protected void addModifiedDocument(final DocumentImpl document) {
+        if (modifiedDocuments == null) {
+            modifiedDocuments = new DefaultDocumentSet();
+        }
+        modifiedDocuments.add(document);
+    }
 }

--- a/exist-core/src/main/java/org/exist/xupdate/Remove.java
+++ b/exist-core/src/main/java/org/exist/xupdate/Remove.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -37,6 +61,7 @@ import org.exist.util.LockException;
 import org.exist.xquery.XPathException;
 import org.w3c.dom.Node;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 /**
@@ -55,40 +80,32 @@ public class Remove extends Modification {
 	 * @param namespaces the namespaces.
 	 * @param variables the variables.
      */
-	public Remove(DBBroker broker, DocumentSet docs, String selectStmt,
-			Map<String, String> namespaces, Map<String, Object> variables) {
+	public Remove(final DBBroker broker, final DocumentSet docs, final String selectStmt, @Nullable final Map<String, String> namespaces, @Nullable final Map<String, Object> variables) {
 		super(broker, docs, selectStmt, namespaces, variables);
 	}
 
 	@Override
-	public long process(Txn transaction) throws PermissionDeniedException,
-			LockException, EXistException, XPathException, TriggerException {
+	public long process(final Txn transaction) throws PermissionDeniedException, LockException, EXistException, XPathException, TriggerException {
 		try {
 			final StoredNode[] ql = selectAndLock(transaction);
-			final NotificationService notifier = broker.getBrokerPool()
-					.getNotificationService();
+			final NotificationService notifier = broker.getBrokerPool().getNotificationService();
             for (final StoredNode node : ql) {
                 final DocumentImpl doc = node.getOwnerDocument();
-                if (!doc.getPermissions().validate(broker.getCurrentSubject(),
-                        Permission.WRITE)) {
+                if (!doc.getPermissions().validate(broker.getCurrentSubject(), Permission.WRITE)) {
                     throw new PermissionDeniedException("User '" + broker.getCurrentSubject().getName() + "' does not have permission to write to the document '" + doc.getDocumentURI() + "'!");
                 }
 
                 final NodeImpl parent = (NodeImpl) getParent(node);
-
                 if (parent == null || parent.getNodeType() != Node.ELEMENT_NODE) {
-                    throw new EXistException(
-                            "you cannot remove the document element. Use update "
-                                    + "instead");
+                    throw new EXistException("You cannot remove the document element. Use update instead");
                 } else {
                     parent.removeChild(transaction, node);
                 }
-                doc.setLastModified(System.currentTimeMillis());
-                modifiedDocuments.add(doc);
+                doc.setLastModified(System.currentTimeMillis()); addModifiedDocument(doc);
                 broker.storeXMLResource(transaction, doc);
                 notifier.notifyUpdate(doc, UpdateListener.UPDATE);
             }
-			checkFragmentation(transaction, modifiedDocuments);
+			checkFragmentation(transaction);
 			return ql.length;
 		} finally {
 			unlockDocuments(transaction);

--- a/exist-core/src/main/java/org/exist/xupdate/Rename.java
+++ b/exist-core/src/main/java/org/exist/xupdate/Rename.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -38,6 +62,8 @@ import org.exist.xquery.XPathException;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import javax.annotation.Nullable;
+
 /**
  * Implements an XUpdate rename operation.
  * 
@@ -52,16 +78,17 @@ public class Rename extends Modification {
      * @param namespaces the namespaces.
      * @param variables the variables.
      */
-    public Rename(DBBroker broker, DocumentSet docs, String selectStmt,
-            Map<String, String> namespaces, Map<String, Object> variables) {
+    public Rename(final DBBroker broker, final DocumentSet docs, final String selectStmt, @Nullable final Map<String, String> namespaces, @Nullable final Map<String, Object> variables) {
         super(broker, docs, selectStmt, namespaces, variables);
     }
 
     @Override
-    public long process(Txn transaction) throws PermissionDeniedException, LockException,
-            EXistException, XPathException, TriggerException {
+    public long process(final Txn transaction) throws PermissionDeniedException, LockException, EXistException, XPathException, TriggerException {
         final NodeList children = content;
-        if (children.getLength() == 0) {return 0;}
+        if (children.getLength() == 0) {
+            return 0;
+        }
+
         int modificationCount = 0;
         try {
             final StoredNode[] ql = selectAndLock(transaction);
@@ -76,21 +103,29 @@ public class Rename extends Modification {
                 final NodeImpl parent = (NodeImpl) getParent(node);
 
                 //update the document
-                final NamedNode newNode = switch (node.getNodeType()) {
-                    case Node.ELEMENT_NODE -> new ElementImpl(node.getExpression(), (ElementImpl) node);
-                    case Node.ATTRIBUTE_NODE -> new AttrImpl(node.getExpression(), (AttrImpl) node);
-                    default -> throw new EXistException("unsupported node-type");
-                };
+                final NamedNode newNode;
+                switch (node.getNodeType()) {
+                    case Node.ELEMENT_NODE:
+                        newNode = new ElementImpl(node.getExpression(), (ElementImpl) node);
+                        break;
+
+                    case Node.ATTRIBUTE_NODE:
+                        newNode = new AttrImpl(node.getExpression(), (AttrImpl) node);
+                        break;
+
+                    default:
+                        throw new EXistException("unsupported node-type");
+                }
                 newNode.setNodeName(new QName(newName, "", null));
                 parent.updateChild(transaction, node, newNode);
                 modificationCount++;
 
                 doc.setLastModified(System.currentTimeMillis());
-                modifiedDocuments.add(doc);
+                addModifiedDocument(doc);
                 broker.storeXMLResource(transaction, doc);
                 notifier.notifyUpdate(doc, UpdateListener.UPDATE);
             }
-            checkFragmentation(transaction, modifiedDocuments);
+            checkFragmentation(transaction);
         } finally {
             unlockDocuments(transaction);
         }

--- a/exist-core/src/main/java/org/exist/xupdate/Replace.java
+++ b/exist-core/src/main/java/org/exist/xupdate/Replace.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -42,6 +66,8 @@ import org.exist.xquery.XPathException;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import javax.annotation.Nullable;
+
 /**
  * Implements xupdate:replace, an extension to the XUpdate standard.
  * The modification replaces a node and its contents. It differs from xupdate:update
@@ -58,23 +84,23 @@ public class Replace extends Modification {
      * @param namespaces the namespaces.
      * @param variables the variables.
 	 */
-	public Replace(DBBroker broker, DocumentSet docs, String selectStmt,
-			Map<String, String> namespaces, Map<String, Object> variables) {
+	public Replace(final DBBroker broker, final DocumentSet docs, final String selectStmt, @Nullable final Map<String, String> namespaces, @Nullable final Map<String, Object> variables) {
 		super(broker, docs, selectStmt, namespaces, variables);
 	}
 	
 	@Override
-	public long process(Txn transaction) throws PermissionDeniedException, LockException,
-			EXistException, XPathException, TriggerException {
+	public long process(final Txn transaction) throws PermissionDeniedException, LockException, EXistException, XPathException, TriggerException {
 		final NodeList children = content;
-        if (children.getLength() == 0) 
-            {return 0;}
-        if (children.getLength() > 1)
-        	{throw new EXistException("xupdate:replace requires exactly one content node");}
+        if (children.getLength() == 0) {
+            return 0;
+        }
+        if (children.getLength() > 1) {
+            throw new EXistException("xupdate:replace requires exactly one content node");
+        }
         LOG.debug("processing replace ...");
         int modifications = children.getLength();
         try {
-            final StoredNode ql[] = selectAndLock(transaction);
+            final StoredNode[] ql = selectAndLock(transaction);
             final NotificationService notifier = broker.getBrokerPool().getNotificationService();
             Node temp;
             TextImpl text;
@@ -91,8 +117,7 @@ public class Replace extends Modification {
                 }
                 parent = (ElementImpl) node.getParentStoredNode();
                 if (parent == null) {
-                    throw new EXistException("The root element of a document can not be replaced with 'xu:replace'. " +
-                            "Please consider removing the document or use 'xu:update' to just replace the children of the root.");
+                    throw new EXistException("The root element of a document can not be replaced with 'xu:replace'. Please consider removing the document or use 'xu:update' to just replace the children of the root.");
                 }
                 switch (node.getNodeType()) {
                     case Node.ELEMENT_NODE:
@@ -120,11 +145,11 @@ public class Replace extends Modification {
                         throw new EXistException("unsupported node-type");
                 }
                 doc.setLastModified(System.currentTimeMillis());
-                modifiedDocuments.add(doc);
+                addModifiedDocument(doc);
                 broker.storeXMLResource(transaction, doc);
                 notifier.notifyUpdate(doc, UpdateListener.UPDATE);
             }
-            checkFragmentation(transaction, modifiedDocuments);
+            checkFragmentation(transaction);
         } finally {
             unlockDocuments(transaction);
         }

--- a/exist-core/src/main/java/org/exist/xupdate/Update.java
+++ b/exist-core/src/main/java/org/exist/xupdate/Update.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -43,6 +67,8 @@ import org.w3c.dom.Attr;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import javax.annotation.Nullable;
+
 /**
  * Implements the XUpdate update modification.
  * 
@@ -57,30 +83,32 @@ public class Update extends Modification {
      * @param namespaces the namespaces.
      * @param variables the variables.
      */
-    public Update(DBBroker broker, DocumentSet docs, String selectStmt,
-            Map<String, String> namespaces, Map<String, Object> variables) {
+    public Update(final DBBroker broker, final DocumentSet docs, final String selectStmt, @Nullable final Map<String, String> namespaces, @Nullable final Map<String, Object> variables) {
         super(broker, docs, selectStmt, namespaces, variables);
     }
 
     @Override
-    public long process(Txn transaction) throws PermissionDeniedException, LockException,
-            EXistException, XPathException, TriggerException {
+    public long process(final Txn transaction) throws PermissionDeniedException, LockException, EXistException, XPathException, TriggerException {
         final NodeList children = content;
-        if (children.getLength() == 0) 
-            {return 0;}
+        if (children.getLength() == 0) {
+            return 0;
+        }
+
         int modifications = children.getLength();
         try {
-            final StoredNode ql[] = selectAndLock(transaction);
+            final StoredNode[] ql = selectAndLock(transaction);
             final NotificationService notifier = broker.getBrokerPool().getNotificationService();
             for (final StoredNode node : ql) {
                 if (node == null) {
                     LOG.warn("select {} returned empty node", selectStmt);
                     continue;
                 }
+
                 final DocumentImpl doc = node.getOwnerDocument();
                 if (!doc.getPermissions().validate(broker.getCurrentSubject(), Permission.WRITE)) {
                     throw new PermissionDeniedException("User '" + broker.getCurrentSubject().getName() + "' does not have permission to write to the document '" + doc.getDocumentURI() + "'!");
                 }
+
                 switch (node.getNodeType()) {
                     case Node.ELEMENT_NODE:
                         if (modifications == 0) {
@@ -115,11 +143,11 @@ public class Update extends Modification {
                         throw new EXistException("unsupported node-type");
                 }
                 doc.setLastModified(System.currentTimeMillis());
-                modifiedDocuments.add(doc);
+                addModifiedDocument(doc);
                 broker.storeXMLResource(transaction, doc);
                 notifier.notifyUpdate(doc, UpdateListener.UPDATE);
             }
-            checkFragmentation(transaction, modifiedDocuments);
+            checkFragmentation(transaction);
         } finally {
             unlockDocuments(transaction);
         }

--- a/exist-core/src/main/java/org/exist/xupdate/XUpdateProcessor.java
+++ b/exist-core/src/main/java/org/exist/xupdate/XUpdateProcessor.java
@@ -54,14 +54,16 @@ package org.exist.xupdate;
 import antlr.RecognitionException;
 import antlr.TokenStreamException;
 import antlr.collections.AST;
+import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectRBTreeMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.exist.Indexer;
 import org.exist.Namespaces;
 import org.exist.dom.persistent.DocumentSet;
 import org.exist.dom.NodeListImpl;
 import org.exist.dom.persistent.NodeSetHelper;
 import org.exist.storage.DBBroker;
-import org.exist.util.Configuration;
 import org.exist.xquery.AnalyzeContextInfo;
 import org.exist.xquery.Constants;
 import org.exist.xquery.PathExpr;
@@ -90,6 +92,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.ext.LexicalHandler;
 
+import javax.annotation.Nullable;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -105,7 +108,7 @@ import java.util.*;
  * method. The modifications can then be executed via {@link Modification#process(org.exist.storage.txn.Txn)}.
  * 
  * @author Wolfgang Meier
- * 
+ * @author <a href="adam@evolvedbinary.com">Adam Retter</a>
  */
 public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 
@@ -133,6 +136,9 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 	
 	public final static String XUPDATE_NS = "http://www.xmldb.org/xupdate";
 
+    private static final String XML_SPACE_DEFAULT = "default";
+    private static final String XML_SPACE_PRESERVE = "preserve";
+
 	private final static Logger LOG = LogManager.getLogger(XUpdateProcessor.class);
 
     /**
@@ -148,15 +154,23 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
     /**
      * Whitespace preservation: the XUpdate processor
      * will honour xml:space attribute settings.
+     *
+     * This is the value from the database configuration.
+     *
+     * 1. false means 'default'
+     * 2. true means 'preserve'
      */
-    private boolean preserveWhitespace = false;
-    private boolean preserveWhitespaceTemp = false;
+    private final boolean defaultConfigPreserveWhiteSpace;
 
     /**
-     * Stack to maintain xml:space settings. The items on the
-     * stack are strings, containing either "default" or "preserve".
+     * Stack to maintain xml:space settings.
+     *
+     * 1. Null means use {@link #defaultConfigPreserveWhiteSpace}.
+     * 2. 0 bit means 'default'
+     * 3. 1 bit means 'preserve'
      */
-    private Deque<String> spaceStack = null;
+    @Nullable private BitSet whiteSpaceHandling = null;
+    private int whiteSpaceHandlingIdx = 0;
 
     /**
      * The modification we are currently processing.
@@ -164,13 +178,13 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
     private Modification modification = null;
 
     /** The DocumentBuilder used to create new nodes */
-    private DocumentBuilder builder;
+    private final DocumentBuilder builder;
 
     /** The Document object used to create new nodes */
     private Document doc;
 
     /** The current element stack. Contains the last elements processed. */
-    private Deque<Element> stack = new ArrayDeque<>();
+    private final Deque<Element> stack = new ArrayDeque<>();
 
     /** The last node that has been created */
     private Node currentNode = null;
@@ -186,7 +200,7 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
      * within the XUpdate will be added to this list. The final list
      * will be returned to the caller.
      */
-    private List<Modification> modifications = new ArrayList<>();
+    @Nullable private List<Modification> modifications = null;
 
     /** Temporary string buffer used for collecting text chunks */
     private final StringBuilder charBuf = new StringBuilder(64);
@@ -197,17 +211,17 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
      * Maps variable QName to the Sequence returned by
      * evaluating the variable expression.
      */
-    private Map<String, Object> variables = new TreeMap<>();
+    @Nullable private Map<String, Object> variables = null;
 
     /**
      * Keeps track of namespaces declared within the XUpdate.
      */
-    private Map<String, String> namespaces = new HashMap<>(10);
+    @Nullable private Map<String, String> namespaces = null;
 
     /**
      * Stack used to track conditionals.
      */
-    private Deque<Conditional> conditionals = new ArrayDeque<>();
+    @Nullable private Deque<Conditional> conditionals = null;
 
 	/**
 	 * Constructor for XUpdateProcessor.
@@ -217,30 +231,28 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 	 *
 	 * @throws ParserConfigurationException if the parser can't be configured
 	 */
-	public XUpdateProcessor(DBBroker broker, DocumentSet docs)
-		throws ParserConfigurationException {
+	public XUpdateProcessor(final DBBroker broker, final DocumentSet docs) throws ParserConfigurationException {
 		final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 		factory.setNamespaceAware(true);
 		factory.setValidating(false);
+
 		this.builder = factory.newDocumentBuilder();
 		this.broker = broker;
 		this.documentSet = docs;
-		//namespaces.put("xml", Namespaces.XML_NS);
-		//TODO : move this to a dedicated configure() method.
-		if (broker != null) {
-			final Configuration config = broker.getConfiguration();
-			Boolean temp;
-			if ((temp = (Boolean) config.getProperty("indexer.preserve-whitespace-mixed-content"))
-				!= null)
-				{preserveWhitespaceTemp = temp;}
-		}
+
+        if (broker != null) {
+            @Nullable final Boolean temp = broker.getConfiguration().getProperty(Indexer.PROPERTY_PRESERVE_WS_MIXED_CONTENT, Boolean.FALSE);
+            this.defaultConfigPreserveWhiteSpace = temp != null ? temp : false;
+		} else {
+            this.defaultConfigPreserveWhiteSpace = false;
+        }
 	}
 	
-	public void setBroker(DBBroker broker) {
+	public void setBroker(final DBBroker broker) {
 	    this.broker = broker;
 	}
 	
-	public void setDocumentSet(DocumentSet docs) {
+	public void setDocumentSet(final DocumentSet docs) {
 	    this.documentSet = docs;
 	}
 	
@@ -255,8 +267,7 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 	 * @throws IOException if an I/O error occurs
 	 * @throws SAXException if an error occurs whilst parsing
 	 */
-	public Modification[] parse(InputSource is)
-		throws ParserConfigurationException, IOException, SAXException {
+	public Modification[] parse(final InputSource is) throws ParserConfigurationException, IOException, SAXException {
 		final XMLReader reader = broker.getBrokerPool().getParserPool().borrowXMLReader();
 		try {
 			reader.setProperty(Namespaces.SAX_LEXICAL_HANDLER, this);
@@ -265,23 +276,23 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 			reader.setContentHandler(this);
 			
 			reader.parse(is);
-			final Modification mods[] = new Modification[modifications.size()];
-			return modifications.toArray(mods);
+            final Modification[] mods = new Modification[0];
+            if (modifications != null) {
+                return modifications.toArray(mods);
+            } else {
+                return mods;
+            }
 		} finally {
 			broker.getBrokerPool().getParserPool().returnXMLReader(reader);
 		}
 	}
 
 	@Override
-	public void setDocumentLocator(Locator locator) {
+	public void setDocumentLocator(final Locator locator) {
 	}
 
 	@Override
 	public void startDocument() throws SAXException {
-        // The default...
-        this.preserveWhitespace = preserveWhitespaceTemp;
-        this.spaceStack = new ArrayDeque<>();
-        this.spaceStack.push("default");
 	}
 
 	@Override
@@ -289,34 +300,28 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 	}
 
 	@Override
-	public void startPrefixMapping(String prefix, String uri)
-		throws SAXException {
+	public void startPrefixMapping(final String prefix, final String uri) throws SAXException {
+        if (namespaces == null) {
+             namespaces = new Object2ObjectArrayMap<>(4);
+        }
 		namespaces.put(prefix, uri);
 	}
 
 	@Override
-	public void endPrefixMapping(String prefix) throws SAXException {
+	public void endPrefixMapping(final String prefix) throws SAXException {
 		namespaces.remove(prefix);
 	}
 
 	@Override
-	public void startElement(
-		String namespaceURI,
-		String localName,
-		String qName,
-		Attributes atts)
-		throws SAXException {
+	public void startElement(final String namespaceURI, final String localName, final String qName, final Attributes atts) throws SAXException {
 		// save accumulated character content
-		if (inModification && charBuf.length() > 0) {
-//            String normalized = charBuf.toString();
-			final String normalized = preserveWhitespace ? charBuf.toString() :
-					charBuf.toString().trim();
+		if (inModification && !charBuf.isEmpty()) {
+			final String normalized = preserveWhiteSpace() ? charBuf.toString() : charBuf.toString().trim();
 
 			if (!normalized.isEmpty()) {
 				final Text text = doc.createTextNode(charBuf.toString());
 				final Element last = stack.peek();
 				if (last == null) {
-					//LOG.debug("appending text to fragment: " + text.getData());
 					contents.add(text);
 				} else {
 					last.appendChild(text);
@@ -324,30 +329,35 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 			}
 			charBuf.setLength(0);
 		}
+
 		if (namespaceURI.equals(XUPDATE_NS)) {
 			String select = null;
 			switch (localName) {
-				case MODIFICATIONS:
+
+                case MODIFICATIONS:
 					startModifications(atts);
 					return;
-				case VARIABLE:
+
+                case VARIABLE:
 					// variable declaration
 					startVariableDecl(atts);
 					return;
-				case IF:
+
+                case IF:
 					if (inModification) {
 						throw new SAXException("xupdate:if is not allowed inside a modification");
 					}
 					select = atts.getValue("test");
 					final Conditional cond = new Conditional(broker, documentSet, select, namespaces, variables);
-					conditionals.push(cond);
+					pushConditional(cond);
 					return;
-				case VALUE_OF:
+
+                case VALUE_OF:
 					if (!inModification) {
 						throw new SAXException("xupdate:value-of is not allowed outside a modification");
 					}
-
 					break;
+
 				case APPEND:
 				case INSERT_BEFORE:
 				case INSERT_AFTER:
@@ -356,30 +366,29 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 				case UPDATE:
 				case REPLACE:
 					if (inModification) {
-						throw new SAXException("nested modifications are not allowed");
+						throw new SAXException("Nested modifications are not allowed");
 					}
 					select = atts.getValue("select");
 					if (select == null) {
-						throw new SAXException(
-								localName + " requires a select attribute");
+						throw new SAXException(localName + " requires a select attribute");
 					}
 					doc = builder.newDocument();
 					contents = new NodeListImpl();
 					inModification = true;
 					break;
+
 				case ELEMENT:
 				case ATTRIBUTE:
 				case TEXT:
 				case PROCESSING_INSTRUCTION:
 				case COMMENT:
 					if (!inModification) {
-						throw new SAXException(
-								"creation elements are only allowed inside "
-										+ "a modification");
+						throw new SAXException("Creation elements are only allowed inside a modification");
 					}
 					charBuf.setLength(0);
 					break;
-				default:
+
+                default:
 					throw new SAXException("Unknown XUpdate element: " + qName);
 			}
 
@@ -393,12 +402,10 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 					modification = new Update(broker, documentSet, select, namespaces, variables);
 					break;
 				case INSERT_BEFORE:
-					modification =
-							new Insert(broker, documentSet, select, Insert.INSERT_BEFORE, namespaces, variables);
+					modification = new Insert(broker, documentSet, select, Insert.INSERT_BEFORE, namespaces, variables);
 					break;
 				case INSERT_AFTER:
-					modification =
-							new Insert(broker, documentSet, select, Insert.INSERT_AFTER, namespaces, variables);
+					modification = new Insert(broker, documentSet, select, Insert.INSERT_AFTER, namespaces, variables);
 					break;
 				case REMOVE:
 					modification = new Remove(broker, documentSet, select, namespaces, variables);
@@ -414,28 +421,26 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 				case ELEMENT: {
 					String name = atts.getValue("name");
 					if (name == null) {
-						throw new SAXException("element requires a name attribute");
+						throw new SAXException("Element requires a name attribute");
 					}
 					final int p = name.indexOf(':');
 					String namespace = null;
-					String prefix = "";
+					String prefix = XMLConstants.DEFAULT_NS_PREFIX;
 					if (p != Constants.STRING_NOT_FOUND) {
 						prefix = name.substring(0, p);
 						if (name.length() == p + 1) {
-							throw new SAXException(
-									"illegal prefix in qname: " + name);
+							throw new SAXException("Illegal prefix in qname: " + name);
 						}
 						name = name.substring(p + 1);
 						namespace = atts.getValue("namespace");
-						if (namespace == null) {
+						if (namespace == null && namespaces != null) {
 							namespace = namespaces.get(prefix);
 						}
 						if (namespace == null) {
-							throw new SAXException(
-									"no namespace defined for prefix " + prefix);
+							throw new SAXException("No namespace defined for prefix " + prefix);
 						}
 					}
-					Element elem;
+					final Element elem;
 					if (namespace != null && !namespace.isEmpty()) {
 						elem = doc.createElementNS(namespace, name);
 						elem.setPrefix(prefix);
@@ -454,31 +459,28 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 					this.setWhitespaceHandling(elem);
 					break;
 				}
+
 				case ATTRIBUTE: {
 					final String name = atts.getValue("name");
 					if (name == null) {
-						throw new SAXException("attribute requires a name attribute");
+						throw new SAXException("Attribute requires a name attribute");
 					}
 					final int p = name.indexOf(':');
 					String namespace = null;
 					if (p != Constants.STRING_NOT_FOUND) {
 						final String prefix = name.substring(0, p);
 						if (name.length() == p + 1) {
-							throw new SAXException(
-									"illegal prefix in qname: " + name);
+							throw new SAXException("Illegal prefix in qname: " + name);
 						}
 						namespace = atts.getValue("namespace");
-						if (namespace == null) {
+						if (namespace == null && namespaces != null) {
 							namespace = namespaces.get(prefix);
 						}
 						if (namespace == null) {
-							throw new SAXException(
-									"no namespace defined for prefix " + prefix);
+							throw new SAXException("No namespace defined for prefix " + prefix);
 						}
 					}
-					Attr attrib = namespace != null && !namespace.isEmpty() ?
-							doc.createAttributeNS(namespace, name) :
-							doc.createAttribute(name);
+					final Attr attrib = namespace != null && !namespace.isEmpty() ? doc.createAttributeNS(namespace, name) : doc.createAttribute(name);
 					if (stack.isEmpty()) {
 						for (int i = 0; i < contents.getLength(); i++) {
 							final Node n = contents.item(i);
@@ -488,19 +490,15 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 								ns = XMLConstants.NULL_NS_URI;
 							}
 							// check for duplicate attributes
-							if (n.getNodeType() == Node.ATTRIBUTE_NODE &&
-									nname.equals(name) &&
-									ns.equals(namespace)) {
+							if (n.getNodeType() == Node.ATTRIBUTE_NODE && nname.equals(name) && ns.equals(namespace)) {
 								throw new SAXException("The attribute " + attrib.getNodeName() + " cannot be specified twice");
 							}
 						}
 						contents.add(attrib);
 					} else {
 						final Element last = stack.peek();
-						if (namespace != null && last.hasAttributeNS(namespace, name) ||
-								namespace == null && last.hasAttribute(name)) {
-							throw new SAXException("The attribute " + attrib.getNodeName() + " cannot be specified " +
-									"twice on the same element");
+						if (namespace != null && last.hasAttributeNS(namespace, name) || namespace == null && last.hasAttribute(name)) {
+							throw new SAXException("The attribute " + attrib.getNodeName() + " cannot be specified twice on the same element");
 						}
 						if (namespace != null) {
 							last.setAttributeNodeNS(attrib);
@@ -514,6 +512,7 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 					// process value-of
 					break;
 				}
+
 				case VALUE_OF:
 					select = atts.getValue("select");
 					if (select == null) {
@@ -546,24 +545,20 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 					break;
 			}
 		} else if (inModification) {
-			final Element elem = namespaceURI != null && !namespaceURI.isEmpty() ?
-									doc.createElementNS(namespaceURI, qName) :
-									doc.createElement(qName);
-			Attr a;
+			final Element elem = namespaceURI != null && !namespaceURI.isEmpty() ? doc.createElementNS(namespaceURI, qName) : doc.createElement(qName);
 			for (int i = 0; i < atts.getLength(); i++) {
                 final String name = atts.getQName(i);
                 final String nsURI = atts.getURI(i);
                 if (name.startsWith("xmlns")) {
                     // Why are these showing up? They are supposed to be stripped out?
                 } else {
-                    a = nsURI != null ?
-                          doc.createAttributeNS(nsURI, name) :
-                            doc.createAttribute(name);
+                    final Attr a = nsURI != null ? doc.createAttributeNS(nsURI, name) : doc.createAttribute(name);
                     a.setValue(atts.getValue(i));
-                    if (nsURI != null)
-                    {elem.setAttributeNodeNS(a);}
-                    else
-                      {elem.setAttributeNode(a);}
+                    if (nsURI != null) {
+                        elem.setAttributeNodeNS(a);
+                    } else {
+                        elem.setAttributeNode(a);
+                    }
                 }
 			}
 			final Element last = stack.peek();
@@ -578,36 +573,32 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 		}
 	}
 
-	private void startVariableDecl(Attributes atts) throws SAXException {
+	private void startVariableDecl(final Attributes atts) throws SAXException {
 		final String select = atts.getValue("select");
-		if (select == null)
-			{throw new SAXException("variable declaration requires a select attribute");}
+		if (select == null) {
+            throw new SAXException("Variable declaration requires a select attribute");
+        }
 		final String name = atts.getValue("name");
-		if (name == null)
-			{throw new SAXException("variable declarations requires a name attribute");}
+		if (name == null) {
+            throw new SAXException("Variable declarations requires a name attribute");
+        }
 		createVariable(name, select);
 	}
 
-	private void startModifications(Attributes atts) throws SAXException {
+	private void startModifications(final Attributes atts) throws SAXException {
 		final String version = atts.getValue("version");
-		if (version == null)
-			{throw new SAXException(
-				"version attribute is required for "
-					+ "element modifications");}
-		if (!"1.0".equals(version))
-			{throw new SAXException(
-				"Version "
-					+ version
-					+ " of XUpdate "
-					+ "not supported.");}
+		if (version == null) {
+            throw new SAXException("version attribute is required for element modifications");
+        }
+		if (!"1.0".equals(version)) {
+            throw new SAXException("Version " + version + " of XUpdate not supported.");
+        }
 	}
 
 	@Override
-	public void endElement(String namespaceURI, String localName, String qName)
-		throws SAXException {
-		if (inModification && charBuf.length() > 0) {
-			final String normalized = preserveWhitespace ? charBuf.toString() :
-					charBuf.toString().trim();
+	public void endElement(final String namespaceURI, final String localName, final String qName) throws SAXException {
+		if (inModification && !charBuf.isEmpty()) {
+			final String normalized = preserveWhiteSpace() ? charBuf.toString() : charBuf.toString().trim();
 			if (!normalized.isEmpty()) {
 				final Text text = doc.createTextNode(charBuf.toString());
 				final Element last = stack.peek();
@@ -619,15 +610,19 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 			}
 			charBuf.setLength(0);
 		}
+
 		if (XUPDATE_NS.equals(namespaceURI)) {
 			if (IF.equals(localName)) {
-				final Conditional cond = conditionals.pop();
-				modifications.add(cond);
-			} else if (localName.equals(ELEMENT)) {
+				final Conditional cond = popConditional();
+				addModification(cond);
+
+            } else if (localName.equals(ELEMENT)) {
 				this.resetWhitespaceHandling(stack.pop());
-			} else if (localName.equals(ATTRIBUTE)) {
+
+            } else if (localName.equals(ATTRIBUTE)) {
 				inAttribute = false;
-			} else if (localName.equals(APPEND)
+
+            } else if (localName.equals(APPEND)
 				|| localName.equals(UPDATE)
 				|| localName.equals(REMOVE)
 				|| localName.equals(RENAME)
@@ -636,11 +631,11 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 				|| localName.equals(INSERT_AFTER)) {
 				inModification = false;
 				modification.setContent(contents);
-				final Conditional cond = conditionals.peek();
+				final Conditional cond = peekConditional();
 				if(cond != null) {
 					cond.addModification(modification);
 				} else {
-					modifications.add(modification);
+					addModification(modification);
 				}
 				modification = null;
 			}
@@ -650,16 +645,16 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 	}
 
 	@Override
-	public void characters(char[] ch, int start, int length)
-		throws SAXException {
+	public void characters(final char[] ch, final int start, final int length) throws SAXException {
 		if (inModification) {
 			if (inAttribute) {
 			    final Attr attr = (Attr)currentNode;
 			    String val = attr.getValue();
-			    if(val == null)
-			        {val = new String(ch, start, length);}
-			    else
-			        {val += new String(ch, start, length);}
+			    if (val == null) {
+                    val = new String(ch, start, length);
+                } else {
+                    val += new String(ch, start, length);
+                }
 				attr.setValue(val);
 			} else {
 				charBuf.append(ch, start, length);
@@ -668,17 +663,18 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 	}
 
 	@Override
-	public void ignorableWhitespace(char[] ch, int start, int length)
+	public void ignorableWhitespace(final char[] ch, final int start, final int length)
 		throws SAXException {
-        if (this.preserveWhitespace) {
+        if (preserveWhiteSpace()) {
             if (this.inModification) {
                 if (this.inAttribute) {
                     final Attr attr = (Attr) this.currentNode;
                     String val = attr.getValue();
-                    if(val == null)
-                        {val = new String(ch, start, length);}
-                    else
-                        {val += new String(ch, start, length);}
+                    if (val == null) {
+                        val = new String(ch, start, length);
+                    } else {
+                        val += new String(ch, start, length);
+                    }
                     attr.setValue(val);
                 } else {
                     this.charBuf.append(ch, start, length);
@@ -687,36 +683,27 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
         }
 	}
     
-    private void setWhitespaceHandling(Element e) {
+    private void setWhitespaceHandling(final Element e) {
         final String wsSetting = e.getAttributeNS(Namespaces.XML_NS, "space");
-        if ("preserve".equals(wsSetting)) {
-            this.spaceStack.push(wsSetting);
-            this.preserveWhitespace = true;
-        } else if ("default".equals(wsSetting)) {
-            this.spaceStack.push(wsSetting);
-            this.preserveWhitespace = preserveWhitespaceTemp;
+        if (XML_SPACE_PRESERVE.equals(wsSetting)) {
+            pushWhiteSpaceHandling(true);
+        } else if (XML_SPACE_DEFAULT.equals(wsSetting)) {
+            pushWhiteSpaceHandling(false);
         }
         // Otherwise, don't change what's currently in effect!
     }
     
-    private void resetWhitespaceHandling(Element e) {
+    private void resetWhitespaceHandling(final Element e) {
         final String wsSetting = e.getAttributeNS(Namespaces.XML_NS, "space");
-        if ("preserve".equals(wsSetting) || "default".equals(wsSetting)) {
+        if (XML_SPACE_PRESERVE.equals(wsSetting) || XML_SPACE_DEFAULT.equals(wsSetting)) {
             // Since an opinion was expressed, restore what was previously set:
-            this.spaceStack.pop();
-            if (this.spaceStack.isEmpty()) {
-                // This is the default...
-                this.preserveWhitespace = preserveWhitespaceTemp;
-            } else {
-                this.preserveWhitespace = ("preserve".equals(this.spaceStack.peek()));
-            }
+            popWhiteSpaceHandling();
         }
     }
 
 	@Override
-	public void processingInstruction(String target, String data)
-		throws SAXException {
-		if (inModification && charBuf.length() > 0) {
+	public void processingInstruction(final String target, final String data) throws SAXException {
+		if (inModification && !charBuf.isEmpty()) {
 			final String normalized =
 					charBuf.toString().trim();
 			if (!normalized.isEmpty()) {
@@ -724,7 +711,7 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 				final Element last = stack.peek();
 				if (last == null) {
 					if (LOG.isDebugEnabled()) {
-						LOG.debug("appending text to fragment: {}", text.getData());
+						LOG.debug("Appending text to fragment: {}", text.getData());
 					}
 					contents.add(text);
 				} else {
@@ -746,33 +733,37 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 	}
 
 	@Override
-	public void skippedEntity(String name) throws SAXException {
+	public void skippedEntity(final String name) throws SAXException {
 	}
 
-	private void createVariable(String name, String select)
-		throws SAXException {
-		if (LOG.isDebugEnabled())
-			{
-				LOG.debug("creating variable {} as {}", name, select);}
+	private void createVariable(final String name, final String select) throws SAXException {
+		if (LOG.isDebugEnabled()) {
+            LOG.debug("Creating variable {} as {}", name, select);
+        }
 		
 		final Sequence result = processQuery(select);
 		
-		if (LOG.isDebugEnabled())
-			{
-				LOG.debug("found {} for variable {}", result.getItemCount(), name);}
-		
+		if (LOG.isDebugEnabled()) {
+            LOG.debug("Found {} for variable {}", result.getItemCount(), name);
+        }
+
+        if (variables == null) {
+            variables = new Object2ObjectRBTreeMap<>();
+        }
 		variables.put(name, result);
 	}
 	
-	private Sequence processQuery(String select) throws SAXException {
+	private Sequence processQuery(final String select) throws SAXException {
         XQueryContext context = null;
         try {
 			context = new XQueryContext(broker.getBrokerPool());
 			context.setStaticallyKnownDocuments(documentSet);
 
-			for (final Map.Entry<String, String> namespace : namespaces.entrySet()) {
-				context.declareNamespace(namespace.getKey(), namespace.getValue());
-			}
+            if (namespaces != null) {
+                for (final Map.Entry<String, String> namespace : namespaces.entrySet()) {
+                    context.declareNamespace(namespace.getKey(), namespace.getValue());
+                }
+            }
 
 			// TODO(pkaminsk2): why replicate XQuery.compile here?
 			final XQueryLexer lexer = new XQueryLexer(context, new StringReader(select));
@@ -785,9 +776,9 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 
 			final AST ast = parser.getAST();
 			
-			if (LOG.isDebugEnabled())
-				{
-					LOG.debug("generated AST: {}", ast.toStringTree());}
+			if (LOG.isDebugEnabled()) {
+                LOG.debug("Generated AST: {}", ast.toStringTree());
+            }
 
 			final PathExpr expr = new PathExpr(context);
 			treeParser.xpath(ast, expr);
@@ -795,15 +786,18 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 				throw new SAXException(treeParser.getErrorMessage());
 			}
 
-            for (final Map.Entry<String, Object> variable : variables.entrySet()) {
-                context.declareVariable(variable.getKey(), true, variable.getValue());
+            if (variables != null) {
+                for (final Map.Entry<String, Object> variable : variables.entrySet()) {
+                    context.declareVariable(variable.getKey(), true, variable.getValue());
+                }
             }
 
 			expr.analyze(new AnalyzeContextInfo());
 			final Sequence seq = expr.eval(null, null);
 			return seq;
+
 		} catch (final RecognitionException | TokenStreamException e) {
-			LOG.warn("error while creating variable", e);
+			LOG.warn("Error while creating variable", e);
 			throw new SAXException(e);
 		} catch (final XPathException e) {
 			throw new SAXException(e);
@@ -816,10 +810,9 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 	}
 
 	@Override
-	public void comment(char[] ch, int start, int length) throws SAXException {
-		if (inModification && charBuf.length() > 0) {
-			final String normalized =
-					charBuf.toString().trim();
+	public void comment(final char[] ch, final int start, final int length) throws SAXException {
+		if (inModification && !charBuf.isEmpty()) {
+			final String normalized = charBuf.toString().trim();
 			if (!normalized.isEmpty()) {
 				final Text text = doc.createTextNode(normalized);
 				final Element last = stack.peek();
@@ -852,7 +845,7 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 	}
 
 	@Override
-	public void endEntity(String name) throws SAXException {
+	public void endEntity(final String name) throws SAXException {
 	}
 
 	@Override
@@ -860,32 +853,93 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 	}
 
 	@Override
-	public void startDTD(String name, String publicId, String systemId)
-		throws SAXException {
+	public void startDTD(final String name, final String publicId, final String systemId) throws SAXException {
 	}
 
 	@Override
-	public void startEntity(String name) throws SAXException {
+	public void startEntity(final String name) throws SAXException {
 	}
 
 	public void reset() {
-        this.preserveWhitespace = false;
-        this.spaceStack = null;
-        
+        if (this.whiteSpaceHandling != null) {
+            this.whiteSpaceHandling.clear();
+        }
+        this.whiteSpaceHandlingIdx = 0;
 	    this.inModification = false;
 		this.inAttribute = false;
 		this.modification = null;
-		this.doc = null;
+		this.builder.reset();
+        this.doc = null;
 		this.contents = null;
-		this.stack.clear();
+        if (this.stack != null) {
+            this.stack.clear();
+        }
 		this.currentNode = null;
 		this.broker = null;
 		this.documentSet = null;
-		this.modifications.clear();
+        if (this.modifications != null) {
+            this.modifications.clear();
+        }
 		this.charBuf.setLength(0);
-		this.variables.clear();
-		this.namespaces.clear();
-		this.conditionals.clear();
-		//this.namespaces.put("xml", Namespaces.XML_NS);
+		if (variables != null) {
+            this.variables.clear();
+        }
+        if (namespaces != null) {
+            this.namespaces.clear();
+        }
+        if (conditionals != null) {
+            this.conditionals.clear();
+        }
 	}
+
+    private boolean preserveWhiteSpace() {
+        if (whiteSpaceHandling == null) {
+            return defaultConfigPreserveWhiteSpace;
+        }
+        return whiteSpaceHandling.get(whiteSpaceHandlingIdx);
+    }
+
+    private void pushWhiteSpaceHandling(final boolean preserveWhiteSpace) {
+        if (whiteSpaceHandling == null) {
+            whiteSpaceHandling = new BitSet();
+        }
+        whiteSpaceHandling.set(whiteSpaceHandlingIdx++, preserveWhiteSpace);
+    }
+
+    private boolean popWhiteSpaceHandling() {
+        if (whiteSpaceHandling == null) {
+            return defaultConfigPreserveWhiteSpace;
+        }
+        final boolean result = whiteSpaceHandling.get(whiteSpaceHandlingIdx);
+        whiteSpaceHandling.clear(whiteSpaceHandlingIdx--);
+        return result;
+    }
+
+    private void addModification(final Modification modification) {
+        if (modifications == null) {
+            modifications = new ArrayList<>(1);
+        }
+        modifications.add(modification);
+    }
+
+    private void pushConditional(final Conditional conditional) {
+        if (conditionals == null) {
+            conditionals = new ArrayDeque<>();
+        }
+        conditionals.push(conditional);
+    }
+
+    private Conditional popConditional() {
+        if (conditionals == null) {
+            throw new NoSuchElementException();
+        }
+        return conditionals.pop();
+    }
+
+    private @Nullable Conditional peekConditional() {
+        if (conditionals == null) {
+            throw null;
+        }
+        return conditionals.peek();
+    }
 }

--- a/exist-core/src/main/java/org/exist/xupdate/XUpdateProcessor.java
+++ b/exist-core/src/main/java/org/exist/xupdate/XUpdateProcessor.java
@@ -134,7 +134,8 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 	public static final String VARIABLE = "variable";
 	public static final String IF = "if";
 	
-	public final static String XUPDATE_NS = "http://www.xmldb.org/xupdate";
+    public static final String XUPDATE_NS = "http://www.xmldb.org/xupdate";
+    public static final String XUPDATE_PREFIX = "xupdate";
 
     private static final String XML_SPACE_DEFAULT = "default";
     private static final String XML_SPACE_PRESERVE = "preserve";
@@ -759,9 +760,15 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 			context = new XQueryContext(broker.getBrokerPool());
 			context.setStaticallyKnownDocuments(documentSet);
 
+            context.declareNamespace(XUPDATE_PREFIX, XUPDATE_NS);
             if (namespaces != null) {
                 for (final Map.Entry<String, String> namespace : namespaces.entrySet()) {
-                    context.declareNamespace(namespace.getKey(), namespace.getValue());
+                    final String prefix = namespace.getKey();
+                    final String uri = namespace.getValue();
+                    // NOTE(AR) guard against declaring XUpdate as the default namespace prefix
+                    if (!(XMLConstants.DEFAULT_NS_PREFIX.equals(prefix) && XUPDATE_NS.equals(uri))) {
+                        context.declareNamespace(prefix, uri);
+                    }
                 }
             }
 


### PR DESCRIPTION
Cleans up the code in the XUpdate implementation. It also reduces its memory use by not allocating a number of collections unless they are actually needed. In addition it fixes a bug with processing XUpdate documents where the XUpdate Namespace is bound to the default namespace prefix, i.e. `xmlns="http://www.xmldb.org/xupdate"`.