### PR TITLE
[7.x.x] Fix Query identity in the JMX process output 

### DIFF
--- a/exist-core/src/main/java/org/exist/management/impl/ProcessReportMXBean.java
+++ b/exist-core/src/main/java/org/exist/management/impl/ProcessReportMXBean.java
@@ -123,7 +123,9 @@ ProcessReportMXBean extends PerInstanceMBean {
             if (other == null) {
                 return 1;
             }
-
+            if (id != other.id) {
+              return Integer.compare(id,  other.id);
+            }
             return key.compareTo(other.key);
         }
     }


### PR DESCRIPTION
In the JMX bean for showing processes, ensure that the ID of the query is considered when calculating whether two queries have the same key.

Closes https://github.com/eXist-db/monex/issues/299