### PR TITLE
[6.x.x] Restore compatibility with EXPath Crypto Module

### DIFF
--- a/exist-core/src/main/java/org/exist/http/RESTServer.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServer.java
@@ -1501,7 +1501,7 @@ public class RESTServer {
             }
 
             if (localname == null) {
-                throw new XPathException(ErrorCodes.W3CErrorCode.XPDY0002, String.format("External variable is missing local name in its qualified name. Prefix=%s URI=%s", prefix, uri));
+                throw new XPathException(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), String.format("External variable is missing local name in its qualified name. Prefix=%s URI=%s", prefix, uri));
             }
 
             if (uri == null && prefix != null) {
@@ -1516,7 +1516,7 @@ public class RESTServer {
             }
 
             if (!context.isExternalVariableDeclared(q)) {
-                throw new XPathException(ErrorCodes.W3CErrorCode.XPDY0002, "External variable " + q + " is not declared in the XQuery");
+                throw new XPathException(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "External variable " + q + " is not declared in the XQuery");
             }
 
             if (uri != null && prefix != null) {

--- a/exist-core/src/main/java/org/exist/xmldb/LocalXPathQueryService.java
+++ b/exist-core/src/main/java/org/exist/xmldb/LocalXPathQueryService.java
@@ -431,11 +431,11 @@ public class LocalXPathQueryService extends AbstractLocalService implements EXis
             try {
                 varName = QName.parse(context, varNameStr);
             } catch (final QName.IllegalQNameException e) {
-                throw new XPathException(org.exist.xquery.ErrorCodes.W3CErrorCode.XPST0081, "Error declaring variable, invalid qname: " + varNameStr + ". " + e.getMessage(), e);
+                throw new XPathException(org.exist.xquery.ErrorCodes.W3CErrorCode.XPST0081.getErrorCode(), "Error declaring variable, invalid qname: " + varNameStr + ". " + e.getMessage(), e);
             }
 
             if (!context.isExternalVariableDeclared(varName)) {
-                throw new XPathException(org.exist.xquery.ErrorCodes.W3CErrorCode.XPDY0002, "External variable " + varName + " is not declared in the XQuery");
+                throw new XPathException(org.exist.xquery.ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "External variable " + varName + " is not declared in the XQuery");
             }
 
             context.declareVariable(varName, true, entry.getValue());

--- a/exist-core/src/main/java/org/exist/xmldb/RemoteXPathQueryService.java
+++ b/exist-core/src/main/java/org/exist/xmldb/RemoteXPathQueryService.java
@@ -209,7 +209,7 @@ public class RemoteXPathQueryService extends AbstractRemote implements EXistXPat
             final QName qname = new QName(localPart, namespaceUri, prefix);
             errorCode = org.exist.xquery.ErrorCodes.fromQName(qname);
         } else {
-            errorCode = org.exist.xquery.ErrorCodes.EXistErrorCode.ERROR;
+            errorCode = org.exist.xquery.ErrorCodes.EXistErrorCode.ERROR.getErrorCode();
         }
 
         return new XPathException(line, column, errorCode, message);

--- a/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
@@ -279,11 +279,11 @@ public class RpcConnection implements RpcAPI {
                     try {
                         varName = QName.parse(context, varNameStr);
                     } catch (final QName.IllegalQNameException e) {
-                        throw new XPathException(org.exist.xquery.ErrorCodes.W3CErrorCode.XPST0081, "Error declaring variable, invalid qname: " + varNameStr + ". " + e.getMessage(), e);
+                        throw new XPathException(org.exist.xquery.ErrorCodes.W3CErrorCode.XPST0081.getErrorCode(), "Error declaring variable, invalid qname: " + varNameStr + ". " + e.getMessage(), e);
                     }
 
                     if (!context.isExternalVariableDeclared(varName)) {
-                        throw new XPathException(org.exist.xquery.ErrorCodes.W3CErrorCode.XPDY0002, "External variable " + varName + " is not declared in the XQuery");
+                        throw new XPathException(org.exist.xquery.ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "External variable " + varName + " is not declared in the XQuery");
                     }
 
                     if (LOG.isDebugEnabled()) {

--- a/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
+++ b/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
@@ -57,7 +57,7 @@ public class ErrorCodes {
     /**
      * A defined Error Code.
      */
-    public interface ErrorCode {
+    public interface IErrorCode {
 
         /**
          * Get the name of the error code.
@@ -74,6 +74,34 @@ public class ErrorCodes {
         @Nullable String getDescription();
     }
 
+    public static class ErrorCode {
+        private final QName errorQName;
+        private @Nullable final String description;
+
+        public ErrorCode(final String code, @Nullable final String description) {
+            this.errorQName = new QName(code, Namespaces.EXIST_XQUERY_XPATH_ERROR_NS, Namespaces.EXIST_XQUERY_XPATH_ERROR_PREFIX);
+            this.description = description;
+        }
+
+        public ErrorCode(final QName errorQName, final String description) {
+            this.errorQName = errorQName;
+            this.description = description;
+        }
+
+        public QName getErrorQName() {
+            return errorQName;
+        }
+
+        @Override
+        public String toString() {
+            return "(" + errorQName.toString() + "): " + description;
+        }
+
+        public @Nullable String getDescription(){
+            return description;
+        }
+    }
+
     /**
      * Get a defined Error Code by its qualified name.
      *
@@ -85,10 +113,10 @@ public class ErrorCodes {
      */
     public static ErrorCode fromQName(final QName qname) {
         if (Namespaces.W3C_XQUERY_XPATH_ERROR_NS.equals(qname.getNamespaceURI())) {
-            return W3CErrorCode.valueOf(qname.getLocalPart());
+            return W3CErrorCode.valueOf(qname.getLocalPart()).errorCode;
 
         } else if (Namespaces.EXIST_XQUERY_XPATH_ERROR_NS.equals(qname.getNamespaceURI())) {
-            return EXistErrorCode.valueOf(qname.getLocalPart());
+            return EXistErrorCode.valueOf(qname.getLocalPart()).errorCode;
         }
 
         throw new IllegalArgumentException("There is no error code defined for the name: " + qname);
@@ -97,7 +125,7 @@ public class ErrorCodes {
     /**
      * Error codes defined in W3C standards.
      */
-    public enum W3CErrorCode implements ErrorCode {
+    public enum W3CErrorCode implements IErrorCode {
         XPDY0002 ("It is a dynamic error if evaluation of an expression relies on some part of the dynamic context that has not been assigned a value."),
         XPST0003 ("It is a static error if an expression is not a valid instance of the grammar defined in A.1 EBNF."),
         XPTY0004 ("It is a type error if, during the static analysis phase, an expression is found to have a static type that is not appropriate for the context in which the expression occurs, or during the dynamic evaluation phase, the dynamic type of a value does not match a required type as specified by the matching rules in 2.5.4 SequenceType Matching."),
@@ -298,22 +326,29 @@ public class ErrorCodes {
         FOXT0006 ("XSLT output contains non-accepted characters"),
         XTSE0165 ("It is a static error if the processor is not able to retrieve the resource identified by the URI reference [ in the href attribute of xsl:include or xsl:import] , or if the resource that is retrieved does not contain a stylesheet module conforming to this specification.");
 
-        private final QName qname;
-        private final String description;
+        private final ErrorCode errorCode;
 
         W3CErrorCode(final String description) {
-            this.qname = new QName(name(), Namespaces.W3C_XQUERY_XPATH_ERROR_NS, Namespaces.W3C_XQUERY_XPATH_ERROR_PREFIX);
-            this.description = description;
+            this.errorCode = new ErrorCode(new QName(name(), Namespaces.W3C_XQUERY_XPATH_ERROR_NS, Namespaces.W3C_XQUERY_XPATH_ERROR_PREFIX), description);
         }
 
         @Override
         public QName getErrorQName() {
-            return qname;
+            return errorCode.getErrorQName();
         }
 
         @Override
         public @Nullable String getDescription() {
-            return description;
+            return errorCode.getDescription();
+        }
+
+        /**
+         * Get the error code.
+         *
+         * @return the error code.
+         */
+        public ErrorCode getErrorCode() {
+            return errorCode;
         }
     }
 
@@ -330,7 +365,7 @@ public class ErrorCodes {
      * nnnn = number
      * </p>
      */
-    public enum EXistErrorCode implements ErrorCode {
+    public enum EXistErrorCode implements IErrorCode {
         EXXQDY0001 ("Index cannot be applied to the given expression."),
         EXXQDY0002 ("Error parsing XML."),
         EXXQDY0003 ("Only Supported for xquery version \"3.0\" and later."),
@@ -349,32 +384,35 @@ public class ErrorCodes {
         @Deprecated
         ERROR ("Error.");
 
-        private final QName qname;
-        private final String description;
+        private final ErrorCode errorCode;
 
         EXistErrorCode(final String description) {
-            this.qname = new QName(name(), Namespaces.EXIST_XQUERY_XPATH_ERROR_NS, Namespaces.EXIST_XQUERY_XPATH_ERROR_PREFIX);
-            this.description = description;
+            this.errorCode = new ErrorCode(new QName(name(), Namespaces.EXIST_XQUERY_XPATH_ERROR_NS, Namespaces.EXIST_XQUERY_XPATH_ERROR_PREFIX), description);
         }
 
         @Override
         public QName getErrorQName() {
-            return qname;
+            return errorCode.getErrorQName();
         }
 
         @Override
         public @Nullable String getDescription() {
-            return description;
+            return errorCode.getDescription();
+        }
+
+        /**
+         * Get the error code.
+         *
+         * @return the error code.
+         */
+        public ErrorCode getErrorCode() {
+            return errorCode;
         }
     }
 
-    public static class JavaErrorCode implements ErrorCode {
-        private final QName qname;
-        private @Nullable final String description;
-
+    public static class JavaErrorCode extends ErrorCode {
         private JavaErrorCode(final QName qname, @Nullable final String description) {
-            this.qname = qname;
-            this.description = description;
+            super(qname, description);
         }
 
         public static JavaErrorCode fromThrowable(final Throwable throwable) {
@@ -389,35 +427,11 @@ public class ErrorCodes {
             }
             return new JavaErrorCode(errorQName, description);
         }
-
-        @Override
-        public QName getErrorQName() {
-            return qname;
-        }
-
-        @Override
-        public @Nullable String getDescription() {
-            return description;
-        }
     }
 
-    public static class DynamicErrorCode implements ErrorCode {
-        private final QName qname;
-        private @Nullable final String description;
-
+    public static class DynamicErrorCode extends ErrorCode {
         public DynamicErrorCode(final QName qname, @Nullable final String description) {
-            this.qname = qname;
-            this.description = description;
-        }
-
-        @Override
-        public QName getErrorQName() {
-            return qname;
-        }
-
-        @Override
-        public @Nullable String getDescription() {
-            return description;
+            super(qname, description);
         }
     }
 
@@ -425,1163 +439,1163 @@ public class ErrorCodes {
      * @deprecated Use {@link W3CErrorCode#XPDY0002}.
      */
     @Deprecated
-    public static final ErrorCode XPDY0002 = W3CErrorCode.XPDY0002;
+    public static final ErrorCode XPDY0002 = W3CErrorCode.XPDY0002.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XPST0003}.
      */
     @Deprecated
-    public static final ErrorCode XPST0003 = W3CErrorCode.XPST0003;
+    public static final ErrorCode XPST0003 = W3CErrorCode.XPST0003.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XPTY0004}.
      */
     @Deprecated
-    public static final ErrorCode XPTY0004 = W3CErrorCode.XPTY0004;
+    public static final ErrorCode XPTY0004 = W3CErrorCode.XPTY0004.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XPST0005}.
      */
     @Deprecated
-    public static final ErrorCode XPST0005 = W3CErrorCode.XPST0005;
+    public static final ErrorCode XPST0005 = W3CErrorCode.XPST0005.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XPTY0006}.
      */
     @Deprecated
-    public static final ErrorCode XPTY0006 = W3CErrorCode.XPTY0006;
+    public static final ErrorCode XPTY0006 = W3CErrorCode.XPTY0006.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XPTY0007}.
      */
     @Deprecated
-    public static final ErrorCode XPTY0007 = W3CErrorCode.XPTY0007;
+    public static final ErrorCode XPTY0007 = W3CErrorCode.XPTY0007.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XPST0008}.
      */
     @Deprecated
-    public static final ErrorCode XPST0008 = W3CErrorCode.XPST0008;
+    public static final ErrorCode XPST0008 = W3CErrorCode.XPST0008.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XPST0010}.
      */
     @Deprecated
-    public static final ErrorCode XPST0010 = W3CErrorCode.XPST0010;
+    public static final ErrorCode XPST0010 = W3CErrorCode.XPST0010.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XPST0017}.
      */
     @Deprecated
-    public static final ErrorCode XPST0017 = W3CErrorCode.XPST0017;
+    public static final ErrorCode XPST0017 = W3CErrorCode.XPST0017.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XPTY0018}.
      */
     @Deprecated
-    public static final ErrorCode XPTY0018 = W3CErrorCode.XPTY0018;
+    public static final ErrorCode XPTY0018 = W3CErrorCode.XPTY0018.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XPTY0019}.
      */
     @Deprecated
-    public static final ErrorCode XPTY0019 = W3CErrorCode.XPTY0019;
+    public static final ErrorCode XPTY0019 = W3CErrorCode.XPTY0019.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XPTY0020}.
      */
     @Deprecated
-    public static final ErrorCode XPTY0020 = W3CErrorCode.XPTY0020;
+    public static final ErrorCode XPTY0020 = W3CErrorCode.XPTY0020.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XPDY0021}.
      */
     @Deprecated
-    public static final ErrorCode XPDY0021 = W3CErrorCode.XPDY0021;
+    public static final ErrorCode XPDY0021 = W3CErrorCode.XPDY0021.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XPDY0050}.
      */
     @Deprecated
-    public static final ErrorCode XPDY0050 = W3CErrorCode.XPDY0050;
+    public static final ErrorCode XPDY0050 = W3CErrorCode.XPDY0050.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XPST0051}.
      */
     @Deprecated
-    public static final ErrorCode XPST0051 = W3CErrorCode.XPST0051;
+    public static final ErrorCode XPST0051 = W3CErrorCode.XPST0051.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XPST0080}.
      */
     @Deprecated
-    public static final ErrorCode XPST0080 = W3CErrorCode.XPST0080;
+    public static final ErrorCode XPST0080 = W3CErrorCode.XPST0080.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XPST0081}.
      */
     @Deprecated
-    public static final ErrorCode XPST0081 = W3CErrorCode.XPST0081;
+    public static final ErrorCode XPST0081 = W3CErrorCode.XPST0081.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XPST0083}.
      */
     @Deprecated
-    public static final ErrorCode XPST0083 = W3CErrorCode.XPST0083;
+    public static final ErrorCode XPST0083 = W3CErrorCode.XPST0083.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0009}.
      */
     @Deprecated
-    public static final ErrorCode XQST0009 = W3CErrorCode.XQST0009;
+    public static final ErrorCode XQST0009 = W3CErrorCode.XQST0009.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0012}.
      */
     @Deprecated
-    public static final ErrorCode XQST0012 = W3CErrorCode.XQST0012;
+    public static final ErrorCode XQST0012 = W3CErrorCode.XQST0012.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0013}.
      */
     @Deprecated
-    public static final ErrorCode XQST0013 = W3CErrorCode.XQST0013;
+    public static final ErrorCode XQST0013 = W3CErrorCode.XQST0013.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0014}.
      */
     @Deprecated
-    public static final ErrorCode XQST0014 = W3CErrorCode.XQST0014;
+    public static final ErrorCode XQST0014 = W3CErrorCode.XQST0014.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0015}.
      */
     @Deprecated
-    public static final ErrorCode XQST0015 = W3CErrorCode.XQST0015;
+    public static final ErrorCode XQST0015 = W3CErrorCode.XQST0015.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0016}.
      */
     @Deprecated
-    public static final ErrorCode XQST0016 = W3CErrorCode.XQST0016;
+    public static final ErrorCode XQST0016 = W3CErrorCode.XQST0016.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0022}.
      */
     @Deprecated
-    public static final ErrorCode XQST0022 = W3CErrorCode.XQST0022;
+    public static final ErrorCode XQST0022 = W3CErrorCode.XQST0022.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQTY0023}.
      */
     @Deprecated
-    public static final ErrorCode XQTY0023 = W3CErrorCode.XQTY0023;
+    public static final ErrorCode XQTY0023 = W3CErrorCode.XQTY0023.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQTY0024}.
      */
     @Deprecated
-    public static final ErrorCode XQTY0024 = W3CErrorCode.XQTY0024;
+    public static final ErrorCode XQTY0024 = W3CErrorCode.XQTY0024.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQDY0025}.
      */
     @Deprecated
-    public static final ErrorCode XQDY0025 = W3CErrorCode.XQDY0025;
+    public static final ErrorCode XQDY0025 = W3CErrorCode.XQDY0025.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQDY0026}.
      */
     @Deprecated
-    public static final ErrorCode XQDY0026 = W3CErrorCode.XQDY0026;
+    public static final ErrorCode XQDY0026 = W3CErrorCode.XQDY0026.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQDY0027}.
      */
     @Deprecated
-    public static final ErrorCode XQDY0027 = W3CErrorCode.XQDY0027;
+    public static final ErrorCode XQDY0027 = W3CErrorCode.XQDY0027.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQTY0028}.
      */
     @Deprecated
-    public static final ErrorCode XQTY0028 = W3CErrorCode.XQTY0028;
+    public static final ErrorCode XQTY0028 = W3CErrorCode.XQTY0028.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQDY0029}.
      */
     @Deprecated
-    public static final ErrorCode XQDY0029 = W3CErrorCode.XQDY0029;
+    public static final ErrorCode XQDY0029 = W3CErrorCode.XQDY0029.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQTY0030}.
      */
     @Deprecated
-    public static final ErrorCode XQTY0030 = W3CErrorCode.XQTY0030;
+    public static final ErrorCode XQTY0030 = W3CErrorCode.XQTY0030.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0031}.
      */
     @Deprecated
-    public static final ErrorCode XQST0031 = W3CErrorCode.XQST0031;
+    public static final ErrorCode XQST0031 = W3CErrorCode.XQST0031.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0032}.
      */
     @Deprecated
-    public static final ErrorCode XQST0032 = W3CErrorCode.XQST0032;
+    public static final ErrorCode XQST0032 = W3CErrorCode.XQST0032.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0033}.
      */
     @Deprecated
-    public static final ErrorCode XQST0033 = W3CErrorCode.XQST0033;
+    public static final ErrorCode XQST0033 = W3CErrorCode.XQST0033.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0034}.
      */
     @Deprecated
-    public static final ErrorCode XQST0034 = W3CErrorCode.XQST0034;
+    public static final ErrorCode XQST0034 = W3CErrorCode.XQST0034.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0035}.
      */
     @Deprecated
-    public static final ErrorCode XQST0035 = W3CErrorCode.XQST0035;
+    public static final ErrorCode XQST0035 = W3CErrorCode.XQST0035.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0036}.
      */
     @Deprecated
-    public static final ErrorCode XQST0036 = W3CErrorCode.XQST0036;
+    public static final ErrorCode XQST0036 = W3CErrorCode.XQST0036.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0037}.
      */
     @Deprecated
-    public static final ErrorCode XQST0037 = W3CErrorCode.XQST0037;
+    public static final ErrorCode XQST0037 = W3CErrorCode.XQST0037.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0038}.
      */
     @Deprecated
-    public static final ErrorCode XQST0038 = W3CErrorCode.XQST0038;
+    public static final ErrorCode XQST0038 = W3CErrorCode.XQST0038.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0039}.
      */
     @Deprecated
-    public static final ErrorCode XQST0039 = W3CErrorCode.XQST0039;
+    public static final ErrorCode XQST0039 = W3CErrorCode.XQST0039.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0040}.
      */
     @Deprecated
-    public static final ErrorCode XQST0040 = W3CErrorCode.XQST0040;
+    public static final ErrorCode XQST0040 = W3CErrorCode.XQST0040.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQDY0041}.
      */
     @Deprecated
-    public static final ErrorCode XQDY0041 = W3CErrorCode.XQDY0041;
+    public static final ErrorCode XQDY0041 = W3CErrorCode.XQDY0041.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0042}.
      */
     @Deprecated
-    public static final ErrorCode XQST0042 = W3CErrorCode.XQST0042;
+    public static final ErrorCode XQST0042 = W3CErrorCode.XQST0042.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0043}.
      */
     @Deprecated
-    public static final ErrorCode XQST0043 = W3CErrorCode.XQST0043;
+    public static final ErrorCode XQST0043 = W3CErrorCode.XQST0043.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQDY0044}.
      */
     @Deprecated
-    public static final ErrorCode XQDY0044 = W3CErrorCode.XQDY0044;
+    public static final ErrorCode XQDY0044 = W3CErrorCode.XQDY0044.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0045}.
      */
     @Deprecated
-    public static final ErrorCode XQST0045 = W3CErrorCode.XQST0045;
+    public static final ErrorCode XQST0045 = W3CErrorCode.XQST0045.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0046}.
      */
     @Deprecated
-    public static final ErrorCode XQST0046 = W3CErrorCode.XQST0046;
+    public static final ErrorCode XQST0046 = W3CErrorCode.XQST0046.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0047}.
      */
     @Deprecated
-    public static final ErrorCode XQST0047 = W3CErrorCode.XQST0047;
+    public static final ErrorCode XQST0047 = W3CErrorCode.XQST0047.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0048}.
      */
     @Deprecated
-    public static final ErrorCode XQST0048 = W3CErrorCode.XQST0048;
+    public static final ErrorCode XQST0048 = W3CErrorCode.XQST0048.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0049}.
      */
     @Deprecated
-    public static final ErrorCode XQST0049 = W3CErrorCode.XQST0049;
+    public static final ErrorCode XQST0049 = W3CErrorCode.XQST0049.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQDY0052}.
      */
     @Deprecated
-    public static final ErrorCode XQDY0052 = W3CErrorCode.XQDY0052;
+    public static final ErrorCode XQDY0052 = W3CErrorCode.XQDY0052.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0053}.
      */
     @Deprecated
-    public static final ErrorCode XQST0053 = W3CErrorCode.XQST0053;
+    public static final ErrorCode XQST0053 = W3CErrorCode.XQST0053.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0054}.
      */
     @Deprecated
-    public static final ErrorCode XQST0054 = W3CErrorCode.XQST0054;
+    public static final ErrorCode XQST0054 = W3CErrorCode.XQST0054.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0055}.
      */
     @Deprecated
-    public static final ErrorCode XQST0055 = W3CErrorCode.XQST0055;
+    public static final ErrorCode XQST0055 = W3CErrorCode.XQST0055.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0056}.
      */
     @Deprecated
-    public static final ErrorCode XQST0056 = W3CErrorCode.XQST0056;
+    public static final ErrorCode XQST0056 = W3CErrorCode.XQST0056.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0057}.
      */
     @Deprecated
-    public static final ErrorCode XQST0057 = W3CErrorCode.XQST0057;
+    public static final ErrorCode XQST0057 = W3CErrorCode.XQST0057.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0058}.
      */
     @Deprecated
-    public static final ErrorCode XQST0058 = W3CErrorCode.XQST0058;
+    public static final ErrorCode XQST0058 = W3CErrorCode.XQST0058.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0059}.
      */
     @Deprecated
-    public static final ErrorCode XQST0059 = W3CErrorCode.XQST0059;
+    public static final ErrorCode XQST0059 = W3CErrorCode.XQST0059.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0060}.
      */
     @Deprecated
-    public static final ErrorCode XQST0060 = W3CErrorCode.XQST0060;
+    public static final ErrorCode XQST0060 = W3CErrorCode.XQST0060.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQDY0061}.
      */
     @Deprecated
-    public static final ErrorCode XQDY0061 = W3CErrorCode.XQDY0061;
+    public static final ErrorCode XQDY0061 = W3CErrorCode.XQDY0061.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQDY0062}.
      */
     @Deprecated
-    public static final ErrorCode XQDY0062 = W3CErrorCode.XQDY0062;
+    public static final ErrorCode XQDY0062 = W3CErrorCode.XQDY0062.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0063}.
      */
     @Deprecated
-    public static final ErrorCode XQST0063 = W3CErrorCode.XQST0063;
+    public static final ErrorCode XQST0063 = W3CErrorCode.XQST0063.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQDY0064}.
      */
     @Deprecated
-    public static final ErrorCode XQDY0064 = W3CErrorCode.XQDY0064;
+    public static final ErrorCode XQDY0064 = W3CErrorCode.XQDY0064.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0065}.
      */
     @Deprecated
-    public static final ErrorCode XQST0065 = W3CErrorCode.XQST0065;
+    public static final ErrorCode XQST0065 = W3CErrorCode.XQST0065.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0066}.
      */
     @Deprecated
-    public static final ErrorCode XQST0066 = W3CErrorCode.XQST0066;
+    public static final ErrorCode XQST0066 = W3CErrorCode.XQST0066.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0067}.
      */
     @Deprecated
-    public static final ErrorCode XQST0067 = W3CErrorCode.XQST0067;
+    public static final ErrorCode XQST0067 = W3CErrorCode.XQST0067.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0068}.
      */
     @Deprecated
-    public static final ErrorCode XQST0068 = W3CErrorCode.XQST0068;
+    public static final ErrorCode XQST0068 = W3CErrorCode.XQST0068.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0069}.
      */
     @Deprecated
-    public static final ErrorCode XQST0069 = W3CErrorCode.XQST0069;
+    public static final ErrorCode XQST0069 = W3CErrorCode.XQST0069.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0070}.
      */
     @Deprecated
-    public static final ErrorCode XQST0070 = W3CErrorCode.XQST0070;
+    public static final ErrorCode XQST0070 = W3CErrorCode.XQST0070.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0071}.
      */
     @Deprecated
-    public static final ErrorCode XQST0071 = W3CErrorCode.XQST0071;
+    public static final ErrorCode XQST0071 = W3CErrorCode.XQST0071.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQDY0072}.
      */
     @Deprecated
-    public static final ErrorCode XQDY0072 = W3CErrorCode.XQDY0072;
+    public static final ErrorCode XQDY0072 = W3CErrorCode.XQDY0072.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0073}.
      */
     @Deprecated
-    public static final ErrorCode XQST0073 = W3CErrorCode.XQST0073;
+    public static final ErrorCode XQST0073 = W3CErrorCode.XQST0073.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQDY0074}.
      */
     @Deprecated
-    public static final ErrorCode XQDY0074 = W3CErrorCode.XQDY0074;
+    public static final ErrorCode XQDY0074 = W3CErrorCode.XQDY0074.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0075}.
      */
     @Deprecated
-    public static final ErrorCode XQST0075 = W3CErrorCode.XQST0075;
+    public static final ErrorCode XQST0075 = W3CErrorCode.XQST0075.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0076}.
      */
     @Deprecated
-    public static final ErrorCode XQST0076 = W3CErrorCode.XQST0076;
+    public static final ErrorCode XQST0076 = W3CErrorCode.XQST0076.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0077}.
      */
     @Deprecated
-    public static final ErrorCode XQST0077 = W3CErrorCode.XQST0077;
+    public static final ErrorCode XQST0077 = W3CErrorCode.XQST0077.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0078}.
      */
     @Deprecated
-    public static final ErrorCode XQST0078 = W3CErrorCode.XQST0078;
+    public static final ErrorCode XQST0078 = W3CErrorCode.XQST0078.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0079}.
      */
     @Deprecated
-    public static final ErrorCode XQST0079 = W3CErrorCode.XQST0079;
+    public static final ErrorCode XQST0079 = W3CErrorCode.XQST0079.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0082}.
      */
     @Deprecated
-    public static final ErrorCode XQST0082 = W3CErrorCode.XQST0082;
+    public static final ErrorCode XQST0082 = W3CErrorCode.XQST0082.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQDY0084}.
      */
     @Deprecated
-    public static final ErrorCode XQDY0084 = W3CErrorCode.XQDY0084;
+    public static final ErrorCode XQDY0084 = W3CErrorCode.XQDY0084.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0085}.
      */
     @Deprecated
-    public static final ErrorCode XQST0085 = W3CErrorCode.XQST0085;
+    public static final ErrorCode XQST0085 = W3CErrorCode.XQST0085.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQTY0086}.
      */
     @Deprecated
-    public static final ErrorCode XQTY0086 = W3CErrorCode.XQTY0086;
+    public static final ErrorCode XQTY0086 = W3CErrorCode.XQTY0086.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0087}.
      */
     @Deprecated
-    public static final ErrorCode XQST0087 = W3CErrorCode.XQST0087;
+    public static final ErrorCode XQST0087 = W3CErrorCode.XQST0087.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0088}.
      */
     @Deprecated
-    public static final ErrorCode XQST0088 = W3CErrorCode.XQST0088;
+    public static final ErrorCode XQST0088 = W3CErrorCode.XQST0088.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0089}.
      */
     @Deprecated
-    public static final ErrorCode XQST0089 = W3CErrorCode.XQST0089;
+    public static final ErrorCode XQST0089 = W3CErrorCode.XQST0089.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0090}.
      */
     @Deprecated
-    public static final ErrorCode XQST0090 = W3CErrorCode.XQST0090;
+    public static final ErrorCode XQST0090 = W3CErrorCode.XQST0090.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQDY0091}.
      */
     @Deprecated
-    public static final ErrorCode XQDY0091 = W3CErrorCode.XQDY0091;
+    public static final ErrorCode XQDY0091 = W3CErrorCode.XQDY0091.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQDY0092}.
      */
     @Deprecated
-    public static final ErrorCode XQDY0092 = W3CErrorCode.XQDY0092;
+    public static final ErrorCode XQDY0092 = W3CErrorCode.XQDY0092.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0093}.
      */
     @Deprecated
-    public static final ErrorCode XQST0093 = W3CErrorCode.XQST0093;
+    public static final ErrorCode XQST0093 = W3CErrorCode.XQST0093.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0094}.
      */
     @Deprecated
-    public static final ErrorCode XQST0094 = W3CErrorCode.XQST0094;
+    public static final ErrorCode XQST0094 = W3CErrorCode.XQST0094.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQDY0101}.
      */
     @Deprecated
-    public static final ErrorCode XQDY0101 = W3CErrorCode.XQDY0101;
+    public static final ErrorCode XQDY0101 = W3CErrorCode.XQDY0101.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQDY0102}.
      */
     @Deprecated
-    public static final ErrorCode XQDY0102 = W3CErrorCode.XQDY0102;
+    public static final ErrorCode XQDY0102 = W3CErrorCode.XQDY0102.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQST0103}.
      */
     @Deprecated
-    public static final ErrorCode XQST0103 = W3CErrorCode.XQST0103;
+    public static final ErrorCode XQST0103 = W3CErrorCode.XQST0103.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQDY0137}.
      */
     @Deprecated
-    public static final ErrorCode XQDY0137 = W3CErrorCode.XQDY0137;
+    public static final ErrorCode XQDY0137 = W3CErrorCode.XQDY0137.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQDY0138}.
      */
     @Deprecated
-    public static final ErrorCode XQDY0138 = W3CErrorCode.XQDY0138;
+    public static final ErrorCode XQDY0138 = W3CErrorCode.XQDY0138.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XUDY0023}.
      */
     @Deprecated
-    public static final ErrorCode XUDY0023 = W3CErrorCode.XUDY0023;
+    public static final ErrorCode XUDY0023 = W3CErrorCode.XUDY0023.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOER0000}.
      */
     @Deprecated
-    public static final ErrorCode FOER0000 = W3CErrorCode.FOER0000;
+    public static final ErrorCode FOER0000 = W3CErrorCode.FOER0000.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOAR0001}.
      */
     @Deprecated
-    public static final ErrorCode FOAR0001 = W3CErrorCode.FOAR0001;
+    public static final ErrorCode FOAR0001 = W3CErrorCode.FOAR0001.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOAR0002}.
      */
     @Deprecated
-    public static final ErrorCode FOAR0002 = W3CErrorCode.FOAR0002;
+    public static final ErrorCode FOAR0002 = W3CErrorCode.FOAR0002.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOCA0001}.
      */
     @Deprecated
-    public static final ErrorCode FOCA0001 = W3CErrorCode.FOCA0001;
+    public static final ErrorCode FOCA0001 = W3CErrorCode.FOCA0001.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOCA0002}.
      */
     @Deprecated
-    public static final ErrorCode FOCA0002 = W3CErrorCode.FOCA0002;
+    public static final ErrorCode FOCA0002 = W3CErrorCode.FOCA0002.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOCA0003}.
      */
     @Deprecated
-    public static final ErrorCode FOCA0003 = W3CErrorCode.FOCA0003;
+    public static final ErrorCode FOCA0003 = W3CErrorCode.FOCA0003.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOCA0005}.
      */
     @Deprecated
-    public static final ErrorCode FOCA0005 = W3CErrorCode.FOCA0005;
+    public static final ErrorCode FOCA0005 = W3CErrorCode.FOCA0005.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOCA0006}.
      */
     @Deprecated
-    public static final ErrorCode FOCA0006 = W3CErrorCode.FOCA0006;
+    public static final ErrorCode FOCA0006 = W3CErrorCode.FOCA0006.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOCH0001}.
      */
     @Deprecated
-    public static final ErrorCode FOCH0001 = W3CErrorCode.FOCH0001;
+    public static final ErrorCode FOCH0001 = W3CErrorCode.FOCH0001.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOCH0002}.
      */
     @Deprecated
-    public static final ErrorCode FOCH0002 = W3CErrorCode.FOCH0002;
+    public static final ErrorCode FOCH0002 = W3CErrorCode.FOCH0002.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOCH0003}.
      */
     @Deprecated
-    public static final ErrorCode FOCH0003 = W3CErrorCode.FOCH0003;
+    public static final ErrorCode FOCH0003 = W3CErrorCode.FOCH0003.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOCH0004}.
      */
     @Deprecated
-    public static final ErrorCode FOCH0004 = W3CErrorCode.FOCH0004;
+    public static final ErrorCode FOCH0004 = W3CErrorCode.FOCH0004.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FODC0001}.
      */
     @Deprecated
-    public static final ErrorCode FODC0001 = W3CErrorCode.FODC0001;
+    public static final ErrorCode FODC0001 = W3CErrorCode.FODC0001.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FODC0002}.
      */
     @Deprecated
-    public static final ErrorCode FODC0002 = W3CErrorCode.FODC0002;
+    public static final ErrorCode FODC0002 = W3CErrorCode.FODC0002.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FODC0003}.
      */
     @Deprecated
-    public static final ErrorCode FODC0003 = W3CErrorCode.FODC0003;
+    public static final ErrorCode FODC0003 = W3CErrorCode.FODC0003.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FODC0004}.
      */
     @Deprecated
-    public static final ErrorCode FODC0004 = W3CErrorCode.FODC0004;
+    public static final ErrorCode FODC0004 = W3CErrorCode.FODC0004.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FODC0005}.
      */
     @Deprecated
-    public static final ErrorCode FODC0005 = W3CErrorCode.FODC0005;
+    public static final ErrorCode FODC0005 = W3CErrorCode.FODC0005.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FODT0001}.
      */
     @Deprecated
-    public static final ErrorCode FODT0001 = W3CErrorCode.FODT0001;
+    public static final ErrorCode FODT0001 = W3CErrorCode.FODT0001.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FODT0002}.
      */
     @Deprecated
-    public static final ErrorCode FODT0002 = W3CErrorCode.FODT0002;
+    public static final ErrorCode FODT0002 = W3CErrorCode.FODT0002.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FODT0003}.
      */
     @Deprecated
-    public static final ErrorCode FODT0003 = W3CErrorCode.FODT0003;
+    public static final ErrorCode FODT0003 = W3CErrorCode.FODT0003.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FONS0004}.
      */
     @Deprecated
-    public static final ErrorCode FONS0004 = W3CErrorCode.FONS0004;
+    public static final ErrorCode FONS0004 = W3CErrorCode.FONS0004.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FONS0005}.
      */
     @Deprecated
-    public static final ErrorCode FONS0005 = W3CErrorCode.FONS0005;
+    public static final ErrorCode FONS0005 = W3CErrorCode.FONS0005.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FORG0001}.
      */
     @Deprecated
-    public static final ErrorCode FORG0001 = W3CErrorCode.FORG0001;
+    public static final ErrorCode FORG0001 = W3CErrorCode.FORG0001.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FORG0002}.
      */
     @Deprecated
-    public static final ErrorCode FORG0002 = W3CErrorCode.FORG0002;
+    public static final ErrorCode FORG0002 = W3CErrorCode.FORG0002.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FORG0003}.
      */
     @Deprecated
-    public static final ErrorCode FORG0003 = W3CErrorCode.FORG0003;
+    public static final ErrorCode FORG0003 = W3CErrorCode.FORG0003.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FORG0004}.
      */
     @Deprecated
-    public static final ErrorCode FORG0004 = W3CErrorCode.FORG0004;
+    public static final ErrorCode FORG0004 = W3CErrorCode.FORG0004.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FORG0005}.
      */
     @Deprecated
-    public static final ErrorCode FORG0005 = W3CErrorCode.FORG0005;
+    public static final ErrorCode FORG0005 = W3CErrorCode.FORG0005.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FORG0006}.
      */
     @Deprecated
-    public static final ErrorCode FORG0006 = W3CErrorCode.FORG0006;
+    public static final ErrorCode FORG0006 = W3CErrorCode.FORG0006.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FORG0008}.
      */
     @Deprecated
-    public static final ErrorCode FORG0008 = W3CErrorCode.FORG0008;
+    public static final ErrorCode FORG0008 = W3CErrorCode.FORG0008.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FORG0009}.
      */
     @Deprecated
-    public static final ErrorCode FORG0009 = W3CErrorCode.FORG0009;
+    public static final ErrorCode FORG0009 = W3CErrorCode.FORG0009.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FORG0010}.
      */
     @Deprecated
-    public static final ErrorCode FORG0010 = W3CErrorCode.FORG0010;
+    public static final ErrorCode FORG0010 = W3CErrorCode.FORG0010.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FORX0001}.
      */
     @Deprecated
-    public static final ErrorCode FORX0001 = W3CErrorCode.FORX0001;
+    public static final ErrorCode FORX0001 = W3CErrorCode.FORX0001.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FORX0002}.
      */
     @Deprecated
-    public static final ErrorCode FORX0002 = W3CErrorCode.FORX0002;
+    public static final ErrorCode FORX0002 = W3CErrorCode.FORX0002.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FORX0003}.
      */
     @Deprecated
-    public static final ErrorCode FORX0003 = W3CErrorCode.FORX0003;
+    public static final ErrorCode FORX0003 = W3CErrorCode.FORX0003.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FORX0004}.
      */
     @Deprecated
-    public static final ErrorCode FORX0004 = W3CErrorCode.FORX0004;
+    public static final ErrorCode FORX0004 = W3CErrorCode.FORX0004.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOTY0012}.
      */
     @Deprecated
-    public static final ErrorCode FOTY0012 = W3CErrorCode.FOTY0012;
+    public static final ErrorCode FOTY0012 = W3CErrorCode.FOTY0012.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOTY0013}.
      */
     @Deprecated
-    public static final ErrorCode FOTY0013 = W3CErrorCode.FOTY0013;
+    public static final ErrorCode FOTY0013 = W3CErrorCode.FOTY0013.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#SENR0001}.
      */
     @Deprecated
-    public static final ErrorCode SENR0001 = W3CErrorCode.SENR0001;
+    public static final ErrorCode SENR0001 = W3CErrorCode.SENR0001.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#SERE0003}.
      */
     @Deprecated
-    public static final ErrorCode SERE0003 = W3CErrorCode.SERE0003;
+    public static final ErrorCode SERE0003 = W3CErrorCode.SERE0003.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#SEPM0004}.
      */
     @Deprecated
-    public static final ErrorCode SEPM0004 = W3CErrorCode.SEPM0004;
+    public static final ErrorCode SEPM0004 = W3CErrorCode.SEPM0004.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#SERE0005}.
      */
     @Deprecated
-    public static final ErrorCode SERE0005 = W3CErrorCode.SERE0005;
+    public static final ErrorCode SERE0005 = W3CErrorCode.SERE0005.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#SERE0006}.
      */
     @Deprecated
-    public static final ErrorCode SERE0006 = W3CErrorCode.SERE0006;
+    public static final ErrorCode SERE0006 = W3CErrorCode.SERE0006.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#SESU0007}.
      */
     @Deprecated
-    public static final ErrorCode SESU0007 = W3CErrorCode.SESU0007;
+    public static final ErrorCode SESU0007 = W3CErrorCode.SESU0007.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#SERE0008}.
      */
     @Deprecated
-    public static final ErrorCode SERE0008 = W3CErrorCode.SERE0008;
+    public static final ErrorCode SERE0008 = W3CErrorCode.SERE0008.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#SEPM0009}.
      */
     @Deprecated
-    public static final ErrorCode SEPM0009 = W3CErrorCode.SEPM0009;
+    public static final ErrorCode SEPM0009 = W3CErrorCode.SEPM0009.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#SEPM0010}.
      */
     @Deprecated
-    public static final ErrorCode SEPM0010 = W3CErrorCode.SEPM0010;
+    public static final ErrorCode SEPM0010 = W3CErrorCode.SEPM0010.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#SESU0011}.
      */
     @Deprecated
-    public static final ErrorCode SESU0011 = W3CErrorCode.SESU0011;
+    public static final ErrorCode SESU0011 = W3CErrorCode.SESU0011.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#SERE0012}.
      */
     @Deprecated
-    public static final ErrorCode SERE0012 = W3CErrorCode.SERE0012;
+    public static final ErrorCode SERE0012 = W3CErrorCode.SERE0012.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#SESU0013}.
      */
     @Deprecated
-    public static final ErrorCode SESU0013 = W3CErrorCode.SESU0013;
+    public static final ErrorCode SESU0013 = W3CErrorCode.SESU0013.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#SERE0014}.
      */
     @Deprecated
-    public static final ErrorCode SERE0014 = W3CErrorCode.SERE0014;
+    public static final ErrorCode SERE0014 = W3CErrorCode.SERE0014.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#SERE0015}.
      */
     @Deprecated
-    public static final ErrorCode SERE0015 = W3CErrorCode.SERE0015;
+    public static final ErrorCode SERE0015 = W3CErrorCode.SERE0015.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#SEPM0016}.
      */
     @Deprecated
-    public static final ErrorCode SEPM0016 = W3CErrorCode.SEPM0016;
+    public static final ErrorCode SEPM0016 = W3CErrorCode.SEPM0016.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#SEPM0017}.
      */
     @Deprecated
-    public static final ErrorCode SEPM0017 = W3CErrorCode.SEPM0017;
+    public static final ErrorCode SEPM0017 = W3CErrorCode.SEPM0017.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#SEPM0018}.
      */
     @Deprecated
-    public static final ErrorCode SEPM0018 = W3CErrorCode.SEPM0018;
+    public static final ErrorCode SEPM0018 = W3CErrorCode.SEPM0018.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#SEPM0019}.
      */
     @Deprecated
-    public static final ErrorCode SEPM0019 = W3CErrorCode.SEPM0019;
+    public static final ErrorCode SEPM0019 = W3CErrorCode.SEPM0019.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#SERE0021}.
      */
     @Deprecated
-    public static final ErrorCode SERE0021 = W3CErrorCode.SERE0021;
+    public static final ErrorCode SERE0021 = W3CErrorCode.SERE0021.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FODF1280}.
      */
     @Deprecated
-    public static final ErrorCode FODF1280 = W3CErrorCode.FODF1280;
+    public static final ErrorCode FODF1280 = W3CErrorCode.FODF1280.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FODF1310}.
      */
     @Deprecated
-    public static final ErrorCode FODF1310 = W3CErrorCode.FODF1310;
+    public static final ErrorCode FODF1310 = W3CErrorCode.FODF1310.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOFD1340}.
      */
     @Deprecated
-    public static final ErrorCode FOFD1340 = W3CErrorCode.FOFD1340;
+    public static final ErrorCode FOFD1340 = W3CErrorCode.FOFD1340.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOFD1350}.
      */
     @Deprecated
-    public static final ErrorCode FOFD1350 = W3CErrorCode.FOFD1350;
+    public static final ErrorCode FOFD1350 = W3CErrorCode.FOFD1350.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FTDY0020}.
      */
     @Deprecated
-    public static final ErrorCode FTDY0020 = W3CErrorCode.FTDY0020;
+    public static final ErrorCode FTDY0020 = W3CErrorCode.FTDY0020.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FODC0006}.
      */
     @Deprecated
-    public static final ErrorCode FODC0006 = W3CErrorCode.FODC0006;
+    public static final ErrorCode FODC0006 = W3CErrorCode.FODC0006.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOAP0001}.
      */
     @Deprecated
-    public static final ErrorCode FOAP0001 = W3CErrorCode.FOAP0001;
+    public static final ErrorCode FOAP0001 = W3CErrorCode.FOAP0001.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XQTY0105}.
      */
     @Deprecated
-    public static final ErrorCode XQTY0105 = W3CErrorCode.XQTY0105;
+    public static final ErrorCode XQTY0105 = W3CErrorCode.XQTY0105.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOAY0001}.
      */
     @Deprecated
-    public static final ErrorCode FOAY0001 = W3CErrorCode.FOAY0001;
+    public static final ErrorCode FOAY0001 = W3CErrorCode.FOAY0001.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOAY0002}.
      */
     @Deprecated
-    public static final ErrorCode FOAY0002 = W3CErrorCode.FOAY0002;
+    public static final ErrorCode FOAY0002 = W3CErrorCode.FOAY0002.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOJS0001}.
      */
     @Deprecated
-    public static final ErrorCode FOJS0001 = W3CErrorCode.FOJS0001;
+    public static final ErrorCode FOJS0001 = W3CErrorCode.FOJS0001.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOJS0002}.
      */
     @Deprecated
-    public static final ErrorCode FOJS0002 = W3CErrorCode.FOJS0002;
+    public static final ErrorCode FOJS0002 = W3CErrorCode.FOJS0002.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOJS0003}.
      */
     @Deprecated
-    public static final ErrorCode FOJS0003 = W3CErrorCode.FOJS0003;
+    public static final ErrorCode FOJS0003 = W3CErrorCode.FOJS0003.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOJS0005}.
      */
     @Deprecated
-    public static final ErrorCode FOJS0005 = W3CErrorCode.FOJS0005;
+    public static final ErrorCode FOJS0005 = W3CErrorCode.FOJS0005.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOJS0006}.
      */
     @Deprecated
-    public static final ErrorCode FOJS0006 = W3CErrorCode.FOJS0006;
+    public static final ErrorCode FOJS0006 = W3CErrorCode.FOJS0006.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOJS0007}.
      */
     @Deprecated
-    public static final ErrorCode FOJS0007 = W3CErrorCode.FOJS0007;
+    public static final ErrorCode FOJS0007 = W3CErrorCode.FOJS0007.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOUT1170}.
      */
     @Deprecated
-    public static final ErrorCode FOUT1170 = W3CErrorCode.FOUT1170;
+    public static final ErrorCode FOUT1170 = W3CErrorCode.FOUT1170.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOUT1190}.
      */
     @Deprecated
-    public static final ErrorCode FOUT1190 = W3CErrorCode.FOUT1190;
+    public static final ErrorCode FOUT1190 = W3CErrorCode.FOUT1190.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOUT1200}.
      */
     @Deprecated
-    public static final ErrorCode FOUT1200 = W3CErrorCode.FOUT1200;
+    public static final ErrorCode FOUT1200 = W3CErrorCode.FOUT1200.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOQM0001}.
      */
     @Deprecated
-    public static final ErrorCode FOQM0001 = W3CErrorCode.FOQM0001;
+    public static final ErrorCode FOQM0001 = W3CErrorCode.FOQM0001.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOQM0002}.
      */
     @Deprecated
-    public static final ErrorCode FOQM0002 = W3CErrorCode.FOQM0002;
+    public static final ErrorCode FOQM0002 = W3CErrorCode.FOQM0002.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOQM0003}.
      */
     @Deprecated
-    public static final ErrorCode FOQM0003 = W3CErrorCode.FOQM0003;
+    public static final ErrorCode FOQM0003 = W3CErrorCode.FOQM0003.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOQM0005}.
      */
     @Deprecated
-    public static final ErrorCode FOQM0005 = W3CErrorCode.FOQM0005;
+    public static final ErrorCode FOQM0005 = W3CErrorCode.FOQM0005.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOQM0006}.
      */
     @Deprecated
-    public static final ErrorCode FOQM0006 = W3CErrorCode.FOQM0006;
+    public static final ErrorCode FOQM0006 = W3CErrorCode.FOQM0006.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOXT0001}.
      */
     @Deprecated
-    public static final ErrorCode FOXT0001 = W3CErrorCode.FOXT0001;
+    public static final ErrorCode FOXT0001 = W3CErrorCode.FOXT0001.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOXT0002}.
      */
     @Deprecated
-    public static final ErrorCode FOXT0002 = W3CErrorCode.FOXT0002;
+    public static final ErrorCode FOXT0002 = W3CErrorCode.FOXT0002.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOXT0003}.
      */
     @Deprecated
-    public static final ErrorCode FOXT0003 = W3CErrorCode.FOXT0003;
+    public static final ErrorCode FOXT0003 = W3CErrorCode.FOXT0003.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOXT0004}.
      */
     @Deprecated
-    public static final ErrorCode FOXT0004 = W3CErrorCode.FOXT0004;
+    public static final ErrorCode FOXT0004 = W3CErrorCode.FOXT0004.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#FOXT0006}.
      */
     @Deprecated
-    public static final ErrorCode FOXT0006 = W3CErrorCode.FOXT0006;
+    public static final ErrorCode FOXT0006 = W3CErrorCode.FOXT0006.errorCode;
 
     /**
      * @deprecated Use {@link W3CErrorCode#XTSE0165}.
      */
     @Deprecated
-    public static final ErrorCode XTSE0165 = W3CErrorCode.XTSE0165;
+    public static final ErrorCode XTSE0165 = W3CErrorCode.XTSE0165.errorCode;
 
     /**
      * @deprecated Use {@link EXistErrorCode#EXXQDY0001}.
      */
     @Deprecated
-    public static final ErrorCode EXXQDY0001 = EXistErrorCode.EXXQDY0001;
+    public static final ErrorCode EXXQDY0001 = EXistErrorCode.EXXQDY0001.errorCode;
 
     /**
      * @deprecated Use {@link EXistErrorCode#EXXQDY0002}.
      */
     @Deprecated
-    public static final ErrorCode EXXQDY0002 = EXistErrorCode.EXXQDY0002;
+    public static final ErrorCode EXXQDY0002 = EXistErrorCode.EXXQDY0002.errorCode;
 
     /**
      * @deprecated Use {@link EXistErrorCode#EXXQDY0003}.
      */
     @Deprecated
-    public static final ErrorCode EXXQDY0003 = EXistErrorCode.EXXQDY0003;
+    public static final ErrorCode EXXQDY0003 = EXistErrorCode.EXXQDY0003.errorCode;
 
     /**
      * @deprecated Use {@link EXistErrorCode#EXXQDY0004}.
      */
     @Deprecated
-    public static final ErrorCode EXXQDY0004 = EXistErrorCode.EXXQDY0004;
+    public static final ErrorCode EXXQDY0004 = EXistErrorCode.EXXQDY0004.errorCode;
 
     /**
      * @deprecated Use {@link EXistErrorCode#EXXQDY0005}.
      */
     @Deprecated
-    public static final ErrorCode EXXQDY0005 = EXistErrorCode.EXXQDY0005;
+    public static final ErrorCode EXXQDY0005 = EXistErrorCode.EXXQDY0005.errorCode;
 
     /**
      * @deprecated Use {@link EXistErrorCode#EXXQDY0006}.
      */
     @Deprecated
-    public static final ErrorCode EXXQDY0006 = EXistErrorCode.EXXQDY0006;
+    public static final ErrorCode EXXQDY0006 = EXistErrorCode.EXXQDY0006.errorCode;
 
     /**
      * @deprecated Use {@link EXistErrorCode#EXXQST0001}.
      */
     @Deprecated
-    public static final ErrorCode EXXQST0001 = EXistErrorCode.EXXQST0001;
+    public static final ErrorCode EXXQST0001 = EXistErrorCode.EXXQST0001.errorCode;
 
     /**
      * @deprecated Use {@link EXistErrorCode#EXXQST0002}.
      */
     @Deprecated
-    public static final ErrorCode EXXQST0002 = EXistErrorCode.EXXQST0002;
+    public static final ErrorCode EXXQST0002 = EXistErrorCode.EXXQST0002.errorCode;
 
     /**
      * @deprecated Use {@link EXistErrorCode#EXXQST0003}.
      */
     @Deprecated
-    public static final ErrorCode EXXQST0003 = EXistErrorCode.EXXQST0003;
+    public static final ErrorCode EXXQST0003 = EXistErrorCode.EXXQST0003.errorCode;
 
     /**
      * @deprecated Use {@link EXistErrorCode#ERROR}.
      */
     @Deprecated
-    public static final ErrorCode ERROR = EXistErrorCode.ERROR;
+    public static final ErrorCode ERROR = EXistErrorCode.ERROR.errorCode;
 }

--- a/exist-core/src/main/java/org/exist/xquery/Option.java
+++ b/exist-core/src/main/java/org/exist/xquery/Option.java
@@ -85,7 +85,7 @@ public class Option {
 	
 	public Option(final Expression expression, QName qname, String contents)  throws XPathException {
 		if (qname.getPrefix() == null || qname.getPrefix().isEmpty()) {
-            throw new XPathException(expression, ErrorCodes.W3CErrorCode.XPST0081, "Options must have a prefix");
+            throw new XPathException(expression, ErrorCodes.W3CErrorCode.XPST0081.getErrorCode(), "Options must have a prefix");
         }
 		this.qname = qname;
 		this.contents = contents;

--- a/exist-core/src/main/java/org/exist/xquery/TryCatchExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/TryCatchExpression.java
@@ -440,7 +440,7 @@ public class TryCatchExpression extends AbstractExpression {
             try {
                 errorQName = QName.parse(context, data[0]);
             } catch (final QName.IllegalQNameException e) {
-                errorCode = ErrorCodes.EXistErrorCode.ERROR;
+                errorCode = ErrorCodes.EXistErrorCode.ERROR.getErrorCode();
             }
 
             if (errorCode == null) {

--- a/exist-core/src/main/java/org/exist/xquery/VariableImpl.java
+++ b/exist-core/src/main/java/org/exist/xquery/VariableImpl.java
@@ -156,14 +156,14 @@ public class VariableImpl implements Variable {
                 else {actualCardinality = Cardinality.EXACTLY_ONE;}
             	//Type.EMPTY is *not* a subtype of other types ; checking cardinality first
         		if (!getSequenceType().getCardinality().isSuperCardinalityOrEqualOf(actualCardinality))
-    				{throw new XPathException(getValue(), ErrorCodes.W3CErrorCode.XPTY0004, "Invalid cardinality for variable $" + getQName() +
+    				{throw new XPathException(getValue(), ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "Invalid cardinality for variable $" + getQName() +
     						". Expected " +
     						getSequenceType().getCardinality().getHumanDescription() +
     						", got " + actualCardinality.getHumanDescription());}
         		//TODO : ignore nodes right now ; they are returned as xs:untypedAtomicType
         		if (!Type.subTypeOf(getSequenceType().getPrimaryType(), Type.NODE)) {
             		if (!getValue().isEmpty() && !Type.subTypeOf(getValue().getItemType(), getSequenceType().getPrimaryType()))
-        				{throw new XPathException(getValue(), ErrorCodes.W3CErrorCode.XPTY0004, "Invalid type for variable $" + getQName() +
+        				{throw new XPathException(getValue(), ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "Invalid type for variable $" + getQName() +
         						". Expected " +
         						Type.getTypeName(getSequenceType().getPrimaryType()) +
         						", got " +Type.getTypeName(getValue().getItemType()));}
@@ -171,7 +171,7 @@ public class VariableImpl implements Variable {
         		} else {
         			//Same as above : we probably may factorize 
             		if (!getValue().isEmpty() && !Type.subTypeOf(getValue().getItemType(), getSequenceType().getPrimaryType()))
-        				{throw new XPathException(getValue(), ErrorCodes.W3CErrorCode.XPTY0004, "Invalid type for variable $" + getQName() +
+        				{throw new XPathException(getValue(), ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "Invalid type for variable $" + getQName() +
         						". Expected " +
         						Type.getTypeName(getSequenceType().getPrimaryType()) +
         						", got " +Type.getTypeName(getValue().getItemType()));}

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
@@ -118,7 +118,7 @@ public class FunSerialize extends BasicFunction {
 
             return new StringValue(this, writer.toString());
         } catch (final SAXException e) {
-            throw new XPathException(this, ErrorCodes.W3CErrorCode.SENR0001, e.getMessage());
+            throw new XPathException(this, ErrorCodes.W3CErrorCode.SENR0001.getErrorCode(), e.getMessage());
         }
     }
 
@@ -192,7 +192,7 @@ public class FunSerialize extends BasicFunction {
             final int itemType = next.getType();
             if (Type.subTypeOf(itemType, Type.NODE)) {
                 if (itemType == Type.ATTRIBUTE || itemType == Type.NAMESPACE || itemType == Type.FUNCTION_REFERENCE) {
-                    throw new XPathException(callingExpr, ErrorCodes.W3CErrorCode.SENR0001,
+                    throw new XPathException(callingExpr, ErrorCodes.W3CErrorCode.SENR0001.getErrorCode(),
                         "It is an error if an item in the sequence to serialize is an attribute node or a namespace node.");
                 }
                 step2.add(next);
@@ -225,7 +225,7 @@ public class FunSerialize extends BasicFunction {
             }
             return (DocumentImpl)receiver.getDocument();
         } catch (final SAXException e) {
-            throw new XPathException(callingExpr, ErrorCodes.W3CErrorCode.SENR0001, e.getMessage());
+            throw new XPathException(callingExpr, ErrorCodes.W3CErrorCode.SENR0001.getErrorCode(), e.getMessage());
         } finally {
             context.popDocumentContext();
         }

--- a/exist-core/src/main/java/org/exist/xquery/functions/map/MapExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/map/MapExpr.java
@@ -100,7 +100,7 @@ public class MapExpr extends AbstractExpression {
         for (final Mapping mapping : this.mappings) {
             final Sequence key = mapping.key.eval(contextSequence, null);
             if (key.getItemCount() != 1) {
-                throw new XPathException(this, ErrorCodes.EXistErrorCode.EXMPDY001, "Expected single value for key, got " + key.getItemCount());
+                throw new XPathException(this, ErrorCodes.EXistErrorCode.EXMPDY001.getErrorCode(), "Expected single value for key, got " + key.getItemCount());
             }
             final AtomicValue atomic = key.itemAt(0).atomize();
             final Sequence value = mapping.value.eval(contextSequence, null);

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/Eval.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/Eval.java
@@ -413,7 +413,7 @@ public class Eval extends BasicFunction {
                         return new StringValue(this, writer.toString());
 
                     } catch (final SAXException e) {
-                        throw new XPathException(this, ErrorCodes.W3CErrorCode.SENR0001, e.getMessage());
+                        throw new XPathException(this, ErrorCodes.W3CErrorCode.SENR0001.getErrorCode(), e.getMessage());
                     }
                 }
             } finally {

--- a/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
@@ -282,7 +282,7 @@ public class SerializerUtils {
             }
 
             if (!Namespaces.XSLT_XQUERY_SERIALIZATION_NS.equals(reader.getNamespaceURI())) {
-                throw new XPathException(parent, ErrorCodes.W3CErrorCode.SENR0001, "serialization parameter elements should be in the output namespace");
+                throw new XPathException(parent, ErrorCodes.W3CErrorCode.SENR0001.getErrorCode(), "serialization parameter elements should be in the output namespace");
             }
 
             final int thisLevel = ((NodeId) reader.getProperty(ExtendedXMLStreamReader.PROPERTY_NODE_ID)).getTreeLevel();
@@ -311,7 +311,7 @@ public class SerializerUtils {
         final String local = key.getLocalPart();
         final String prefix = key.getPrefix();
         if (properties.containsKey(local)) {
-            throw new XPathException(parent, ErrorCodes.W3CErrorCode.SEPM0019, "serialization parameter specified twice: " + key);
+            throw new XPathException(parent, ErrorCodes.W3CErrorCode.SEPM0019.getErrorCode(), "serialization parameter specified twice: " + key);
         }
         if (prefix.equals(OUTPUT_NAMESPACE) && !W3CParameterConventionKeys.contains(local)) {
             throw new XPathException(ErrorCodes.SEPM0017, "serialization parameter not recognized: " + key);
@@ -469,7 +469,7 @@ public class SerializerUtils {
 
             return properties;
         } catch (final UnsupportedOperationException e) {
-            throw new XPathException(parent, ErrorCodes.W3CErrorCode.SENR0001, e.getMessage());
+            throw new XPathException(parent, ErrorCodes.W3CErrorCode.SENR0001.getErrorCode(), e.getMessage());
         }
     }
 

--- a/exist-core/src/test/java/org/exist/xmldb/XMLDBExternalVariableTest.java
+++ b/exist-core/src/test/java/org/exist/xmldb/XMLDBExternalVariableTest.java
@@ -137,12 +137,12 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableUndeclared() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "xs:string*", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "xs:string*", (ExternalVariableValueRep[]) null);
     }
 
     @Test
     public void queryPostWithExternalVariableUntypedNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, null, (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), null, (ExternalVariableValueRep[]) null);
     }
 
     @Test
@@ -160,13 +160,13 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableStringNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "xs:string", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "xs:string", (ExternalVariableValueRep[]) null);
     }
 
     @Test
     public void queryPostWithExternalVariableStringSuppliedEmpty() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[0];
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "xs:string", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "xs:string", externalVariable);
     }
 
     @Test
@@ -178,7 +178,7 @@ public class XMLDBExternalVariableTest {
     @Test
     public void queryPostWithExternalVariableStringSuppliedStrings() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[]{ UntypedValueRep.value("hello"), UntypedValueRep.value("goodbye") };
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "xs:string", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "xs:string", externalVariable);
     }
 
     @Test
@@ -203,7 +203,7 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableOptStringNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "xs:string?", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "xs:string?", (ExternalVariableValueRep[]) null);
     }
 
     @Test
@@ -221,7 +221,7 @@ public class XMLDBExternalVariableTest {
     @Test
     public void queryPostWithExternalVariableOptStringSuppliedStrings() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { value(Type.STRING, "hello"), value(Type.STRING, "goodbye") };
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "xs:string?", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "xs:string?", externalVariable);
     }
 
     @Test
@@ -233,13 +233,13 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableStringsNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "xs:string+", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "xs:string+", (ExternalVariableValueRep[]) null);
     }
 
     @Test
     public void queryPostWithExternalVariableStringsSuppliedEmpty() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[0];
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "xs:string+", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "xs:string+", externalVariable);
     }
 
     @Test
@@ -270,7 +270,7 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableStringzNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "xs:string*", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "xs:string*", (ExternalVariableValueRep[]) null);
     }
 
     @Test
@@ -319,13 +319,13 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableElementNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "element()", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "element()", (ExternalVariableValueRep[]) null);
     }
 
     @Test
     public void queryPostWithExternalVariableElementSuppliedEmpty() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[0];
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "element()", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "element()", externalVariable);
     }
 
     @Test
@@ -337,7 +337,7 @@ public class XMLDBExternalVariableTest {
     @Test
     public void queryPostWithExternalVariableElementSuppliedElements() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>"), UntypedValueRep.value("<goodbye>see you soon</goodbye>") };
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "element()", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "element()", externalVariable);
     }
 
     @Test
@@ -346,7 +346,7 @@ public class XMLDBExternalVariableTest {
         // NOTE(AR) unlike {@link RESTExternalVariableTest#queryPostWithExternalVariableElementSuppliedUntyped} a value supplied as an 'untyped' Element cannot be inferred by the XML:DB API as it can be via the REST API
 //        queryPostWithExternalVariable("element()", externalVariable);
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected element(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "element()", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "element()", externalVariable);
     }
 
     @Test
@@ -363,7 +363,7 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableOptElementNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "element()?", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "element()?", (ExternalVariableValueRep[]) null);
     }
 
     @Test
@@ -381,7 +381,7 @@ public class XMLDBExternalVariableTest {
     @Test
     public void queryPostWithExternalVariableOptElementSuppliedElements() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { value(Type.ELEMENT, "<hello>world</hello>"), value(Type.ELEMENT, "<goodbye>see you soon</goodbye>") };
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "element()?", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "element()?", externalVariable);
     }
 
     @Test
@@ -390,18 +390,18 @@ public class XMLDBExternalVariableTest {
         // NOTE(AR) unlike {@link RESTExternalVariableTest#queryPostWithExternalVariableOptElementSuppliedUntyped} a value supplied as an 'untyped' Element cannot be inferred by the XML:DB API as it can be via the REST API
 //        queryPostWithExternalVariable("element()?", externalVariable);
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected element(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "element()?", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "element()?", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableElementsNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "element()+", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "element()+", (ExternalVariableValueRep[]) null);
     }
 
     @Test
     public void queryPostWithExternalVariableElementsSuppliedEmpty() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[0];
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "element()+", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "element()+", externalVariable);
     }
 
     @Test
@@ -422,7 +422,7 @@ public class XMLDBExternalVariableTest {
         // NOTE(AR) unlike {@link RESTExternalVariableTest#queryPostWithExternalVariableElementsSuppliedUntyped} a value supplied as an 'untyped' Element cannot be inferred by the XML:DB API as it can be via the REST API
 //        queryPostWithExternalVariable("element()+", externalVariable);
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected element(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "element()+", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "element()+", externalVariable);
     }
 
     @Test
@@ -431,12 +431,12 @@ public class XMLDBExternalVariableTest {
         // NOTE(AR) unlike {@link RESTExternalVariableTest#queryPostWithExternalVariableElementsSuppliedUntypeds} a value supplied as an 'untyped' Element cannot be inferred by the XML:DB API as it can be via the REST API
 //        queryPostWithExternalVariable("element()+", externalVariable);
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected element(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "element()+", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "element()+", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableElementzNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "element()*", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "element()*", (ExternalVariableValueRep[]) null);
     }
 
     @Test
@@ -463,7 +463,7 @@ public class XMLDBExternalVariableTest {
         // NOTE(AR) unlike {@link RESTExternalVariableTest#queryPostWithExternalVariableElementszSuppliedUntyped} a value supplied as an 'untyped' Element cannot be inferred by the XML:DB API as it can be via the REST API
 //        queryPostWithExternalVariable("element()*", externalVariable);
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected element(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "element()*", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "element()*", externalVariable);
     }
 
     @Test
@@ -472,7 +472,7 @@ public class XMLDBExternalVariableTest {
         // NOTE(AR) unlike {@link RESTExternalVariableTest#queryPostWithExternalVariableElementzSuppliedUntypeds} a value supplied as an 'untyped' Element cannot be inferred by the XML:DB API as it can be via the REST API
 //        queryPostWithExternalVariable("element()*", externalVariable);
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected element(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "element()*", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "element()*", externalVariable);
     }
 
     @Test
@@ -489,13 +489,13 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableDocumentNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "document-node()", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "document-node()", (ExternalVariableValueRep[]) null);
     }
 
     @Test
     public void queryPostWithExternalVariableDocumentSuppliedEmpty() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[0];
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "document-node()", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "document-node()", externalVariable);
     }
 
     @Test
@@ -507,14 +507,14 @@ public class XMLDBExternalVariableTest {
     @Test
     public void queryPostWithExternalVariableDocumentSuppliedDocuments() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>"), UntypedValueRep.value("<goodbye>see you soon</goodbye>") };
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "document-node()", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "document-node()", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableDocumentSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep externalVariable = UntypedValueRep.value("<hello>world</hello>");
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected document-node(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "document-node()", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "document-node()", externalVariable);
     }
 
     @Test
@@ -531,7 +531,7 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableOptDocumentNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "document-node()?", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "document-node()?", (ExternalVariableValueRep[]) null);
     }
 
     @Test
@@ -549,25 +549,25 @@ public class XMLDBExternalVariableTest {
     @Test
     public void queryPostWithExternalVariableOptDocumentSuppliedDocuments() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { value(Type.DOCUMENT, "<hello>world</hello>"), value(Type.DOCUMENT, "<goodbye>see you soon</goodbye>") };
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "document-node()?", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "document-node()?", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableOptDocumentSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep externalVariable = UntypedValueRep.value("<hello>world</hello>");
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected document-node(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "document-node()?", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "document-node()?", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableDocumentsNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "document-node()+", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "document-node()+", (ExternalVariableValueRep[]) null);
     }
 
     @Test
     public void queryPostWithExternalVariableDocumentsSuppliedEmpty() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[0];
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "document-node()+", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "document-node()+", externalVariable);
     }
 
     @Test
@@ -586,19 +586,19 @@ public class XMLDBExternalVariableTest {
     public void queryPostWithExternalVariableDocumentsSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>") };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected document-node(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "document-node()+", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "document-node()+", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableDocumentsSuppliedUntypeds() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>"), UntypedValueRep.value("<goodbye>see you soon</goodbye>") };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected document-node(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "document-node()+", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "document-node()+", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableDocumentzNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "document-node()*", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "document-node()*", (ExternalVariableValueRep[]) null);
     }
 
     @Test
@@ -623,14 +623,14 @@ public class XMLDBExternalVariableTest {
     public void queryPostWithExternalVariableDocumentszSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>") };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected document-node(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "document-node()*", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "document-node()*", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableDocumentzSuppliedUntypeds() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>"), UntypedValueRep.value("<goodbye>see you soon</goodbye>") };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected document-node(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "document-node()*", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "document-node()*", externalVariable);
     }
 
     @Test
@@ -647,13 +647,13 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableCommentNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "comment()", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "comment()", (ExternalVariableValueRep[]) null);
     }
 
     @Test
     public void queryPostWithExternalVariableCommentSuppliedEmpty() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[0];
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "comment()", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "comment()", externalVariable);
     }
 
     @Test
@@ -665,14 +665,14 @@ public class XMLDBExternalVariableTest {
     @Test
     public void queryPostWithExternalVariableCommentSuppliedComments() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<!-- hello world -->"), UntypedValueRep.value("<!-- goodbye see you soon -->") };
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "comment()", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "comment()", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableCommentSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep externalVariable = UntypedValueRep.value("<!-- hello world -->");
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected comment(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "comment()", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "comment()", externalVariable);
     }
 
     @Test
@@ -689,7 +689,7 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableOptCommentNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "comment()?", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "comment()?", (ExternalVariableValueRep[]) null);
     }
 
     @Test
@@ -707,25 +707,25 @@ public class XMLDBExternalVariableTest {
     @Test
     public void queryPostWithExternalVariableOptCommentSuppliedComments() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { value(Type.COMMENT, "<!-- hello world -->"), value(Type.COMMENT, "<!-- goodbye see you soon -->") };
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "comment()?", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "comment()?", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableOptCommentSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep externalVariable = UntypedValueRep.value("<!-- hello world -->");
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected comment(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "comment()?", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "comment()?", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableCommentsNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "comment()+", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "comment()+", (ExternalVariableValueRep[]) null);
     }
 
     @Test
     public void queryPostWithExternalVariableCommentsSuppliedEmpty() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[0];
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "comment()+", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "comment()+", externalVariable);
     }
 
     @Test
@@ -744,19 +744,19 @@ public class XMLDBExternalVariableTest {
     public void queryPostWithExternalVariableCommentsSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<!-- hello world -->") };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected comment(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "comment()+", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "comment()+", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableCommentsSuppliedUntypeds() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<!-- hello world -->"), UntypedValueRep.value("<!-- goodbye see you soon -->") };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected comment(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "comment()+", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "comment()+", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableCommentzNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "comment()*", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "comment()*", (ExternalVariableValueRep[]) null);
     }
 
     @Test
@@ -781,14 +781,14 @@ public class XMLDBExternalVariableTest {
     public void queryPostWithExternalVariableCommentszSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<!-- hello world -->") };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected comment(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "comment()*", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "comment()*", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableCommentzSuppliedUntypeds() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<!-- hello world -->"), UntypedValueRep.value("<!-- goodbye see you soon -->") };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected comment(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "comment()*", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "comment()*", externalVariable);
     }
 
     @Test
@@ -805,13 +805,13 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableProcessingInstructionNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "processing-instruction()", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "processing-instruction()", (ExternalVariableValueRep[]) null);
     }
 
     @Test
     public void queryPostWithExternalVariableProcessingInstructionSuppliedEmpty() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[0];
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "processing-instruction()", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "processing-instruction()", externalVariable);
     }
 
     @Test
@@ -823,14 +823,14 @@ public class XMLDBExternalVariableTest {
     @Test
     public void queryPostWithExternalVariableProcessingInstructionSuppliedProcessingInstructions() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<?hello world?>"), UntypedValueRep.value("<?goodbye see-you-soon?>") };
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "processing-instruction()", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "processing-instruction()", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableProcessingInstructionSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep externalVariable = UntypedValueRep.value("<?hello world?>");
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected processing-instruction(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "processing-instruction()", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "processing-instruction()", externalVariable);
     }
 
     @Test
@@ -847,7 +847,7 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableOptProcessingInstructionNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "processing-instruction()?", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "processing-instruction()?", (ExternalVariableValueRep[]) null);
     }
 
     @Test
@@ -865,25 +865,25 @@ public class XMLDBExternalVariableTest {
     @Test
     public void queryPostWithExternalVariableOptProcessingInstructionSuppliedProcessingInstructions() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { value(Type.PROCESSING_INSTRUCTION, "<?hello world?>"), value(Type.PROCESSING_INSTRUCTION, "<?goodbye see-you-soon?>") };
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "processing-instruction()?", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "processing-instruction()?", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableOptProcessingInstructionSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep externalVariable = UntypedValueRep.value("<?hello world?>");
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected processing-instruction(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "processing-instruction()?", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "processing-instruction()?", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableProcessingInstructionsNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "processing-instruction()+", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "processing-instruction()+", (ExternalVariableValueRep[]) null);
     }
 
     @Test
     public void queryPostWithExternalVariableProcessingInstructionsSuppliedEmpty() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[0];
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "processing-instruction()+", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "processing-instruction()+", externalVariable);
     }
 
     @Test
@@ -902,19 +902,19 @@ public class XMLDBExternalVariableTest {
     public void queryPostWithExternalVariableProcessingInstructionsSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<?hello world?>") };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected processing-instruction(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "processing-instruction()+", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "processing-instruction()+", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableProcessingInstructionsSuppliedUntypeds() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<?hello world?>"), UntypedValueRep.value("<?goodbye see-you-soon?>") };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected processing-instruction(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "processing-instruction()+", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "processing-instruction()+", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableProcessingInstructionzNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "processing-instruction()*", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "processing-instruction()*", (ExternalVariableValueRep[]) null);
     }
 
     @Test
@@ -939,14 +939,14 @@ public class XMLDBExternalVariableTest {
     public void queryPostWithExternalVariableProcessingInstructionszSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<?hello world?>") };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected processing-instruction(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "processing-instruction()*", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "processing-instruction()*", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableProcessingInstructionzSuppliedUntypeds() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<?hello world?>"), UntypedValueRep.value("<?goodbye see-you-soon?>") };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected processing-instruction(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "processing-instruction()*", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "processing-instruction()*", externalVariable);
     }
 
     @Test
@@ -965,13 +965,13 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableTextNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "text()", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "text()", (ExternalVariableValueRep[]) null);
     }
 
     @Test
     public void queryPostWithExternalVariableTextSuppliedEmpty() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[0];
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "text()", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "text()", externalVariable);
     }
 
     @Test
@@ -983,14 +983,14 @@ public class XMLDBExternalVariableTest {
     @Test
     public void queryPostWithExternalVariableTextSuppliedTexts() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("hello world"), UntypedValueRep.value("goodbye see you soon") };
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "text()", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "text()", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableTextSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep externalVariable = UntypedValueRep.value("hello world");
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected text(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "text()", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "text()", externalVariable);
     }
 
     @Test
@@ -1009,7 +1009,7 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableOptTextNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "text()?", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "text()?", (ExternalVariableValueRep[]) null);
     }
 
     @Test
@@ -1027,25 +1027,25 @@ public class XMLDBExternalVariableTest {
     @Test
     public void queryPostWithExternalVariableOptTextSuppliedTexts() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { value(Type.TEXT, "hello world"), value(Type.TEXT, "goodbye see you soon") };
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "text()?", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "text()?", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableOptTextSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep externalVariable = UntypedValueRep.value("hello world");
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected text(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "text()?", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "text()?", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableTextsNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "text()+", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "text()+", (ExternalVariableValueRep[]) null);
     }
 
     @Test
     public void queryPostWithExternalVariableTextsSuppliedEmpty() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[0];
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "text()+", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "text()+", externalVariable);
     }
 
     @Test
@@ -1064,19 +1064,19 @@ public class XMLDBExternalVariableTest {
     public void queryPostWithExternalVariableTextsSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("hello world") };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected text(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "text()+", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "text()+", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableTextsSuppliedUntypeds() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("hello world"), UntypedValueRep.value("goodbye see you soon") };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected text(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "text()+", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "text()+", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableTextzNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "text()*", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "text()*", (ExternalVariableValueRep[]) null);
     }
 
     @Test
@@ -1101,14 +1101,14 @@ public class XMLDBExternalVariableTest {
     public void queryPostWithExternalVariableTextszSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("hello world") };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected text(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "text()*", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "text()*", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableTextzSuppliedUntypeds() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("hello world"), UntypedValueRep.value("goodbye see you soon") };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected text(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "text()*", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "text()*", externalVariable);
     }
 
     @Test
@@ -1125,13 +1125,13 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableAttributeNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "attribute()", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "attribute()", (ExternalVariableValueRep[]) null);
     }
 
     @Test
     public void queryPostWithExternalVariableAttributeSuppliedEmpty() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[0];
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "attribute()", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "attribute()", externalVariable);
     }
 
     @Test
@@ -1143,14 +1143,14 @@ public class XMLDBExternalVariableTest {
     @Test
     public void queryPostWithExternalVariableAttributeSuppliedAttributes() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { value("xevt:hello", "world"), value("goodbye", "see you soon") };
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "attribute()", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "attribute()", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableAttributeSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep externalVariable = value("xevt:hello", "world");
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected attribute(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "attribute()", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "attribute()", externalVariable);
     }
 
     @Test
@@ -1167,7 +1167,7 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableOptAttributeNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "attribute()?", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "attribute()?", (ExternalVariableValueRep[]) null);
     }
 
     @Test
@@ -1185,25 +1185,25 @@ public class XMLDBExternalVariableTest {
     @Test
     public void queryPostWithExternalVariableOptAttributeSuppliedAttributes() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { value(Type.ATTRIBUTE, "xevt:hello", "world"), value(Type.ATTRIBUTE, "goodbye", "see you soon") };
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "attribute()?", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "attribute()?", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableOptAttributeSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep externalVariable = value("xevt:hello", "world");
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected attribute(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "attribute()?", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "attribute()?", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableAttributesNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "attribute()+", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "attribute()+", (ExternalVariableValueRep[]) null);
     }
 
     @Test
     public void queryPostWithExternalVariableAttributesSuppliedEmpty() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[0];
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "attribute()+", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "attribute()+", externalVariable);
     }
 
     @Test
@@ -1222,19 +1222,19 @@ public class XMLDBExternalVariableTest {
     public void queryPostWithExternalVariableAttributesSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { value("xevt:hello", "world") };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected attribute(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "attribute()+", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "attribute()+", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableAttributesSuppliedUntypeds() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { value("xevt:hello", "world"), value("goodbye", "see you soon") };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected attribute(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "attribute()+", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "attribute()+", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableAttributezNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "attribute()*", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "attribute()*", (ExternalVariableValueRep[]) null);
     }
 
     @Test
@@ -1259,14 +1259,14 @@ public class XMLDBExternalVariableTest {
     public void queryPostWithExternalVariableAttributeszSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { value("xevt:hello", "world") };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected attribute(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "attribute()*", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "attribute()*", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableAttributezSuppliedUntypeds() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { value("xevt:hello", "world"), value("goodbye", "see you soon") };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected attribute(), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "attribute()*", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "attribute()*", externalVariable);
     }
 
     @Test
@@ -1283,13 +1283,13 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableArrayNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "array(*)", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "array(*)", (ExternalVariableValueRep[]) null);
     }
 
     @Test
     public void queryPostWithExternalVariableArraySuppliedEmpty() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ArrayRep[0];
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "array(*)", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "array(*)", externalVariable);
     }
 
     @Test
@@ -1301,14 +1301,14 @@ public class XMLDBExternalVariableTest {
     @Test
     public void queryPostWithExternalVariableArraySuppliedArrays() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = { array(sequence(value(Type.STRING, "hello"))), array(sequence(value(Type.STRING, "goodbye"))) };
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "array(*)", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "array(*)", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableArraySuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep externalVariable = untypedArray(sequence(value(Type.STRING, "hello")));
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected array(*), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "array(*)", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "array(*)", externalVariable);
     }
 
     @Test
@@ -1325,7 +1325,7 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableOptArrayNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "array(*)?", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "array(*)?", (ExternalVariableValueRep[]) null);
     }
 
     @Test
@@ -1343,25 +1343,25 @@ public class XMLDBExternalVariableTest {
     @Test
     public void queryPostWithExternalVariableOptArraySuppliedArrays() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = { array(sequence(value(Type.STRING, "hello"), value(Type.INTEGER, 42))), array(sequence(value(Type.STRING, "goodbye"))) };
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "array(*)?", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "array(*)?", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableOptArraySuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep externalVariable = untypedArray(sequence(value(Type.STRING, "hello")));
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected array(*), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "array(*)?", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "array(*)?", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableArraysNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "array(*)+", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "array(*)+", (ExternalVariableValueRep[]) null);
     }
 
     @Test
     public void queryPostWithExternalVariableArraysSuppliedEmpty() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new ArrayRep[0];
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "array(*)+", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "array(*)+", externalVariable);
     }
 
     @Test
@@ -1380,19 +1380,19 @@ public class XMLDBExternalVariableTest {
     public void queryPostWithExternalVariableArraysSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep externalVariable = untypedArray(sequence(value(Type.STRING, "hello")));
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected array(*), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "array(*)+", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "array(*)+", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableArraysSuppliedUntypeds() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = { untypedArray(sequence(value(Type.STRING, "hello"))), untypedArray(sequence(value(Type.STRING, "goodbye"))) };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected array(*), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "array(*)+", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "array(*)+", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableArrayzNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "array(*)*", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "array(*)*", (ExternalVariableValueRep[]) null);
     }
 
     @Test
@@ -1417,14 +1417,14 @@ public class XMLDBExternalVariableTest {
     public void queryPostWithExternalVariableArrayszSuppliedUntyped() throws XMLDBException {
         final ExternalVariableValueRep externalVariable = untypedArray(sequence(value(Type.STRING, "hello")));
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected array(*), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "array(*)*", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "array(*)*", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableArrayzSuppliedUntypeds() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = { untypedArray(sequence(value(Type.STRING, "hello"))), untypedArray(sequence(value(Type.STRING, "goodbye"))) };
         final String expectedResponseError = "Invalid type for variable $local:my-variable. Expected array(*), got xs:string";
-        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004, expectedResponseError), "array(*)*", externalVariable);
+        queryPostWithExternalVariable(Tuple(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), expectedResponseError), "array(*)*", externalVariable);
     }
 
     @Test
@@ -1441,13 +1441,13 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableMapNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "map(*)", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "map(*)", (ExternalVariableValueRep[]) null);
     }
 
     @Test
     public void queryPostWithExternalVariableMapSuppliedEmpty() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new MapRep[0];
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "map(*)", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "map(*)", externalVariable);
     }
 
     @Test
@@ -1467,7 +1467,7 @@ public class XMLDBExternalVariableTest {
                 entry(key(Type.STRING, "key3"), sequence(value(Type.STRING, "in the beginning"), value(Type.STRING, "but at the end"), value(Type.INTEGER, 42)))
             )
         };
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "map(*)", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "map(*)", externalVariable);
     }
 
     @Test
@@ -1506,7 +1506,7 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableOptMapNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "map(*)?", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "map(*)?", (ExternalVariableValueRep[]) null);
     }
 
     @Test
@@ -1532,7 +1532,7 @@ public class XMLDBExternalVariableTest {
                 entry(key(Type.STRING, "key3"), sequence(value(Type.STRING, "in the beginning"), value(Type.STRING, "but at the end"), value(Type.INTEGER, 42)))
             )
         };
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "map(*)?", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "map(*)?", externalVariable);
     }
 
     @Test
@@ -1543,13 +1543,13 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableMapsNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "map(*)+", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "map(*)+", (ExternalVariableValueRep[]) null);
     }
 
     @Test
     public void queryPostWithExternalVariableMapsSuppliedEmpty() throws XMLDBException {
         final ExternalVariableValueRep[] externalVariable = new MapRep[0];
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004, "map(*)+", externalVariable);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPTY0004.getErrorCode(), "map(*)+", externalVariable);
     }
 
     @Test
@@ -1595,7 +1595,7 @@ public class XMLDBExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableMapzNotSupplied() throws XMLDBException {
-        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002, "map(*)*", (ExternalVariableValueRep[]) null);
+        queryPostWithExternalVariable(ErrorCodes.W3CErrorCode.XPDY0002.getErrorCode(), "map(*)*", (ExternalVariableValueRep[]) null);
     }
 
     @Test

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/adapters/EXQueryErrorCode.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/adapters/EXQueryErrorCode.java
@@ -27,28 +27,36 @@
 package org.exist.extensions.exquery.restxq.impl.adapters;
 
 import org.exist.dom.QName;
-import org.exist.xquery.ErrorCodes.ErrorCode;
+import org.exist.xquery.ErrorCodes;
+import org.exist.xquery.ErrorCodes.IErrorCode;
 import org.exquery.restxq.RestXqErrorCodes;
 
-public enum EXQueryErrorCode implements ErrorCode {
+public enum EXQueryErrorCode implements IErrorCode {
 
     RQDY0101(RestXqErrorCodes.RQDY0101);
 
-    private final QName qname;
-    private final String description;
+    private final ErrorCodes.ErrorCode errorCode;
 
     EXQueryErrorCode(final org.exquery.ErrorCodes.ErrorCode errorCode) {
-        this.qname = new QName(errorCode.getErrorQName().getLocalPart(), errorCode.getErrorQName().getNamespaceURI(), errorCode.getErrorQName().getPrefix());
-        this.description = errorCode.getDescription();
+        this.errorCode = new ErrorCodes.ErrorCode(new QName(errorCode.getErrorQName().getLocalPart(), errorCode.getErrorQName().getNamespaceURI(), errorCode.getErrorQName().getPrefix()), errorCode.getDescription());
     }
 
     @Override
     public QName getErrorQName() {
-        return qname;
+        return errorCode.getErrorQName();
     }
 
     @Override
     public String getDescription() {
-        return description;
+        return errorCode.getDescription();
+    }
+
+    /**
+     * Get the error code.
+     *
+     * @return the error code.
+     */
+    public ErrorCodes.ErrorCode getErrorCode() {
+        return errorCode;
     }
 }

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/xquery/UriFunctions.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/xquery/UriFunctions.java
@@ -78,7 +78,7 @@ public class UriFunctions extends BasicFunction {
         }
 
         if(var == null) {
-            throw new XPathException(EXQueryErrorCode.RQDY0101, getLine(), getColumn());
+            throw new XPathException(EXQueryErrorCode.RQDY0101.getErrorCode(), getLine(), getColumn());
         } else {
             return var.getValue();
         }

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Facets.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Facets.java
@@ -167,7 +167,7 @@ public class Facets extends BasicFunction {
             try {
                 addFacetsToMap(map, dimension, count, paths, match);
             } catch (IOException e) {
-                throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0002, e.getMessage());
+                throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0002.getErrorCode(), e.getMessage());
             }
         }
         return new MapType(this, context, map.forked(), Type.STRING);

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
@@ -189,7 +189,7 @@ public class Field extends BasicFunction {
             return result;
 
         } catch (final IOException e) {
-            throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0002, "Error retrieving field: " + e.getMessage(), e);
+            throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0002.getErrorCode(), "Error retrieving field: " + e.getMessage(), e);
         }
     }
 
@@ -429,7 +429,7 @@ public class Field extends BasicFunction {
 
                 case Type.NOTATION:
                 default:
-                    throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0005, "Cannot convert binary field to " + Type.getTypeName(type));
+                    throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0005.getErrorCode(), "Cannot convert binary field to " + Type.getTypeName(type));
             }
         } catch (final NumberFormatException e) {
             throw new XPathException(this, e.getMessage(), e);
@@ -514,7 +514,7 @@ public class Field extends BasicFunction {
                 try {
                     return new QNameValue(null, QName.parse(value));
                 } catch (final QName.IllegalQNameException e) {
-                    throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0006, "Cannot convert string field to " + Type.getTypeName(type), e);
+                    throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0006.getErrorCode(), "Cannot convert string field to " + Type.getTypeName(type), e);
                 }
 
             case Type.STRING:
@@ -531,7 +531,7 @@ public class Field extends BasicFunction {
 
             case Type.NOTATION:
             default:
-                throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0006, "Cannot convert string field to " + Type.getTypeName(type));
+                throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0006.getErrorCode(), "Cannot convert string field to " + Type.getTypeName(type));
         }
     }
 
@@ -596,7 +596,7 @@ public class Field extends BasicFunction {
             case Type.IDREF:
             case Type.ENTITY:
             default:
-                throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0007, "Cannot convert numeric field to " + Type.getTypeName(type));
+                throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0007.getErrorCode(), "Cannot convert numeric field to " + Type.getTypeName(type));
         }
     }
 }

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/GetField.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/GetField.java
@@ -103,9 +103,9 @@ public class GetField extends BasicFunction {
             final String content = index.getFieldContent(lockedDoc.getDocument().getDocId(), field);
             return content == null ? Sequence.EMPTY_SEQUENCE : new org.exist.xquery.value.StringValue(this, content);
 		} catch (PermissionDeniedException e) {
-			throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0001, "Permission denied to read document " + args[0].getStringValue());
+			throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0001.getErrorCode(), "Permission denied to read document " + args[0].getStringValue());
 		} catch (IOException e) {
-			throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0002, "IO error while reading document " + args[0].getStringValue());
+			throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0002.getErrorCode(), "IO error while reading document " + args[0].getStringValue());
 		}
 	}
 

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/InspectIndex.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/InspectIndex.java
@@ -105,11 +105,11 @@ public class InspectIndex extends BasicFunction {
 				context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
 			return new BooleanValue(this, index.hasIndex(lockedDoc.getDocument().getDocId()));
 		} catch (PermissionDeniedException e) {
-			throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0001, e.getMessage());
+			throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0001.getErrorCode(), e.getMessage());
 		} catch (URISyntaxException e) {
-			throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0003, e.getMessage());
+			throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0003.getErrorCode(), e.getMessage());
 		} catch (IOException e) {
-			throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0002, e.getMessage());
+			throw new XPathException(this, LuceneModule.LuceneErrorCode.EXXQDYFT0002.getErrorCode(), e.getMessage());
 		}
 	}
 

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/LuceneModule.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/LuceneModule.java
@@ -49,11 +49,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.exist.dom.QName;
-import org.exist.xquery.AbstractInternalModule;
-import org.exist.xquery.ErrorCodes.ErrorCode;
-import org.exist.xquery.FunctionDSL;
-import org.exist.xquery.FunctionDef;
-import org.exist.xquery.FunctionSignature;
+import org.exist.xquery.*;
+import org.exist.xquery.ErrorCodes.IErrorCode;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 
@@ -131,7 +128,7 @@ public class LuceneModule extends AbstractInternalModule {
         return FunctionDSL.functionSignatures(new QName(name, NAMESPACE_URI, PREFIX), description, returnType, variableParamTypes);
     }
 
-    enum LuceneErrorCode implements ErrorCode {
+    enum LuceneErrorCode implements IErrorCode {
         EXXQDYFT0001 ("Permission denied."),
         EXXQDYFT0002 ("IO Exception in lucene index."),
         EXXQDYFT0003 ("Document not found."),
@@ -140,22 +137,29 @@ public class LuceneModule extends AbstractInternalModule {
         EXXQDYFT0006 ("Unable to deserialize string value in call to ft:field"),
         EXXQDYFT0007 ("Unable to deserialize numeric value in call to ft:field");
 
-        private final QName qname;
-        private final String description;
+        private final ErrorCodes.ErrorCode errorCode;
 
         LuceneErrorCode(final String description) {
-            this.qname = new QName(name(), NAMESPACE_URI, PREFIX);
-            this.description = description;
+            this.errorCode = new ErrorCodes.ErrorCode(new QName(name(), NAMESPACE_URI, PREFIX), description);
         }
 
         @Override
         public QName getErrorQName() {
-            return qname;
+            return errorCode.getErrorQName();
         }
 
         @Override
         public String getDescription() {
-            return description;
+            return errorCode.getDescription();
+        }
+
+        /**
+         * Get the error code.
+         *
+         * @return the error code.
+         */
+        public ErrorCodes.ErrorCode getErrorCode() {
+            return errorCode;
         }
     }
 }

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
@@ -377,7 +377,7 @@ public class Query extends Function implements Optimizable {
         } else if (Type.subTypeOf(optSeq.getItemType(), Type.MAP)) {
             return new QueryOptions((AbstractMapType) optSeq.itemAt(0));
         } else {
-            throw new XPathException(funct, LuceneModule.LuceneErrorCode.EXXQDYFT0004, "Argument 3 should be either a map or an XML element");
+            throw new XPathException(funct, LuceneModule.LuceneErrorCode.EXXQDYFT0004.getErrorCode(), "Argument 3 should be either a map or an XML element");
         }
     }
 

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryOptions.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryOptions.java
@@ -118,7 +118,7 @@ public class QueryOptions {
                 }
             }
         } catch (XMLStreamException | IOException e) {
-            throw new XPathException((Expression) null, LuceneModule.LuceneErrorCode.EXXQDYFT0004, "Error while parsing options to ft:query: " + e.getMessage(), e);
+            throw new XPathException((Expression) null, LuceneModule.LuceneErrorCode.EXXQDYFT0004.getErrorCode(), "Error while parsing options to ft:query: " + e.getMessage(), e);
         }
     }
 
@@ -245,7 +245,7 @@ public class QueryOptions {
                 try {
                     phraseSlop = Optional.of(Integer.parseInt(value));
                 } catch (NumberFormatException e) {
-                    throw new XPathException((Expression) null, LuceneModule.LuceneErrorCode.EXXQDYFT0004, "Option " + OPTION_PHRASE_SLOP + " must be an integer");
+                    throw new XPathException((Expression) null, LuceneModule.LuceneErrorCode.EXXQDYFT0004.getErrorCode(), "Option " + OPTION_PHRASE_SLOP + " must be an integer");
                 }
                 break;
             case OPTION_FILTER_REWRITE:

--- a/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/Lookup.java
+++ b/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/Lookup.java
@@ -276,7 +276,7 @@ public class Lookup extends Function implements Optimizable {
         // throw an exception if substring match operation is applied to collated index
         final RangeIndex.Operator operator = getOperator();
         if (usesCollation && !operator.supportsCollation()) {
-            throw new XPathException(this, RangeIndexModule.RangeIndexErrorCode.EXXQDYFT0001, "Index defines a collation which cannot be " +
+            throw new XPathException(this, RangeIndexModule.RangeIndexErrorCode.EXXQDYFT0001.getErrorCode(), "Index defines a collation which cannot be " +
                     "used with the '" + operator + "' operation.");
         }
 
@@ -372,7 +372,7 @@ public class Lookup extends Function implements Optimizable {
 
                 // throw an exception if substring match operation is applied to collated index
                 if (usesCollation && !operator.supportsCollation()) {
-                    throw new XPathException(this, RangeIndexModule.RangeIndexErrorCode.EXXQDYFT0001, "Index defines a collation which cannot be " +
+                    throw new XPathException(this, RangeIndexModule.RangeIndexErrorCode.EXXQDYFT0001.getErrorCode(), "Index defines a collation which cannot be " +
                             "used with the '" + operator + "' operation.");
                 }
 

--- a/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/RangeIndexModule.java
+++ b/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/RangeIndexModule.java
@@ -103,25 +103,32 @@ public class RangeIndexModule extends AbstractInternalModule {
 
     }
 
-    protected enum RangeIndexErrorCode implements ErrorCodes.ErrorCode {
+    protected enum RangeIndexErrorCode implements ErrorCodes.IErrorCode {
         EXXQDYFT0001 ("Collation not supported");
 
-        private final QName qname;
-        private final String description;
+        private final ErrorCodes.ErrorCode errorCode;
 
         RangeIndexErrorCode(final String description) {
-            this.qname = new QName(name(), NAMESPACE_URI, PREFIX);
-            this.description = description;
+            this.errorCode = new ErrorCodes.ErrorCode(new QName(name(), NAMESPACE_URI, PREFIX), description);
         }
 
         @Override
         public QName getErrorQName() {
-            return qname;
+            return errorCode.getErrorQName();
         }
 
         @Override
         public String getDescription() {
-            return description;
+            return errorCode.getDescription();
+        }
+
+        /**
+         * Get the error code.
+         *
+         * @return the error code.
+         */
+        public ErrorCodes.ErrorCode getErrorCode() {
+            return errorCode;
         }
     }
 

--- a/extensions/modules/cache/src/main/java/org/exist/xquery/modules/cache/CacheFunctions.java
+++ b/extensions/modules/cache/src/main/java/org/exist/xquery/modules/cache/CacheFunctions.java
@@ -332,7 +332,7 @@ public class CacheFunctions extends BasicFunction {
         final Optional<CacheConfig> maybeLazyCacheConfig = cacheModule.getLazyCacheConfig();
 
         if (!maybeLazyCacheConfig.isPresent()) {
-            throw new XPathException(this, LAZY_CREATION_DISABLED, "There is no such named cache: " + cacheName + ", and lazy creation of the cache has been disabled.");
+            throw new XPathException(this, LAZY_CREATION_DISABLED.getErrorCode(), "There is no such named cache: " + cacheName + ", and lazy creation of the cache has been disabled.");
         }
 
         createCache(cacheName, maybeLazyCacheConfig.get());
@@ -354,7 +354,7 @@ public class CacheFunctions extends BasicFunction {
             final Optional<String> putGroup = cache.getConfig().getPermissions().flatMap(CacheConfig.Permissions::getPutGroup);
             if (putGroup.isPresent()) {
                 if (!context.getEffectiveUser().hasGroup(putGroup.get())) {
-                    throw new XPathException(this, INSUFFICIENT_PERMISSIONS, "User does not have the appropriate permissions to put data into this cache");
+                    throw new XPathException(this, INSUFFICIENT_PERMISSIONS.getErrorCode(), "User does not have the appropriate permissions to put data into this cache");
                 }
             }
         }
@@ -370,7 +370,7 @@ public class CacheFunctions extends BasicFunction {
             final Optional<String> getGroup = cache.getConfig().getPermissions().flatMap(CacheConfig.Permissions::getGetGroup);
             if (getGroup.isPresent()) {
                 if (!context.getEffectiveUser().hasGroup(getGroup.get())) {
-                    throw new XPathException(this, INSUFFICIENT_PERMISSIONS, "User does not have the appropriate permissions to list data in this cache");
+                    throw new XPathException(this, INSUFFICIENT_PERMISSIONS.getErrorCode(), "User does not have the appropriate permissions to list data in this cache");
                 }
             }
         }
@@ -386,7 +386,7 @@ public class CacheFunctions extends BasicFunction {
             final Optional<String> getGroup = cache.getConfig().getPermissions().flatMap(CacheConfig.Permissions::getGetGroup);
             if (getGroup.isPresent()) {
                 if (!context.getEffectiveUser().hasGroup(getGroup.get())) {
-                    throw new XPathException(this, INSUFFICIENT_PERMISSIONS, "User does not have the appropriate permissions to list data in this cache");
+                    throw new XPathException(this, INSUFFICIENT_PERMISSIONS.getErrorCode(), "User does not have the appropriate permissions to list data in this cache");
                 }
             }
         }
@@ -402,7 +402,7 @@ public class CacheFunctions extends BasicFunction {
             final Optional<String> getGroup = cache.getConfig().getPermissions().flatMap(CacheConfig.Permissions::getGetGroup);
             if (getGroup.isPresent()) {
                 if (!context.getEffectiveUser().hasGroup(getGroup.get())) {
-                    throw new XPathException(this, INSUFFICIENT_PERMISSIONS, "User does not have the appropriate permissions to get data from this cache");
+                    throw new XPathException(this, INSUFFICIENT_PERMISSIONS.getErrorCode(), "User does not have the appropriate permissions to get data from this cache");
                 }
             }
         }
@@ -418,7 +418,7 @@ public class CacheFunctions extends BasicFunction {
             final Optional<String> removeGroup = cache.getConfig().getPermissions().flatMap(CacheConfig.Permissions::getRemoveGroup);
             if (removeGroup.isPresent()) {
                 if (!context.getEffectiveUser().hasGroup(removeGroup.get())) {
-                    throw new XPathException(this, INSUFFICIENT_PERMISSIONS, "User does not have the appropriate permissions to remove data from this cache");
+                    throw new XPathException(this, INSUFFICIENT_PERMISSIONS.getErrorCode(), "User does not have the appropriate permissions to remove data from this cache");
                 }
             }
         }
@@ -435,7 +435,7 @@ public class CacheFunctions extends BasicFunction {
                 final Optional<String> clearGroup = cache.getConfig().getPermissions().flatMap(CacheConfig.Permissions::getClearGroup);
                 if (clearGroup.isPresent()) {
                     if (!context.getEffectiveUser().hasGroup(clearGroup.get())) {
-                        throw new XPathException(this, INSUFFICIENT_PERMISSIONS, "User does not have the appropriate permissions to clear data from all caches");
+                        throw new XPathException(this, INSUFFICIENT_PERMISSIONS.getErrorCode(), "User does not have the appropriate permissions to clear data from all caches");
                     }
                 }
             }
@@ -455,7 +455,7 @@ public class CacheFunctions extends BasicFunction {
             final Optional<String> clearGroup = cache.getConfig().getPermissions().flatMap(CacheConfig.Permissions::getClearGroup);
             if (clearGroup.isPresent()) {
                 if (!context.getEffectiveUser().hasGroup(clearGroup.get())) {
-                    throw new XPathException(this, INSUFFICIENT_PERMISSIONS, "User does not have the appropriate permissions to clear data from this cache");
+                    throw new XPathException(this, INSUFFICIENT_PERMISSIONS.getErrorCode(), "User does not have the appropriate permissions to clear data from this cache");
                 }
             }
         }
@@ -471,7 +471,7 @@ public class CacheFunctions extends BasicFunction {
             final Optional<String> clearGroup = cache.getConfig().getPermissions().flatMap(CacheConfig.Permissions::getClearGroup);
             if (clearGroup.isPresent()) {
                 if (!context.getEffectiveUser().hasGroup(clearGroup.get())) {
-                    throw new XPathException(this, INSUFFICIENT_PERMISSIONS, "User does not have the appropriate permissions to clear data from this cache");
+                    throw new XPathException(this, INSUFFICIENT_PERMISSIONS.getErrorCode(), "User does not have the appropriate permissions to clear data from this cache");
                 }
             }
         }
@@ -509,7 +509,7 @@ public class CacheFunctions extends BasicFunction {
                 i++;
             }
         } catch (final SAXException e) {
-            throw new XPathException(this, KEY_SERIALIZATION, e);
+            throw new XPathException(this, KEY_SERIALIZATION.getErrorCode(), e);
         } finally {
             context.getBroker().returnSerializer(serializer);
         }
@@ -532,7 +532,7 @@ public class CacheFunctions extends BasicFunction {
             }
             return sbWriter.toString();
         } catch (final SAXException e) {
-            throw new XPathException(this, KEY_SERIALIZATION, e);
+            throw new XPathException(this, KEY_SERIALIZATION.getErrorCode(), e);
         } finally {
             context.getBroker().returnSerializer(serializer);
         }

--- a/extensions/modules/cache/src/main/java/org/exist/xquery/modules/cache/CacheModule.java
+++ b/extensions/modules/cache/src/main/java/org/exist/xquery/modules/cache/CacheModule.java
@@ -144,27 +144,34 @@ public class CacheModule extends AbstractInternalModule {
         return FunctionDSL.functionSignatures(new QName(name, NAMESPACE_URI, PREFIX), description, returnType, variableParamTypes);
     }
 
-    enum CacheModuleErrorCode implements ErrorCodes.ErrorCode {
+    enum CacheModuleErrorCode implements ErrorCodes.IErrorCode {
         INSUFFICIENT_PERMISSIONS ("The calling user does not have sufficient permissions to operate on the cache."),
         KEY_SERIALIZATION ("Unable to serialize the provided key."),
         LAZY_CREATION_DISABLED ("There is no such named cache, and lazy creation of the cache has been disabled.");
 
-        private final QName qname;
-        private final String description;
+        private final ErrorCodes.ErrorCode errorCode;
 
         CacheModuleErrorCode(final String description) {
-            this.qname = new QName(name(), NAMESPACE_URI, PREFIX);
-            this.description = description;
+            this.errorCode = new ErrorCodes.ErrorCode(new QName(name(), NAMESPACE_URI, PREFIX), description);
         }
 
         @Override
         public QName getErrorQName() {
-            return qname;
+            return errorCode.getErrorQName();
         }
 
         @Override
         public String getDescription() {
-            return description;
+            return errorCode.getDescription();
+        }
+
+        /**
+         * Get the error code.
+         *
+         * @return the error code.
+         */
+        public ErrorCodes.ErrorCode getErrorCode() {
+            return errorCode;
         }
     }
 

--- a/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/CompressionModule.java
+++ b/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/CompressionModule.java
@@ -145,25 +145,32 @@ public class CompressionModule extends AbstractInternalModule {
         return FunctionDSL.functionSignatures(new QName(name, NAMESPACE_URI, PREFIX), description, returnType, variableParamTypes);
     }
 
-    enum CompressionModuleErrorCode implements ErrorCodes.ErrorCode {
+    enum CompressionModuleErrorCode implements ErrorCodes.IErrorCode {
         ARCHIVE_EXIT_ATTACK ("The archive likely contains an exit attack, whereby a file extraction tries to escape the destination path.");
 
-        private final QName qname;
-        private final String description;
+        private final ErrorCodes.ErrorCode errorCode;
 
         CompressionModuleErrorCode(final String description) {
-            this.qname = new QName(name(), NAMESPACE_URI, PREFIX);
-            this.description = description;
+            this.errorCode = new ErrorCodes.ErrorCode(new QName(name(), NAMESPACE_URI, PREFIX), description);
         }
 
         @Override
         public QName getErrorQName() {
-            return qname;
+            return errorCode.getErrorQName();
         }
 
         @Override
         public String getDescription() {
-            return description;
+            return errorCode.getDescription();
+        }
+
+        /**
+         * Get the error code.
+         *
+         * @return the error code.
+         */
+        public ErrorCodes.ErrorCode getErrorCode() {
+            return errorCode;
         }
     }
 }

--- a/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/EntryFunctions.java
+++ b/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/EntryFunctions.java
@@ -248,7 +248,7 @@ public class EntryFunctions extends BasicFunction {
             final Path destPath = fsDest.resolve(path).normalize();
 
             if (!destPath.startsWith(fsDest)) {
-                throw new XPathException(this, CompressionModule.CompressionModuleErrorCode.ARCHIVE_EXIT_ATTACK, "Detected archive exit attack!");
+                throw new XPathException(this, CompressionModule.CompressionModuleErrorCode.ARCHIVE_EXIT_ATTACK.getErrorCode(), "Detected archive exit attack!");
             }
 
             switch (dataType) {
@@ -323,7 +323,7 @@ public class EntryFunctions extends BasicFunction {
             final XmldbURI destPath = destCollection.resolveCollectionPath(XmldbURI.create(path));
 
             if (!destPath.startsWith(destCollection)) {
-                throw new XPathException(this, CompressionModule.CompressionModuleErrorCode.ARCHIVE_EXIT_ATTACK, "Detected archive exit attack!");
+                throw new XPathException(this, CompressionModule.CompressionModuleErrorCode.ARCHIVE_EXIT_ATTACK.getErrorCode(), "Detected archive exit attack!");
             }
 
             switch (dataType) {

--- a/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/Deploy.java
+++ b/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/Deploy.java
@@ -145,7 +145,7 @@ public class Deploy extends BasicFunction {
 	public Sequence eval(final Sequence[] args, final Sequence contextSequence)
 			throws XPathException {
 		if (!context.getSubject().hasDbaRole())
-			throw new XPathException(this, EXPathErrorCode.EXPDY003, "Permission denied. You need to be a member " +
+			throw new XPathException(this, EXPathErrorCode.EXPDY003.getErrorCode(), "Permission denied. You need to be a member " +
 					"of the dba group to use repo:deploy/undeploy");
 		
 		final String pkgName = args[0].getStringValue();
@@ -192,7 +192,7 @@ public class Deploy extends BasicFunction {
 	        target.orElseThrow(() -> new XPathException(this, "expath repository is not available."));
             return statusReport(target);
         } catch (PackageException e) {
-            throw new XPathException(this, EXPathErrorCode.EXPDY001, e.getMessage(), args[0], e);
+            throw new XPathException(this, EXPathErrorCode.EXPDY001.getErrorCode(), e.getMessage(), args[0], e);
         } catch (IOException e) {
             throw new XPathException(this, ErrorCodes.FOER0000, "Caught IO error while deploying expath archive", args[0], e);
         } catch (TransactionException e) {
@@ -210,10 +210,10 @@ public class Deploy extends BasicFunction {
             }
             return Optional.empty();
         } catch (final MalformedURLException e) {
-            throw new XPathException(this, EXPathErrorCode.EXPDY005, "Malformed URL: " + repoURI);
+            throw new XPathException(this, EXPathErrorCode.EXPDY005.getErrorCode(), "Malformed URL: " + repoURI);
         } catch (final PackageException | IOException e) {
             LOG.error(e.getMessage(), e);
-            throw new XPathException(this, EXPathErrorCode.EXPDY007, e.getMessage());
+            throw new XPathException(this, EXPathErrorCode.EXPDY007.getErrorCode(), e.getMessage());
         }
     }
 
@@ -221,12 +221,12 @@ public class Deploy extends BasicFunction {
         final XmldbURI docPath = XmldbURI.createInternal(path);
         try(final LockedDocument lockedDoc = context.getBroker().getXMLResource(docPath, LockMode.READ_LOCK)) {
             if(lockedDoc == null) {
-                throw new XPathException(this, EXPathErrorCode.EXPDY001, path + " no such .xar", new StringValue(this, path));
+                throw new XPathException(this, EXPathErrorCode.EXPDY001.getErrorCode(), path + " no such .xar", new StringValue(this, path));
             }
 
             final DocumentImpl doc = lockedDoc.getDocument();
             if (doc.getResourceType() != DocumentImpl.BINARY_FILE) {
-                throw new XPathException(this, EXPathErrorCode.EXPDY001, path + " is not a valid .xar", new StringValue(this, path));
+                throw new XPathException(this, EXPathErrorCode.EXPDY001.getErrorCode(), path + " is not a valid .xar", new StringValue(this, path));
             }
 
             RepoPackageLoader loader = null;
@@ -239,7 +239,7 @@ public class Deploy extends BasicFunction {
             return deployment.installAndDeploy(context.getBroker(), transaction, xarSource, loader);
         } catch (PackageException | IOException | PermissionDeniedException e) {
             LOG.error(e.getMessage(), e);
-            throw new XPathException(this, EXPathErrorCode.EXPDY007, "Package installation failed: " + e.getMessage(), new StringValue(this, e.getMessage()));
+            throw new XPathException(this, EXPathErrorCode.EXPDY007.getErrorCode(), "Package installation failed: " + e.getMessage(), new StringValue(this, e.getMessage()));
         }
     }
 

--- a/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/EXPathErrorCode.java
+++ b/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/EXPathErrorCode.java
@@ -46,7 +46,8 @@
 package org.exist.xquery.modules.expathrepo;
 
 import org.exist.dom.QName;
-import org.exist.xquery.ErrorCodes.ErrorCode;
+import org.exist.xquery.ErrorCodes;
+import org.exist.xquery.ErrorCodes.IErrorCode;
 
 import javax.annotation.Nullable;
 
@@ -62,7 +63,7 @@ import javax.annotation.Nullable;
  *
  * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
-public enum EXPathErrorCode implements ErrorCode {
+public enum EXPathErrorCode implements IErrorCode {
     EXPDY001 ("Package not found."),
     EXPDY002 ("Bad collection URI."),
     EXPDY003 ("Permission denied."),
@@ -75,21 +76,28 @@ public enum EXPathErrorCode implements ErrorCode {
     public final static String EXPATH_ERROR_NS = "http://expath.org/ns/error";
     public final static String EXPATH_ERROR_PREFIX = "experr";
 
-    private final QName qname;
-    private @Nullable final String description;
+    private final ErrorCodes.ErrorCode errorCode;
 
     EXPathErrorCode(@Nullable final String description) {
-        this.qname = new QName(name(), EXPATH_ERROR_NS, EXPATH_ERROR_PREFIX);
-        this.description = description;
+        this.errorCode = new ErrorCodes.ErrorCode(new QName(name(), EXPATH_ERROR_NS, EXPATH_ERROR_PREFIX), description);
     }
 
     @Override
     public QName getErrorQName() {
-        return qname;
+        return errorCode.getErrorQName();
     }
 
     @Override
     public @Nullable String getDescription() {
-        return description;
+        return errorCode.getDescription();
+    }
+
+    /**
+     * Get the error code.
+     *
+     * @return the error code.
+     */
+    public ErrorCodes.ErrorCode getErrorCode() {
+        return errorCode;
     }
 }

--- a/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/InstallFunction.java
+++ b/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/InstallFunction.java
@@ -163,12 +163,12 @@ public class InstallFunction extends BasicFunction {
         try {
             uri = new URI(s);
         } catch (URISyntaxException ex) {
-            throw new XPathException(this, EXPathErrorCode.EXPDY001, s + " is not a valid URI: " + ex.getMessage(), new StringValue(this, s), ex);
+            throw new XPathException(this, EXPathErrorCode.EXPDY001.getErrorCode(), s + " is not a valid URI: " + ex.getMessage(), new StringValue(this, s), ex);
         }
         if (uri.isAbsolute()) {
             return uri;
         } else {
-            throw new XPathException(this, EXPathErrorCode.EXPDY001, s + " must be an absolute URI", new StringValue(this, s));
+            throw new XPathException(this, EXPathErrorCode.EXPDY001.getErrorCode(), s + " must be an absolute URI", new StringValue(this, s));
         }
     }
 
@@ -177,20 +177,20 @@ public class InstallFunction extends BasicFunction {
           final XmldbURI uri = XmldbURI.createInternal(path);
           final LockedDocument lockedDoc = context.getBroker().getXMLResource(uri, LockMode.READ_LOCK);
           if (lockedDoc == null) {
-            throw new XPathException(this, EXPathErrorCode.EXPDY001,
+            throw new XPathException(this, EXPathErrorCode.EXPDY001.getErrorCode(),
                 path + " is not .xar resource",
                 new StringValue(this, path)
             );
           } else if (lockedDoc.getDocument().getResourceType() != DocumentImpl.BINARY_FILE) {
             lockedDoc.close();
-            throw new XPathException(this, EXPathErrorCode.EXPDY001,
+            throw new XPathException(this, EXPathErrorCode.EXPDY001.getErrorCode(),
                 path + " is not a valid .xar, it's not a binary resource",
                 new StringValue(this, path)
             );
           }
           return lockedDoc;
       } catch (PermissionDeniedException e) {
-        throw new XPathException(this, EXPathErrorCode.EXPDY003, e.getMessage(), new StringValue(this, path), e);
+        throw new XPathException(this, EXPathErrorCode.EXPDY003.getErrorCode(), e.getMessage(), new StringValue(this, path), e);
       }
   }
 }

--- a/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/DirectoryList.java
+++ b/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/DirectoryList.java
@@ -193,7 +193,7 @@ public class DirectoryList extends BasicFunction {
 
             return (NodeValue) builder.getDocument().getDocumentElement();
         } catch (final IOException | IllegalStateException e) {
-            throw new XPathException(this, DIRECTORY_NOT_FOUND, e.getMessage());
+            throw new XPathException(this, DIRECTORY_NOT_FOUND.getErrorCode(), e.getMessage());
         } finally {
             context.popDocumentContext();
         }

--- a/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/FileModule.java
+++ b/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/FileModule.java
@@ -126,25 +126,32 @@ public class FileModule extends AbstractInternalModule
         return RELEASED_IN_VERSION;
     }
 
-    enum FileModuleErrorCode implements ErrorCodes.ErrorCode {
+    enum FileModuleErrorCode implements ErrorCodes.IErrorCode {
         DIRECTORY_NOT_FOUND ("The directory could not be found.");
 
-        private final QName qname;
-        private final String description;
+        private final ErrorCodes.ErrorCode errorCode;
 
         FileModuleErrorCode(final String description) {
-            this.qname = new QName(name(), NAMESPACE_URI, PREFIX);
-            this.description = description;
+            this.errorCode = new ErrorCodes.ErrorCode(new QName(name(), NAMESPACE_URI, PREFIX), description);
         }
 
         @Override
         public QName getErrorQName() {
-            return qname;
+            return errorCode.getErrorQName();
         }
 
         @Override
         public String getDescription() {
-            return description;
+            return errorCode.getDescription();
+        }
+
+        /**
+         * Get the error code.
+         *
+         * @return the error code.
+         */
+        public ErrorCodes.ErrorCode getErrorCode() {
+            return errorCode;
         }
     }
 }

--- a/extensions/modules/xmldiff/src/main/java/org/exist/xquery/modules/xmldiff/Compare.java
+++ b/extensions/modules/xmldiff/src/main/java/org/exist/xquery/modules/xmldiff/Compare.java
@@ -126,7 +126,7 @@ public class Compare extends BasicFunction {
             final Node node2 = toNode(nodeSet2.itemAt(i));
 
             if (node1 == null || node2 == null) {
-                throw new XPathException(this, XmlDiffModule.XmldDiffModuleErrorCode.UNSUPPORTED_DOM_IMPLEMENTATION, "Unable to determine DOM implementation of node set item");
+                throw new XPathException(this, XmlDiffModule.XmldDiffModuleErrorCode.UNSUPPORTED_DOM_IMPLEMENTATION.getErrorCode(), "Unable to determine DOM implementation of node set item");
             }
 
             final Source expected = Input.fromNode(node1).build();

--- a/extensions/modules/xmldiff/src/main/java/org/exist/xquery/modules/xmldiff/XmlDiffModule.java
+++ b/extensions/modules/xmldiff/src/main/java/org/exist/xquery/modules/xmldiff/XmlDiffModule.java
@@ -90,25 +90,32 @@ public class XmlDiffModule extends AbstractInternalModule {
         return FunctionDSL.functionSignature(new QName(name, NAMESPACE_URI, PREFIX), description, returnType, paramTypes);
     }
 
-    enum XmldDiffModuleErrorCode implements ErrorCodes.ErrorCode {
+    enum XmldDiffModuleErrorCode implements ErrorCodes.IErrorCode {
         UNSUPPORTED_DOM_IMPLEMENTATION ("The DOM implementation of a Node is unsupported.");
 
-        private final QName qname;
-        private final String description;
+        private final ErrorCodes.ErrorCode errorCode;
 
         XmldDiffModuleErrorCode(final String description) {
-            this.qname = new QName(name(), NAMESPACE_URI, PREFIX);
-            this.description = description;
+            this.errorCode = new ErrorCodes.ErrorCode(new QName(name(), NAMESPACE_URI, PREFIX), description);
         }
 
         @Override
         public QName getErrorQName() {
-            return qname;
+            return errorCode.getErrorQName();
         }
 
         @Override
         public String getDescription() {
-            return description;
+            return errorCode.getDescription();
+        }
+
+        /**
+         * Get the error code.
+         *
+         * @return the error code.
+         */
+        public ErrorCodes.ErrorCode getErrorCode() {
+            return errorCode;
         }
     }
 }


### PR DESCRIPTION
Backport of https://github.com/evolvedbinary/elemental/pull/136

Restore compatibility between `org.exist.xquery.ErrorCodes.ErrorCode` and externally distributed XQuery Java Modules such as EXPath Crypto Module. Fixes a regression introduced in a4979fb8

Closes https://github.com/evolvedbinary/elemental/issues/130