### PR TITLE
[6.x.x] Update project dependencies and Maven plugins

### DIFF
--- a/elemental-parent/pom.xml
+++ b/elemental-parent/pom.xml
@@ -192,6 +192,12 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <inherited>true</inherited>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.6.2</version>
+                </plugin>
+                <plugin>
                     <groupId>org.jvnet.jaxb</groupId>
                     <artifactId>jaxb-maven-plugin</artifactId>
                     <version>${jaxb.impl.version}</version>
@@ -209,7 +215,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.4.2</version>
+                    <version>3.5.0</version>
                     <configuration>
                         <archive>
                             <manifest>
@@ -238,7 +244,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.4.0</version>
                     <configuration>
                         <archive>
                             <manifest>
@@ -356,7 +362,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <plugin>
                     <groupId>com.code54.mojo</groupId>
@@ -394,7 +400,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.3.1</version>
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <tagNameFormat>elemental-@{project.version}</tagNameFormat>
@@ -441,7 +447,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.19.1</version>
+                    <version>2.20.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -520,6 +526,26 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-maven-version</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.9.0</version>
+                                </requireMavenVersion>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>

--- a/elemental-parent/pom.xml
+++ b/elemental-parent/pom.xml
@@ -95,8 +95,8 @@
         <sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
 
         <!-- Dependencies -->
-        <junit.platform.version>1.14.0</junit.platform.version>
-        <junit.jupiter.version>5.14.0</junit.jupiter.version>
+        <junit.platform.version>1.14.1</junit.platform.version>
+        <junit.jupiter.version>5.14.1</junit.jupiter.version>
         <objenesis.version>3.4</objenesis.version>
         <jakarta.activation.version>2.0.1</jakarta.activation.version>
         <jaxb.api.version>3.0.1</jaxb.api.version>
@@ -490,7 +490,7 @@
                             <user.country>UK</user.country>
                             <user.language>en</user.language>
                             <user.timezone>Europe/Berlin</user.timezone>
-                            <java.locale.providers>JRE,CLDR,SPI</java.locale.providers>
+                            <java.locale.providers>CLDR,SPI</java.locale.providers>
                             <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
                         </systemPropertyVariables>
                         <includes>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.20.0</version>
+            <version>2.20.1</version>
         </dependency>
 
         <dependency>
@@ -198,11 +198,11 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.82</version>
+            <version>1.83</version>
         </dependency>
 
         <dependency>
-            <groupId>org.lz4</groupId>
+            <groupId>at.yawk.lz4</groupId>
             <artifactId>lz4-java</artifactId>
             <version>${lz4-java.version}</version>
         </dependency>
@@ -221,7 +221,7 @@
         <dependency>
             <groupId>com.fasterxml.uuid</groupId>
             <artifactId>java-uuid-generator</artifactId>
-            <version>5.1.1</version>
+            <version>5.2.0</version>
         </dependency>
 
         <dependency>
@@ -282,7 +282,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-pool2</artifactId>
-            <version>2.12.1</version>
+            <version>2.13.0</version>
         </dependency>
 
         <dependency>

--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -712,9 +712,9 @@
             </plugin>
 
             <plugin>
-                <groupId>org.exist-db.maven.plugins</groupId>
-                <artifactId>public-xar-repo-plugin</artifactId>
-                <version>1.2.0</version>
+                <groupId>com.evolvedbinary.maven.plugins</groupId>
+                <artifactId>expath-package-repository-plugin</artifactId>
+                <version>1.3.1</version>
                 <executions>
                     <execution>
                         <id>fetch-xars</id>
@@ -725,7 +725,7 @@
                         <configuration>
                             <repoUri>${public.xar.repo.uri}</repoUri>
                             <outputDirectory>${expath.pkg.dir}</outputDirectory>
-                            <existDbVersion>${project.version}</existDbVersion>
+                            <elementalVersion>${project.version}</elementalVersion>
                             <packages>
                                 <package>
                                     <abbrev>dashboard</abbrev>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -98,7 +98,7 @@
         <icu.version>59.1</icu.version>
         <izpack.version>5.2.4</izpack.version>
         <jline.version>3.30.6</jline.version>
-        <lz4-java.version>1.8.0</lz4-java.version>
+        <lz4-java.version>1.10.2</lz4-java.version>
         <jetty.version>9.4.58.v20250814</jetty.version>
         <log4j.version>2.25.2</log4j.version>
         <lucene.version>4.10.4</lucene.version>
@@ -169,13 +169,13 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.19.0</version>
+                <version>1.20.0</version>
             </dependency>
 
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.20.0</version>
+                <version>2.21.0</version>
             </dependency>
 
             <dependency>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -486,7 +486,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.7.1</version>
+                    <version>3.8.0</version>
                     <configuration>
                         <archive>
                             <manifest>

--- a/extensions/debuggee/pom.xml
+++ b/extensions/debuggee/pom.xml
@@ -185,7 +185,7 @@
                 <configuration>
                     <argLine>@{jacocoArgLine}</argLine>
                     <systemPropertyVariables>
-                        <java.locale.providers>JRE,CLDR,SPI</java.locale.providers>
+                        <java.locale.providers>CLDR,SPI</java.locale.providers>
                         <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>
                         <exist.jetty.standalone.webapp.dir>${project.build.testOutputDirectory}/standalone-webapp</exist.jetty.standalone.webapp.dir>
                     </systemPropertyVariables>

--- a/extensions/modules/compression/pom.xml
+++ b/extensions/modules/compression/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.27.1</version>
+            <version>1.28.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Backport of https://github.com/evolvedbinary/elemental/pull/156

1. Update all project dependencies and Maven plugins to the latest applicable versions.
2. Switch from `public-xar-repo-plugin` to `expath-package-repository-plugin` which should handle timeouts when the eXist-db public repo (http://exist-db.org/exist/apps/public-repo) is overloaded or offline