### PR TITLE
[7.x.x] Ignore the 'autodeploy' folder if it does not exist

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -945,6 +945,7 @@
                                 <include>src/main/java/org/exist/numbering/NodeIdFactory.java</include>
                                 <include>src/main/java/org/exist/protocolhandler/xmldb/XmldbURL.java</include>
                                 <include>src/main/java/org/exist/protocolhandler/xmlrpc/XmlrpcUpload.java</include>
+                                <include>src/main/java/org/exist/repo/AutoDeploymentTrigger.java</include>
                                 <include>src/main/java/org/exist/repo/ClasspathHelper.java</include>
                                 <include>src/main/java/org/exist/repo/Deployment.java</include>
                                 <include>src/main/java/org/exist/repo/ExistRepository.java</include>
@@ -1540,6 +1541,7 @@
                                 <exclude>src/main/java/org/exist/numbering/NodeIdFactory.java</exclude>
                                 <exclude>src/main/java/org/exist/protocolhandler/xmldb/XmldbURL.java</exclude>
                                 <exclude>src/main/java/org/exist/protocolhandler/xmlrpc/XmlrpcUpload.java</exclude>
+                                <exclude>src/main/java/org/exist/repo/AutoDeploymentTrigger.java</exclude>
                                 <exclude>src/main/java/org/exist/repo/ClasspathHelper.java</exclude>
                                 <exclude>src/main/java/org/exist/repo/Deployment.java</exclude>
                                 <exclude>src/main/java/org/exist/repo/ExistRepository.java</exclude>

--- a/exist-core/src/main/java/org/exist/repo/AutoDeploymentTrigger.java
+++ b/exist-core/src/main/java/org/exist/repo/AutoDeploymentTrigger.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -81,7 +105,7 @@ public class AutoDeploymentTrigger implements StartupTrigger {
             }
         }
 
-        if (!Files.isReadable(autodeployDir) && Files.isDirectory(autodeployDir)) {
+        if (!(Files.isReadable(autodeployDir) && Files.isDirectory(autodeployDir))) {
             LOG.warn("Unable to read autodeploy directory: {}", autodeployDir);
             return;
         }


### PR DESCRIPTION
The existence check for the `autodeploy` folder was coded incorrectly, which meant that a missing folder was not detected and then an exception would be thrown. This corrects this, so that if the `autodeploy` folder is missing, then no further work needs to be performed by the `AutoDeploymentTrigger`.