### PR TITLE
[7.x.x] Don't log a warning when there are zero listeners

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -975,6 +975,7 @@
                                 <include>src/main/java/org/exist/storage/NativeValueIndex.java</include>
                                 <include>src/main/java/org/exist/storage/NodePath.java</include>
                                 <include>src/test/java/org/exist/storage/NodePathTest.java</include>
+                                <include>src/main/java/org/exist/storage/NotificationService.java</include>
                                 <include>src/main/java/org/exist/storage/ProcessMonitor.java</include>
                                 <include>src/test/java/org/exist/storage/RecoverBinary2Test.java</include>
                                 <include>src/test/java/org/exist/storage/Recovery2Test.java</include>
@@ -1586,6 +1587,7 @@
                                 <exclude>src/main/java/org/exist/storage/NativeValueIndex.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/NodePath.java</exclude>
                                 <exclude>src/test/java/org/exist/storage/NodePathTest.java</exclude>
+                                <exclude>src/main/java/org/exist/storage/NotificationService.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/ProcessMonitor.java</exclude>
                                 <exclude>src/test/java/org/exist/storage/RecoverBinary2Test.java</exclude>
                                 <exclude>src/test/java/org/exist/storage/RecoverBinaryTest.java</exclude>

--- a/exist-core/src/main/java/org/exist/storage/NotificationService.java
+++ b/exist-core/src/main/java/org/exist/storage/NotificationService.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -104,7 +128,10 @@ public class NotificationService implements BrokerPoolService {
     @Override
     public void shutdown() {
         synchronized (this) {
-            LOG.warn("Expected 0 listeners at shutdown, but {} listeners are still registered", listeners.size());
+            final int remainingListeners = listeners.size();
+            if (remainingListeners > 0) {
+                LOG.warn("Expected 0 listeners at shutdown, but {} listeners are still registered", remainingListeners);
+            }
         }
         BrokerPoolService.super.shutdown();
     }


### PR DESCRIPTION
At shutdown we now check if there are zero listeners before logging a warning that we expected zero listeners.