### PR TITLE
[6.x.x] Remove duplicate dependency

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -584,11 +584,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.xmlunit</groupId>
-            <artifactId>xmlunit-matchers</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.googlecode.junit-toolbox</groupId>
             <artifactId>junit-toolbox</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Backport of https://github.com/evolvedbinary/elemental/pull/146

Remove a duplicate dependency that was accidentally introduced in 06c1495