### PR TITLE
[6.x.x] Avoid an NPE when there are no XUpdate Conditionals

### DIFF
--- a/exist-core/src/main/java/org/exist/xupdate/XUpdateProcessor.java
+++ b/exist-core/src/main/java/org/exist/xupdate/XUpdateProcessor.java
@@ -949,7 +949,7 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 
     private @Nullable Conditional peekConditional() {
         if (conditionals == null) {
-            throw null;
+            return null;
         }
         return conditionals.peek();
     }


### PR DESCRIPTION
Backport of https://github.com/evolvedbinary/elemental/pull/138

Avoid an NPE when there are no XUpdate Conditionals