### PR TITLE
[7.x.x] Improvements to XPath Axes navigation

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1445,6 +1445,7 @@
                                 <include>src/main/java/org/exist/xquery/value/TimeUtils.java</include>
                                 <include>src/main/java/org/exist/xquery/value/TimeValue.java</include>
                                 <include>src/main/java/org/exist/xquery/value/Type.java</include>
+                                <include>src/main/java/org/exist/xquery/value/ValueSequence.java</include>
                                 <include>src/test/java/org/exist/xquery/value/YearMonthDurationTest.java</include>
                                 <include>src/main/java/org/exist/xquery/value/YearMonthDurationValue.java</include>
                                 <include>src/main/java/org/exist/xslt/EXistURIResolver.java</include>
@@ -2273,6 +2274,7 @@
                                 <exclude>src/main/java/org/exist/xquery/value/TimeUtils.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/TimeValue.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/Type.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/value/ValueSequence.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/value/YearMonthDurationTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/YearMonthDurationValue.java</exclude>
                                 <exclude>src/main/java/org/exist/xslt/EXistURIResolver.java</exclude>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -980,6 +980,7 @@
                                 <include>src/main/java/org/exist/management/impl/JMXAgent.java</include>
                                 <include>src/main/java/org/exist/management/impl/SanityReport.java</include>
                                 <include>src/main/java/org/exist/numbering/DLN.java</include>
+                                <include>src/main/java/org/exist/numbering/DLNBase.java</include>
                                 <include>src/main/java/org/exist/numbering/DLNFactory.java</include>
                                 <include>src/test/java/org/exist/numbering/DLNStorageTest.java</include>
                                 <include>src/main/java/org/exist/numbering/NodeId.java</include>
@@ -1690,6 +1691,7 @@
                                 <exclude>src/main/java/org/exist/mediatype/MediaTypeService.java</exclude>
                                 <exclude>src/main/java/org/exist/mediatype/MediaTypeUtil.java</exclude>
                                 <exclude>src/main/java/org/exist/numbering/DLN.java</exclude>
+                                <exclude>src/main/java/org/exist/numbering/DLNBase.java</exclude>
                                 <exclude>src/main/java/org/exist/numbering/DLNFactory.java</exclude>
                                 <exclude>src/test/java/org/exist/numbering/DLNStorageTest.java</exclude>
                                 <exclude>src/main/java/org/exist/numbering/NodeId.java</exclude>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1219,6 +1219,7 @@
                                 <include>src/test/java/org/exist/xquery/NodeTypeTest.java</include>
                                 <include>src/main/java/org/exist/xquery/Optimizer.java</include>
                                 <include>src/main/java/org/exist/xquery/Option.java</include>
+                                <include>src/main/java/org/exist/xquery/PathExpr.java</include>
                                 <include>src/main/java/org/exist/xquery/PerformanceStatsImpl.java</include>
                                 <include>src/test/java/org/exist/xquery/RestBinariesTest.java</include>
                                 <include>src/test/java/org/exist/xquery/StoredModuleTest.java</include>
@@ -2013,6 +2014,7 @@
                                 <exclude>src/test/java/org/exist/xquery/NodeTypeTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/Optimizer.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/Option.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/PathExpr.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/PerformanceStatsImpl.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/RestBinariesTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/StoredModuleTest.java</exclude>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1299,6 +1299,7 @@
                                 <include>src/main/java/org/exist/xquery/functions/fn/FunInsertBefore.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/FunIRIToURI.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/FunLang.java</include>
+                                <include>src/test/java/org/exist/xquery/functions/fn/FunLangTest.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/FunLast.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/FunLocalName.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/fn/FunMax.java</include>
@@ -2101,6 +2102,7 @@
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FunInsertBefore.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FunIRIToURI.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FunLang.java</exclude>
+                                <exclude>src/test/java/org/exist/xquery/functions/fn/FunLangTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FunLast.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FunLocalName.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/fn/FunMax.java</exclude>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -802,6 +802,7 @@
                                 <include>src/test/resources/log4j2.xml</include>
                                 <include>src/test/resources/standalone-webapp/WEB-INF/web.xml</include>
                                 <include>src/main/xjb/rest-api.xjb</include>
+                                <include>src/test/xquery/parenthesizedLocationStep.xml</include>
                                 <include>src/test/xquery/tail-recursion.xml</include>
                                 <include>src/test/xquery/maps/maps.xqm</include>
                                 <include>src/test/xquery/numbers/format-numbers.xql</include>
@@ -1490,6 +1491,7 @@
                                 <exclude>src/test/xquery/instance-of.xqm</exclude>
                                 <exclude>src/test/xquery/operator-mapping.xqm</exclude>
                                 <exclude>src/test/xquery/order.xqm</exclude>
+                                <exclude>src/test/xquery/parenthesizedLocationStep.xml</exclude>
                                 <exclude>src/test/xquery/pi.xqm</exclude>
                                 <exclude>src/test/xquery/tail-recursion.xml</exclude>
                                 <exclude>src/test/xquery/type-promotion.xqm</exclude>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1210,10 +1210,12 @@
                                 <include>src/test/java/org/exist/xquery/EmbeddedBinariesTest.java</include>
                                 <include>src/test/java/org/exist/xquery/EmbeddedBinariesTest.java.java</include>
                                 <include>src/main/java/org/exist/xquery/ErrorCodes.java</include>
+                                <include>src/main/java/org/exist/xquery/Except.java</include>
                                 <include>src/main/java/org/exist/xquery/ExternalModuleImpl.java</include>
                                 <include>src/test/java/org/exist/xquery/ForwardReferenceTest.java</include>
                                 <include>src/main/java/org/exist/xquery/Function.java</include>
                                 <include>src/main/java/org/exist/xquery/FunctionFactory.java</include>
+                                <include>src/main/java/org/exist/xquery/Intersect.java</include>
                                 <include>src/test/java/org/exist/xquery/LexerTest.java</include>
                                 <include>src/main/java/org/exist/xquery/LocationStep.java</include>
                                 <include>src/main/java/org/exist/xquery/Module.java</include>
@@ -2003,6 +2005,7 @@
                                 <exclude>src/test/java/org/exist/xquery/EmbeddedBinariesTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/EmbeddedBinariesTest.java.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/ErrorCodes.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/Except.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/ExternalModuleImpl.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/ForwardReferenceTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/Function.java</exclude>
@@ -2010,6 +2013,7 @@
                                 <exclude>src/test/resources-filtered/org/exist/xquery/import-from-pkg-test.conf.xml</exclude>
                                 <exclude>src/test/java/org/exist/xquery/ImportFromPkgTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/ImportModuleTest.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/Intersect.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/JavaBinding.java</exclude>
                                 <exclude>src/test/resources-filtered/org/exist/xquery/JavaBindingTest.conf.xml</exclude>
                                 <exclude>src/test/java/org/exist/xquery/JavaBindingTest.java</exclude>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -918,6 +918,7 @@
                                 <include>src/main/java/org/exist/dom/persistent/DocumentSet.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/DocumentTypeImpl.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/ElementImpl.java</include>
+                                <include>src/main/java/org/exist/dom/persistent/EmptyNodeSet.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/LockToken.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/NodeProxy.java</include>
@@ -1626,6 +1627,7 @@
                                 <exclude>src/main/java/org/exist/dom/persistent/DocumentSet.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/DocumentTypeImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/ElementImpl.java</exclude>
+                                <exclude>src/main/java/org/exist/dom/persistent/EmptyNodeSet.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/LockToken.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/NodeProxy.java</exclude>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1442,6 +1442,7 @@
                                 <include>src/main/java/org/exist/xquery/value/GYearMonthValue.java</include>
                                 <include>src/main/java/org/exist/xquery/value/GYearValue.java</include>
                                 <include>src/main/java/org/exist/xquery/value/IntegerValue.java</include>
+                                <include>src/main/java/org/exist/xquery/value/MemoryNodeSet.java</include>
                                 <include>src/main/java/org/exist/xquery/value/QNameValue.java</include>
                                 <include>src/main/java/org/exist/xquery/value/SequenceType.java</include>
                                 <include>src/main/java/org/exist/xquery/value/StringValue.java</include>
@@ -2271,6 +2272,7 @@
                                 <exclude>src/main/java/org/exist/xquery/value/GYearValue.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/IntegerValue.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/ItemComparator.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/value/MemoryNodeSet.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/QNameValue.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/SequenceComparator.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/SequenceType.java</exclude>

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -3083,7 +3083,12 @@ throws PermissionDeniedException, EXistException, XPathException
                         final LocationStep dsStep = new LocationStep(context, Constants.DESCENDANT_SELF_AXIS, new AnyNodeTest());
                         path.insertBeforeLast(dsStep);
                     } else {
-                        rightStep.setPrimaryAxis(Constants.DESCENDANT_SELF_AXIS);
+                        if (rightStep.getPrimaryAxis() == Constants.ATTRIBUTE_AXIS) {
+                            rightStep.setPrimaryAxis(Constants.DESCENDANT_ATTRIBUTE_AXIS);
+                        } else {
+                            rightStep.setPrimaryAxis(Constants.DESCENDANT_SELF_AXIS);
+                        }
+
                         if(rightStep instanceof VariableReference) {
                             // VariableReference needs special handling
                             rightStep = new SimpleStep(context, Constants.DESCENDANT_SELF_AXIS, rightStep);

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -3065,19 +3065,33 @@ throws PermissionDeniedException, EXistException, XPathException
                         rs.setAxis(Constants.DESCENDANT_AXIS);
                     } else if (rs.getAxis() == Constants.SELF_AXIS) {
                         rs.setAxis(Constants.DESCENDANT_SELF_AXIS);
-                    } else {
+                    } else if (rs.getAxis() == Constants.CHILD_AXIS || rs.getAxis() == Constants.UNKNOWN_AXIS) {
+                        // For CHILD_AXIS or UNKNOWN_AXIS, change to descendant-or-self
                         rs.setAxis(Constants.DESCENDANT_SELF_AXIS);
                         rs.setAbbreviated(true);
+                    } else {
+                        // For other explicit axes (following, preceding, ancestor, etc.)
+                        // insert a separate descendant-or-self::node() step before this step
+                        final LocationStep dsStep = new LocationStep(context, Constants.DESCENDANT_SELF_AXIS, new AnyNodeTest());
+                        path.insertBeforeLast(dsStep);
                     }
 
                 } else {
-                    rightStep.setPrimaryAxis(Constants.DESCENDANT_SELF_AXIS);
-                    if(rightStep instanceof VariableReference) {
-                        rightStep = new SimpleStep(context, Constants.DESCENDANT_SELF_AXIS, rightStep);
-                        path.replaceLastExpression(rightStep);
-                    } else if (rightStep instanceof FilteredExpression)
-                        ((FilteredExpression)rightStep).setAbbreviated(true);
-
+                    if (rightStep instanceof Function) {
+                        // For non-LocationStep expressions (function calls, etc.)
+                        // insert a separate descendant-or-self::node() step before this step
+                        final LocationStep dsStep = new LocationStep(context, Constants.DESCENDANT_SELF_AXIS, new AnyNodeTest());
+                        path.insertBeforeLast(dsStep);
+                    } else {
+                        rightStep.setPrimaryAxis(Constants.DESCENDANT_SELF_AXIS);
+                        if(rightStep instanceof VariableReference) {
+                            // VariableReference needs special handling
+                            rightStep = new SimpleStep(context, Constants.DESCENDANT_SELF_AXIS, rightStep);
+                            path.replaceLastExpression(rightStep);
+                        } else if (rightStep instanceof FilteredExpression) {
+                            ((FilteredExpression)rightStep).setAbbreviated(true);
+                        }
+                    }
                 }
             }
         )?

--- a/exist-core/src/main/java/org/exist/dom/persistent/EmptyNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/EmptyNodeSet.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -67,10 +91,12 @@ public final class EmptyNodeSet extends AbstractNodeSet {
 
     @Override
     public void add(final NodeProxy proxy) {
+        throw new IllegalStateException("Cannot add a NodeProxy to an EmptyNodeSet because it is immutable");
     }
 
     @Override
     public void addAll(final NodeSet other) {
+        throw new IllegalStateException("Cannot add a NodeSet to an EmptyNodeSet because it is immutable");
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/numbering/DLNBase.java
+++ b/exist-core/src/main/java/org/exist/numbering/DLNBase.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -494,7 +518,14 @@ public class DLNBase {
         return Arrays.equals(bits, other.bits);
     }
 
-//    public int compareTo(final DLNBase other) {
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(bits);
+        result = 31 * result + bitIndex;
+        return result;
+    }
+
+    //    public int compareTo(final DLNBase other) {
 //        if (other == null)
 //            return 1;
 //        final int a1len = bits.length;

--- a/exist-core/src/main/java/org/exist/xquery/Except.java
+++ b/exist-core/src/main/java/org/exist/xquery/Except.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -22,14 +46,11 @@
 package org.exist.xquery;
 
 import java.util.Set;
-import java.util.TreeSet;
 
-import org.exist.xquery.value.Item;
-import org.exist.xquery.value.ItemComparator;
-import org.exist.xquery.value.Sequence;
-import org.exist.xquery.value.SequenceIterator;
-import org.exist.xquery.value.Type;
-import org.exist.xquery.value.ValueSequence;
+import it.unimi.dsi.fastutil.objects.ObjectAVLTreeSet;
+import org.exist.xquery.value.*;
+
+import javax.annotation.Nullable;
 
 /**
  * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
@@ -57,18 +78,29 @@ public class Except extends CombiningExpression {
             if (ls.isPersistentSet() && rs.isPersistentSet()) {
                 result = ls.toNodeSet().except(rs.toNodeSet());
             } else {
-                result = new ValueSequence();
-                final Set<Item> set = new TreeSet<>(new ItemComparator());
+                @Nullable Sequence values = null;
+                @Nullable Set<Item> set = null;
                 for (final SequenceIterator i = rs.unorderedIterator(); i.hasNext(); ) {
+                    if (set == null) {
+                        set = new ObjectAVLTreeSet<>(new ItemComparator(null));
+                    }
                     set.add(i.nextItem());
                 }
                 for (final SequenceIterator i = ls.unorderedIterator(); i.hasNext(); ) {
                     final Item next = i.nextItem();
-                    if (!set.contains(next)) {
-                        result.add(next);
+                    if (set == null || !set.contains(next)) {
+                        if (values == null) {
+                            values = new ValueSequence();
+                        }
+                        values.add(next);
                     }
                 }
-                result.removeDuplicates();
+                if (values != null) {
+                    values.removeDuplicates();
+                    result = values;
+                } else {
+                    result = Sequence.EMPTY_SEQUENCE;
+                }
             }
         }
 

--- a/exist-core/src/main/java/org/exist/xquery/Except.java
+++ b/exist-core/src/main/java/org/exist/xquery/Except.java
@@ -82,7 +82,7 @@ public class Except extends CombiningExpression {
                 @Nullable Set<Item> set = null;
                 for (final SequenceIterator i = rs.unorderedIterator(); i.hasNext(); ) {
                     if (set == null) {
-                        set = new ObjectAVLTreeSet<>(new ItemComparator(null));
+                        set = new ObjectAVLTreeSet<>(ItemComparator.WITHOUT_COLLATOR);
                     }
                     set.add(i.nextItem());
                 }

--- a/exist-core/src/main/java/org/exist/xquery/Intersect.java
+++ b/exist-core/src/main/java/org/exist/xquery/Intersect.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -21,10 +45,11 @@
  */
 package org.exist.xquery;
 
+import it.unimi.dsi.fastutil.objects.ObjectAVLTreeSet;
 import org.exist.xquery.value.*;
 
+import javax.annotation.Nullable;
 import java.util.Set;
-import java.util.TreeSet;
 
 /**
  * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
@@ -47,18 +72,29 @@ public class Intersect extends CombiningExpression {
             if (ls.isPersistentSet() && rs.isPersistentSet()) {
                 result = ls.toNodeSet().intersection(rs.toNodeSet());
             } else {
-                result = new ValueSequence(true);
-                final Set<Item> set = new TreeSet<>(new ItemComparator());
+                @Nullable Sequence values = null;
+                @Nullable Set<Item> set = null;
                 for (final SequenceIterator i = ls.unorderedIterator(); i.hasNext(); ) {
+                    if (set == null) {
+                        set = new ObjectAVLTreeSet<>(new ItemComparator(null));
+                    }
                     set.add(i.nextItem());
                 }
                 for (final SequenceIterator i = rs.unorderedIterator(); i.hasNext(); ) {
                     final Item next = i.nextItem();
-                    if (set.contains(next)) {
-                        result.add(next);
+                    if (set != null && set.contains(next)) {
+                        if (values == null) {
+                            values = new ValueSequence(true);
+                        }
+                        values.add(next);
                     }
                 }
-                result.removeDuplicates();
+                if (values != null) {
+                    values.removeDuplicates();
+                    result = values;
+                } else {
+                    result = Sequence.EMPTY_SEQUENCE;
+                }
             }
         }
 

--- a/exist-core/src/main/java/org/exist/xquery/Intersect.java
+++ b/exist-core/src/main/java/org/exist/xquery/Intersect.java
@@ -76,7 +76,7 @@ public class Intersect extends CombiningExpression {
                 @Nullable Set<Item> set = null;
                 for (final SequenceIterator i = ls.unorderedIterator(); i.hasNext(); ) {
                     if (set == null) {
-                        set = new ObjectAVLTreeSet<>(new ItemComparator(null));
+                        set = new ObjectAVLTreeSet<>(ItemComparator.WITHOUT_COLLATOR);
                     }
                     set.add(i.nextItem());
                 }

--- a/exist-core/src/main/java/org/exist/xquery/PathExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/PathExpr.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -496,6 +520,16 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
             return;
         }
         steps.set(steps.size() - 1, s);
+    }
+
+    /**
+     * Insert an expression before the last expression in the path.
+     *
+     * @param expression the expression to insert
+     */
+    public void insertBeforeLast(final Expression expression) {
+        final int idx = steps.isEmpty() ? 0 : steps.size() - 1;
+        steps.add(idx, expression);
     }
 
     public String getLiteralValue() {

--- a/exist-core/src/main/java/org/exist/xquery/Union.java
+++ b/exist-core/src/main/java/org/exist/xquery/Union.java
@@ -59,7 +59,6 @@ public class Union extends CombiningExpression {
                 final ValueSequence values = new ValueSequence(true);
                 values.addAll(ls);
                 values.addAll(rs);
-                values.sortInDocumentOrder();
                 values.removeDuplicates();
                 result = values;
             }

--- a/exist-core/src/main/java/org/exist/xquery/value/ArrayListValueSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/ArrayListValueSequence.java
@@ -266,7 +266,7 @@ public class ArrayListValueSequence extends AbstractSequence implements MemoryNo
         final List<Item> newValues = new ArrayList<>(values.size());
         int newType = Type.ANY_TYPE;
 
-        final ItemComparator itemComparator = new ItemComparator();
+        final ItemComparator itemComparator = ItemComparator.WITHOUT_COLLATOR;
 
         for (int i = 0; i < values.size(); i++) {
             final Item value = values.get(i);

--- a/exist-core/src/main/java/org/exist/xquery/value/AtomicValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/AtomicValue.java
@@ -230,14 +230,14 @@ public abstract class AtomicValue implements Item, Sequence, Indexable {
 		if (!effectiveBooleanValue())
 			return NodeSet.EMPTY_SET;
 		*/
-        throw new XPathException(getExpression(), 
+        throw new XPathException(getExpression(), ErrorCodes.W3CErrorCode.XPTY0019.getErrorCode(),
                 "cannot convert " + Type.getTypeName(getType()) + "('" + getStringValue() + "')"
                         + " to a node set");
     }
 
     @Override
     public MemoryNodeSet toMemNodeSet() throws XPathException {
-        throw new XPathException(getExpression(), 
+        throw new XPathException(getExpression(), ErrorCodes.W3CErrorCode.XPTY0019.getErrorCode(),
                 "cannot convert " + Type.getTypeName(getType()) + "('" + getStringValue() + "')"
                         + " to a node set");
     }

--- a/exist-core/src/main/java/org/exist/xquery/value/AtomicValueComparator.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/AtomicValueComparator.java
@@ -48,11 +48,13 @@ import java.util.Comparator;
 @ThreadSafe
 public class AtomicValueComparator implements Comparator<AtomicValue> {
 
-    protected static final Logger LOG = LogManager.getLogger(RESTServer.class);
+    protected static final Logger LOG = LogManager.getLogger(AtomicValueComparator.class);
+
+    public static AtomicValueComparator WITHOUT_COLLATOR = new AtomicValueComparator();
 
     private final @Nullable Collator collator;
 
-    public AtomicValueComparator() {
+    private AtomicValueComparator() {
         this(null);
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/value/ItemComparator.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/ItemComparator.java
@@ -56,6 +56,8 @@ public class ItemComparator implements Comparator<Item> {
     @Nullable private final Collator collator;
     @Nullable private AtomicValueComparator atomicValueComparator = null;
 
+    public static ItemComparator WITHOUT_COLLATOR = new ItemComparator();
+
     public ItemComparator() {
         this(null);
     }
@@ -70,7 +72,11 @@ public class ItemComparator implements Comparator<Item> {
             return Constants.INFERIOR;
         } else if (n1 instanceof AtomicValue && n2 instanceof AtomicValue) {
             if (atomicValueComparator == null) {
-                atomicValueComparator = new AtomicValueComparator(collator);
+                if (collator == null) {
+                    atomicValueComparator = AtomicValueComparator.WITHOUT_COLLATOR;
+                } else {
+                    atomicValueComparator = new AtomicValueComparator(collator);
+                }
             }
             return atomicValueComparator.compare((AtomicValue)n1, (AtomicValue)n2);
         } else if (n1 instanceof Comparable) {

--- a/exist-core/src/main/java/org/exist/xquery/value/MemoryNodeSet.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/MemoryNodeSet.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -28,7 +52,7 @@ import org.exist.xquery.XPathException;
 
 public interface MemoryNodeSet extends Sequence {
 
-    MemoryNodeSet EMPTY = new ValueSequence(1);
+    MemoryNodeSet EMPTY = new ValueSequence(0);
 
     Sequence getAttributes(NodeTest test) throws XPathException;
 

--- a/exist-core/src/main/java/org/exist/xquery/value/SequenceComparator.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/SequenceComparator.java
@@ -83,7 +83,11 @@ public class SequenceComparator implements Comparator<Sequence> {
 
         for (int i = 0; i < o1Count; i++) {
             if (itemComparator == null) {
-                itemComparator = new ItemComparator(collator);
+                if (collator == null) {
+                    itemComparator = ItemComparator.WITHOUT_COLLATOR;
+                } else {
+                    itemComparator = new ItemComparator(collator);
+                }
             }
 
             final Item i1 = o1.itemAt(i);

--- a/exist-core/src/main/java/org/exist/xquery/value/ValueSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/ValueSequence.java
@@ -499,7 +499,7 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
             if (!hasNodes) {
                 return;
             }
-            final Map<Item, Item> nodes = new TreeMap<>(new ItemComparator());
+            final Map<Item, Item> nodes = new TreeMap<>(ItemComparator.WITHOUT_COLLATOR);
             int j = 0;
             for (int i = 0; i <= size; i++) {
                 if (Type.subTypeOf(values[i].getType(), Type.NODE)) {

--- a/exist-core/src/main/java/org/exist/xquery/value/ValueSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/ValueSequence.java
@@ -433,9 +433,11 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
 
     @Override
     public void removeDuplicates() {
-        enforceOrder = true;
-        isOrdered = false;
+        final boolean prevEnforceOrder = this.enforceOrder;
+        this.enforceOrder = true;
+        this.isOrdered = false;
         sortInDocumentOrder();
+        this.enforceOrder = prevEnforceOrder;
     }
 
     private void ensureCapacity() {

--- a/exist-core/src/main/java/org/exist/xquery/value/ValueSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/ValueSequence.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -454,15 +478,13 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
             return;
         }
         if (inMemNodeSet) {
-            int j = 0;
+            int writeIdx = 1;
             for (int i = 1; i <= size; i++) {
-                if (!values[i].equals(values[j])) {
-                    if (i != ++j) {
-                        values[j] = values[i];
-                    }
+                if (!values[i].equals(values[i - 1])) {
+                    values[writeIdx++] = values[i];
                 }
             }
-            size = j;
+            size = writeIdx - 1;
         } else {
             if (itemType != Type.ANY_TYPE && Type.subTypeOf(itemType, Type.ANY_ATOMIC_TYPE)) {
                 return;

--- a/exist-core/src/main/java/org/exist/xquery/value/ValueSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/ValueSequence.java
@@ -46,6 +46,8 @@
 package org.exist.xquery.value;
 
 import com.evolvedbinary.j8fu.function.FunctionE;
+import it.unimi.dsi.fastutil.objects.Object2ObjectRBTreeMap;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.collections.Collection;
@@ -261,9 +263,10 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
         if (size == UNSET_SIZE) {
             return NodeSet.EMPTY_SET;
         }
+
         // for this method to work, all items have to be nodes
         if (itemType != Type.ANY_TYPE && Type.subTypeOf(itemType, Type.NODE)) {
-            final NodeSet set = new NewArrayNodeSet();
+            @Nullable NodeSet set = null;
             for (int i = 0; i <= size; i++) {
                 NodeValue v = (NodeValue) values[i];
                 if (v.getImplementationType() != NodeValue.PERSISTENT_NODE) {
@@ -318,16 +321,29 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
                                 }
                             }
                         }
+                        if (set == null) {
+                            set = new NewArrayNodeSet(size + 1 - i);
+                        }
                         set.add((NodeProxy) values[i]);
                     }
                 } else {
+                    if (set == null) {
+                        set = new NewArrayNodeSet(size + 1 - i);
+                    }
                     set.add((NodeProxy) v);
                 }
             }
+
+            if (set == null) {
+                set = NodeSet.EMPTY_SET;
+            }
+
             if (holderVar != null) {
                 holderVar.setValue(set);
             }
+
             return set;
+
         } else {
             throw new XPathException((Expression) null, "Type error: the sequence cannot be converted into" +
                     " a node set. Item type is " + Type.getTypeName(itemType));
@@ -339,10 +355,12 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
         if (size == UNSET_SIZE) {
             return MemoryNodeSet.EMPTY;
         }
+
         if (itemType == Type.ANY_TYPE || !Type.subTypeOf(itemType, Type.NODE)) {
             throw new XPathException((Expression) null, "Type error: the sequence cannot be converted into" +
                     " a node set. Item type is " + Type.getTypeName(itemType));
         }
+
         for (int i = 0; i <= size; i++) {
             final NodeValue v = (NodeValue) values[i];
             if (v.getImplementationType() == NodeValue.PERSISTENT_NODE) {
@@ -350,6 +368,7 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
                         " a MemoryNodeSet. It contains nodes from stored resources.");
             }
         }
+
         expand();
         inMemNodeSet = true;
         return this;
@@ -359,15 +378,18 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
         if (size == UNSET_SIZE) {
             return true;
         }
+
         if (itemType == Type.ANY_TYPE || !Type.subTypeOf(itemType, Type.NODE)) {
             return false;
         }
+
         for (int i = 0; i <= size; i++) {
             final NodeValue v = (NodeValue) values[i];
             if (v.getImplementationType() == NodeValue.PERSISTENT_NODE) {
                 return false;
             }
         }
+
         return true;
     }
 
@@ -376,6 +398,7 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
         if (size == UNSET_SIZE) {
             return true;
         }
+
         if (itemType != Type.ANY_TYPE && Type.subTypeOf(itemType, Type.NODE)) {
             for (int i = 0; i <= size; i++) {
                 final NodeValue v = (NodeValue) values[i];
@@ -385,6 +408,7 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
             }
             return true;
         }
+
         return false;
     }
 
@@ -394,17 +418,23 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
      * Expand those references to get a pure in-memory DOM tree.
      */
     private void expand() {
-        final Set<DocumentImpl> docs = new HashSet<>();
+        @Nullable Set<DocumentImpl> docs = null;
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
             final DocumentImpl ownerDoc = node.getNodeType() == Node.DOCUMENT_NODE ? (DocumentImpl) node : node.getOwnerDocument();
 
             if (ownerDoc.hasReferenceNodes()) {
+                if (docs == null) {
+                    docs = new ObjectOpenHashSet<>(size + 1 - i);
+                }
                 docs.add(ownerDoc);
             }
         }
-        for (final DocumentImpl doc : docs) {
-            doc.expand();
+
+        if (docs != null) {
+            for (final DocumentImpl doc : docs) {
+                doc.expand();
+            }
         }
     }
 
@@ -440,17 +470,21 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
         if (size == UNSET_SIZE) {
             return;
         }
+
         if (keepUnOrdered) {
             removeDuplicateNodes();
             return;
         }
+
         if (!enforceOrder || isOrdered) {
             return;
         }
+
         inMemNodeSet = inMemNodeSet || isInMemorySet();
         if (inMemNodeSet) {
             FastQSort.sort(values, new InMemoryNodeComparator(), 0, size);
         }
+
         removeDuplicateNodes();
         isOrdered = true;
     }
@@ -477,6 +511,7 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
         if (noDuplicates || size < 1) {
             return;
         }
+
         if (inMemNodeSet) {
             int writeIdx = 1;
             for (int i = 1; i <= size; i++) {
@@ -485,10 +520,12 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
                 }
             }
             size = writeIdx - 1;
+
         } else {
             if (itemType != Type.ANY_TYPE && Type.subTypeOf(itemType, Type.ANY_ATOMIC_TYPE)) {
                 return;
             }
+
             // check if the sequence contains nodes
             boolean hasNodes = false;
             for (int i = 0; i <= size; i++) {
@@ -496,17 +533,22 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
                     hasNodes = true;
                 }
             }
+
             if (!hasNodes) {
                 return;
             }
-            final Map<Item, Item> nodes = new TreeMap<>(ItemComparator.WITHOUT_COLLATOR);
+
+            @Nullable Map<Item, Item> nodes = null;
             int j = 0;
             for (int i = 0; i <= size; i++) {
                 if (Type.subTypeOf(values[i].getType(), Type.NODE)) {
-                    final Item found = nodes.get(values[i]);
+                    @Nullable final Item found = nodes != null ? nodes.get(values[i]) : null;
                     if (found == null) {
                         final Item item = values[i];
                         values[j++] = item;
+                        if (nodes == null) {
+                            nodes = new Object2ObjectRBTreeMap<>(ItemComparator.WITHOUT_COLLATOR);
+                        }
                         nodes.put(item, item);
                     } else {
                         final NodeValue nv = (NodeValue) found;
@@ -539,7 +581,11 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
     }
 
     private void setHasChanged() {
-        state = (state == Integer.MAX_VALUE ? state = 0 : state + 1);
+        if (state == Integer.MAX_VALUE) {
+            state = 0;
+        } else {
+            state++;
+        }
     }
 
     @Override
@@ -562,6 +608,7 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
         if (cachedSet != null) {
             return cachedSet.getDocumentSet();
         }
+
         try {
             boolean isPersistentSet = true;
             for (int i = 0; i <= size; i++) {
@@ -582,19 +629,28 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
             }
         } catch (final XPathException e) {
         }
+
         return extractDocumentSet();
     }
 
     private DocumentSet extractDocumentSet() {
-        final MutableDocumentSet docs = new DefaultDocumentSet();
+        @Nullable MutableDocumentSet docs = null;
         for (int i = 0; i <= size; i++) {
             if (Type.subTypeOf(values[i].getType(), Type.NODE)) {
                 final NodeValue node = (NodeValue) values[i];
                 if (node.getImplementationType() == NodeValue.PERSISTENT_NODE) {
+                    if (docs == null) {
+                        docs = new DefaultDocumentSet(size + 1 - i);
+                    }
                     docs.add((org.exist.dom.persistent.DocumentImpl) node.getOwnerDocument());
                 }
             }
         }
+
+        if (docs == null) {
+            return new DefaultDocumentSet(0);
+        }
+
         return docs;
     }
 
@@ -602,193 +658,310 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
     @Override
     public Sequence getAttributes(final NodeTest test) throws XPathException {
         sortInDocumentOrder();
-        final ValueSequence nodes = new ValueSequence(true);
-        nodes.keepUnOrdered(keepUnOrdered);
+        @Nullable ValueSequence attributes = null;
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
-            node.selectAttributes(test, nodes);
+            if (attributes == null) {
+                attributes = new ValueSequence(true);
+                attributes.keepUnOrdered(keepUnOrdered);
+            }
+            node.selectAttributes(test, attributes);
         }
-        return nodes;
+
+        if (attributes == null) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
+        return attributes;
     }
 
     @Override
     public Sequence getDescendantAttributes(final NodeTest test) throws XPathException {
         sortInDocumentOrder();
-        final ValueSequence nodes = new ValueSequence(true);
-        nodes.keepUnOrdered(keepUnOrdered);
+        @Nullable ValueSequence attributes = null;
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
-            node.selectDescendantAttributes(test, nodes);
+            if (attributes == null) {
+                attributes = new ValueSequence(true);
+                attributes.keepUnOrdered(keepUnOrdered);
+            }
+            node.selectDescendantAttributes(test, attributes);
         }
-        return nodes;
+
+        if (attributes == null) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
+        return attributes;
     }
 
     @Override
     public Sequence getChildren(final NodeTest test) throws XPathException {
         sortInDocumentOrder();
-        final ValueSequence nodes = new ValueSequence(true);
-        nodes.keepUnOrdered(keepUnOrdered);
+        @Nullable ValueSequence children = null;
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
-            node.selectChildren(test, nodes);
+            if (children == null) {
+                children = new ValueSequence(true);
+                children.keepUnOrdered(keepUnOrdered);
+            }
+            node.selectChildren(test, children);
         }
-        return nodes;
+
+        if (children == null) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
+        return children;
     }
 
     @Override
     public Sequence getChildrenForParent(final NodeImpl parent) {
         sortInDocumentOrder();
-        final ValueSequence nodes = new ValueSequence(true);
-        nodes.keepUnOrdered(keepUnOrdered);
+        @Nullable ValueSequence children = null;
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
             if (node.getNodeId().isChildOf(parent.getNodeId())) {
-                nodes.add(node);
+                if (children == null) {
+                    children = new ValueSequence(true);
+                    children.keepUnOrdered(keepUnOrdered);
+                }
+                children.add(node);
             }
         }
-        return nodes;
+
+        if (children == null) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
+        return children;
     }
 
     @Override
     public Sequence getDescendants(final boolean includeSelf, final NodeTest test) throws XPathException {
         sortInDocumentOrder();
-        final ValueSequence nodes = new ValueSequence(true);
-        nodes.keepUnOrdered(keepUnOrdered);
+        @Nullable ValueSequence descendants = null;
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
-            node.selectDescendants(includeSelf, test, nodes);
+            if (descendants == null) {
+                descendants = new ValueSequence(true);
+                descendants.keepUnOrdered(keepUnOrdered);
+            }
+            node.selectDescendants(includeSelf, test, descendants);
         }
-        return nodes;
+
+        if (descendants == null) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
+        return descendants;
     }
 
     @Override
     public Sequence getAncestors(final boolean includeSelf, final NodeTest test) throws XPathException {
         sortInDocumentOrder();
-        final ValueSequence nodes = new ValueSequence(true);
-        nodes.keepUnOrdered(keepUnOrdered);
+        @Nullable ValueSequence ancestors = null;
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
-            node.selectAncestors(includeSelf, test, nodes);
+            if (ancestors == null) {
+                ancestors = new ValueSequence(true);
+                ancestors.keepUnOrdered(keepUnOrdered);
+            }
+            node.selectAncestors(includeSelf, test, ancestors);
         }
-        return nodes;
+
+        if (ancestors == null) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
+        return ancestors;
     }
 
     @Override
     public Sequence getParents(final NodeTest test) throws XPathException {
         sortInDocumentOrder();
-        final ValueSequence nodes = new ValueSequence(true);
-        nodes.keepUnOrdered(keepUnOrdered);
+        @Nullable ValueSequence parents = null;
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
-            final NodeImpl parent = (NodeImpl) node.selectParentNode();
+            @Nullable final NodeImpl parent = (NodeImpl) node.selectParentNode();
+
             if (parent != null && test.matches(parent)) {
-                nodes.add(parent);
+                if (parents == null) {
+                    parents = new ValueSequence(size + 1 - i);
+                    parents.setIsOrdered(true);
+                    parents.keepUnOrdered(keepUnOrdered);
+                }
+
+                parents.add(parent);
             }
         }
-        return nodes;
+
+        if (parents == null) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
+        return parents;
     }
 
     @Override
     public Sequence getSelf(final NodeTest test) throws XPathException {
         sortInDocumentOrder();
-        final ValueSequence nodes = new ValueSequence(true);
-        nodes.keepUnOrdered(keepUnOrdered);
+        @Nullable ValueSequence selves = null;
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
             if ((test.getType() == Type.NODE && node.getNodeType() == Node.ATTRIBUTE_NODE) ||
                     test.matches(node)) {
-                nodes.add(node);
+                if (selves == null) {
+                    selves = new ValueSequence(size + 1 - i);
+                    selves.setIsOrdered(true);
+                    selves.keepUnOrdered(keepUnOrdered);
+                }
+                selves.add(node);
             }
         }
-        return nodes;
+
+        if (selves == null) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
+        return selves;
     }
 
     @Override
     public Sequence getPrecedingSiblings(final NodeTest test) throws XPathException {
         sortInDocumentOrder();
-        final ValueSequence nodes = new ValueSequence(true);
-        nodes.keepUnOrdered(keepUnOrdered);
+        @Nullable ValueSequence precedingSiblings = null;
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
 
             // if the context node is an attribute or namespace node, the preceding-sibling axis is empty
             if (node.getNodeType() != Node.ATTRIBUTE_NODE) {
-                node.selectPrecedingSiblings(test, nodes);
+                if (precedingSiblings == null) {
+                    precedingSiblings = new ValueSequence(true);
+                    precedingSiblings.keepUnOrdered(keepUnOrdered);
+                }
+                node.selectPrecedingSiblings(test, precedingSiblings);
             }
         }
-        return nodes;
+
+        if (precedingSiblings == null) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
+        return precedingSiblings;
     }
 
     @Override
     public Sequence getPreceding(final NodeTest test, final int position) throws XPathException {
         sortInDocumentOrder();
-        final ValueSequence nodes = new ValueSequence(true);
-        nodes.keepUnOrdered(keepUnOrdered);
+        @Nullable ValueSequence preceding = null;
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
-            node.selectPreceding(test, nodes, position);
+            if (preceding == null) {
+                preceding = new ValueSequence(true);
+                preceding.keepUnOrdered(keepUnOrdered);
+            }
+            node.selectPreceding(test, preceding, position);
         }
-        return nodes;
+
+        if (preceding == null) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
+        return preceding;
     }
 
     @Override
     public Sequence getFollowingSiblings(final NodeTest test) throws XPathException {
         sortInDocumentOrder();
-        final ValueSequence nodes = new ValueSequence(true);
-        nodes.keepUnOrdered(keepUnOrdered);
+        @Nullable ValueSequence followingSiblings = null;
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
             // if the context node is an attribute or namespace node, the following-sibling axis is empty
             if (node.getNodeType() != Node.ATTRIBUTE_NODE) {
-                node.selectFollowingSiblings(test, nodes);
+                if (followingSiblings == null) {
+                    followingSiblings = new ValueSequence(true);
+                    followingSiblings.keepUnOrdered(keepUnOrdered);
+                }
+                node.selectFollowingSiblings(test, followingSiblings);
             }
         }
-        return nodes;
+
+        if (followingSiblings == null) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
+        return followingSiblings;
     }
 
     @Override
     public Sequence getFollowing(final NodeTest test, final int position) throws XPathException {
         sortInDocumentOrder();
-        final ValueSequence nodes = new ValueSequence(true);
-        nodes.keepUnOrdered(keepUnOrdered);
+        @Nullable ValueSequence following = null;
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
-            node.selectFollowing(test, nodes, position);
+            if (following == null) {
+                following = new ValueSequence(true);
+                following.keepUnOrdered(keepUnOrdered);
+            }
+            node.selectFollowing(test, following, position);
         }
-        return nodes;
+
+        if (following == null) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
+        return following;
     }
 
     @Override
     public Sequence selectDescendants(final MemoryNodeSet descendants) {
         sortInDocumentOrder();
-        final ValueSequence nodes = new ValueSequence(true);
-        nodes.keepUnOrdered(keepUnOrdered);
+        @Nullable ValueSequence nodes = null;
+
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
             for (int j = 0; j < descendants.size(); j++) {
                 final NodeImpl descendant = descendants.get(j);
                 if (descendant.getNodeId().isDescendantOrSelfOf(node.getNodeId())) {
+                    if (nodes == null) {
+                        nodes = new ValueSequence(true);
+                        nodes.keepUnOrdered(keepUnOrdered);
+                    }
                     nodes.add(node);
                 }
             }
         }
+
+        if (nodes == null) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
         return nodes;
     }
 
     @Override
     public Sequence selectChildren(final MemoryNodeSet children) {
         sortInDocumentOrder();
-        final ValueSequence nodes = new ValueSequence(true);
-        nodes.keepUnOrdered(keepUnOrdered);
+        @Nullable ValueSequence nodes = null;
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
             for (int j = 0; j < children.size(); j++) {
                 final NodeImpl descendant = children.get(j);
                 if (descendant.getNodeId().isChildOf(node.getNodeId())) {
+                    if (nodes == null) {
+                        nodes = new ValueSequence(true);
+                        nodes.keepUnOrdered(keepUnOrdered);
+                    }
                     nodes.add(node);
                 }
             }
         }
+
+        if (nodes == null) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
         return nodes;
     }
 
@@ -835,7 +1008,6 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
 
     @Override
     public boolean matchSelf(final NodeTest test) {
-        //UNDERSTAND: is it required? -shabanovd
         sortInDocumentOrder();
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
@@ -849,7 +1021,6 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
 
     @Override
     public boolean matchChildren(final NodeTest test) throws XPathException {
-        //UNDERSTAND: is it required? -shabanovd
         sortInDocumentOrder();
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
@@ -862,7 +1033,6 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
 
     @Override
     public boolean matchAttributes(final NodeTest test) {
-        //UNDERSTAND: is it required? -shabanovd
         sortInDocumentOrder();
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
@@ -875,7 +1045,6 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
 
     @Override
     public boolean matchDescendantAttributes(final NodeTest test) throws XPathException {
-        //UNDERSTAND: is it required? -shabanovd
         sortInDocumentOrder();
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];

--- a/exist-core/src/test/java/org/exist/xquery/XPathQueryTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XPathQueryTest.java
@@ -819,6 +819,54 @@ public class XPathQueryTest {
 
         result = queryResource(service, "siblings.xml", "//a/s[. = 'B']/following::s[2]", 1);
         assertThat(result.getResource(0).getContent().toString(), CompareMatcher.isIdenticalTo("<s>C</s>"));
+
+        String query = "declare variable $i := \n" +
+            "  <root>\n" +
+            "     <child/>\n" +
+            "     <child/>\n" +
+            "     <child>\n" +
+            "        <child2>\n" +
+            "           <child3>\n" +
+            "              <leaf/>\n" +
+            "           </child3>\n" +
+            "        </child2>\n" +
+            "     </child>\n" +
+            "  </root>;\n" +
+            "\n" +
+            "root($i)//following::node()";
+
+        result = service.query(query);
+        assertEquals(5, result.getSize());
+        assertThat(result.getResource(0).getContent().toString(), CompareMatcher.isIdenticalTo("<child/>"));
+        assertThat(result.getResource(1).getContent().toString(), CompareMatcher.isIdenticalTo("<child><child2><child3><leaf/></child3></child2></child>"));
+        assertThat(result.getResource(2).getContent().toString(), CompareMatcher.isIdenticalTo("<child2><child3><leaf/></child3></child2>"));
+        assertThat(result.getResource(3).getContent().toString(), CompareMatcher.isIdenticalTo("<child3><leaf/></child3>"));
+        assertThat(result.getResource(4).getContent().toString(), CompareMatcher.isIdenticalTo("<leaf/>"));
+
+        query = "declare variable $i := \n" +
+            "  <root>\n" +
+            "     <child/>\n" +
+            "     <child/>\n" +
+            "     <child>\n" +
+            "        <child2>\n" +
+            "           <child3>\n" +
+            "              <leaf/>\n" +
+            "           </child3>\n" +
+            "        </child2>\n" +
+            "     </child>\n" +
+            "  </root>;\n" +
+            "\n" +
+            "root($i)//count(following::node())";
+
+        result = service.query(query);
+        assertEquals(7, result.getSize());
+        assertEquals("0", result.getResource(0).getContent());
+        assertEquals("5", result.getResource(1).getContent());
+        assertEquals("4", result.getResource(2).getContent());
+        assertEquals("0", result.getResource(3).getContent());
+        assertEquals("0", result.getResource(4).getContent());
+        assertEquals("0", result.getResource(5).getContent());
+        assertEquals("0", result.getResource(6).getContent());
     }
 
     @Test

--- a/exist-core/src/test/java/org/exist/xquery/XPathQueryTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XPathQueryTest.java
@@ -1099,11 +1099,17 @@ public class XPathQueryTest {
         service.setProperty(OutputKeys.INDENT, "no");
 
 
-        String query = "let $t := <test>" + "<a> <s>A</s> 1 </a>"
-                + "<a> <s>Z</s> 2 </a>" + "<a> <s>B</s> 3 </a>"
-                + "<a> <s>Z</s> 4 </a>" + "<a> <s>C</s> 5 </a>"
-                + "<a> <s>Z</s> 6 </a>" + "</test>"
-                + "return $t//a[s='Z' and preceding-sibling::*[1]/s='B']";
+        String query = "let $t := " +
+            "<test>" +
+            "<a> <s>A</s> 1 </a>" +
+            "<a> <s>Z</s> 2 </a>" +
+            "<a> <s>B</s> 3 </a>" +
+            "<a> <s>Z</s> 4 </a>" +
+            "<a> <s>C</s> 5 </a>" +
+            "<a> <s>Z</s> 6 </a>" +
+            "</test>" +
+            "return " +
+            "$t//a[s = 'Z' and preceding-sibling::*[1]/s = 'B']";
         ResourceSet result = queryResource(service, "numbers.xml", query, 1);
         assertThat(result.getResource(0).getContent().toString(), CompareMatcher.isIdenticalTo("<a><s>Z</s> 4 </a>"));
 

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/FunLangTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/FunLangTest.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -43,57 +67,57 @@ public class FunLangTest {
 
     @Test
     public void testFnLangWithContext() throws XMLDBException {
-        final ResourceSet resourceSet = existEmbeddedServer.executeQuery(
-            "let $doc-frag := " +
-	    "<desclist xml:lang=\"en\">" +
-	       "<desc xml:lang=\"en-US\" n=\"1\">" +
-	          "<line>The first line of the description.</line>" +
-	       "</desc>" +
-	       "<desc xml:lang=\"fr\" n=\"2\">"+
-	          "<line>La premi&#232;re ligne de la déscription.</line>" +
-	       "</desc>" +
-	    "</desclist>" + 
-            "return $doc-frag//desc[lang(\"en-US\")]"
-        );
-        
+		final String query =
+			"let $doc-frag := " +
+			"<desclist xml:lang=\"en\">" +
+			"<desc xml:lang=\"en-US\" n=\"1\">" +
+			"<line>The first line of the description.</line>" +
+			"</desc>" +
+			"<desc xml:lang=\"fr\" n=\"2\">"+
+			"<line>La premi&#232;re ligne de la déscription.</line>" +
+			"</desc>" +
+			"</desclist>" +
+			"return " +
+			"$doc-frag//desc[lang(\"en-US\")]";
+        final ResourceSet resourceSet = existEmbeddedServer.executeQuery(query);
         assertEquals(1, resourceSet.getSize());
         assertEquals("<desc xml:lang=\"en-US\" n=\"1\">\n    <line>The first line of the description.</line>\n</desc>", resourceSet.getResource(0).getContent());
     }
 
-        @Test
+	@Test
     public void testFnLangWithArgument() throws XMLDBException {
-		final ResourceSet resourceSet = existEmbeddedServer.executeQuery(
-            "let $doc-frag := " +
-	    "<desclist xml:lang=\"en\">" +
-	       "<desc xml:lang=\"en-US\" n=\"1\">" +
-	          "<line>The first line of the description.</line>" +
-	       "</desc>" +
-	       "<desc xml:lang=\"fr\" n=\"2\">"+
-	          "<line>La premi&#232;re ligne de la déscription.</line>" +
-	       "</desc>" +
-	    "</desclist>" + 
-            "return lang(\"en-US\", $doc-frag//desc[@n eq \"2\"])"
-        );
-        
+		final String query =
+			"let $doc-frag := " +
+			"<desclist xml:lang=\"en\">" +
+			"<desc xml:lang=\"en-US\" n=\"1\">" +
+			"<line>The first line of the description.</line>" +
+			"</desc>" +
+			"<desc xml:lang=\"fr\" n=\"2\">"+
+			"<line>La premi&#232;re ligne de la déscription.</line>" +
+			"</desc>" +
+			"</desclist>" +
+			"return " +
+			"lang(\"en-US\", $doc-frag//desc[@n eq \"2\"])";
+		final ResourceSet resourceSet = existEmbeddedServer.executeQuery(query);
         assertEquals(1, resourceSet.getSize());
         assertEquals("false", resourceSet.getResource(0).getContent());
     }
     
     @Test
     public void testFnLangWithAttributeArgument() throws XMLDBException {
-		final ResourceSet resourceSet = existEmbeddedServer.executeQuery(
-            "let $doc-frag := " +
-	    "<desclist xml:lang=\"en\">" +
-	       "<desc xml:lang=\"en-US\" n=\"1\">" +
-	          "<line>The first line of the description.</line>" +
-	       "</desc>" +
-	       "<desc xml:lang=\"fr\" n=\"2\">"+
-	          "<line>La premi&#232;re ligne de la déscription.</line>" +
-	       "</desc>" +
-	    "</desclist>" + 
-            "return lang(\"en-US\", $doc-frag//desc/@n[. eq \"1\"])"
-        );
-        
+		final String query =
+			"let $doc-frag := " +
+			"<desclist xml:lang=\"en\">" +
+			"<desc xml:lang=\"en-US\" n=\"1\">" +
+			"<line>The first line of the description.</line>" +
+			"</desc>" +
+			"<desc xml:lang=\"fr\" n=\"2\">"+
+			"<line>La premi&#232;re ligne de la déscription.</line>" +
+			"</desc>" +
+			"</desclist>" +
+			"return " +
+			"lang(\"en-US\", $doc-frag//desc/@n[. eq \"1\"])";
+		final ResourceSet resourceSet = existEmbeddedServer.executeQuery(query);
         assertEquals(1, resourceSet.getSize());
         assertEquals("true", resourceSet.getResource(0).getContent());
     }

--- a/exist-core/src/test/xquery/parenthesizedLocationStep.xml
+++ b/exist-core/src/test/xquery/parenthesizedLocationStep.xml
@@ -1,5 +1,29 @@
 <!--
 
+    Elemental
+    Copyright (C) 2024, Evolved Binary Ltd
+
+    admin@evolvedbinary.com
+    https://www.evolvedbinary.com | https://www.elemental.xyz
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; version 2.1.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+    NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+          The original license header is included below.
+
+    =====================================================================
+
     eXist-db Open Source Native XML Database
     Copyright (C) 2001 The eXist-db Authors
 
@@ -106,7 +130,7 @@
             ]]></code>
         <expected>test</expected>
     </test>
-    <test output="text" ignore="yes">
+    <test output="text">
         <task>[retrieval, qname] descendant step with parenthesized attribute node</task>
         <code><![CDATA[
             collection('/db/coll')//test/qname//(@att.qname)/string()
@@ -120,24 +144,13 @@
             ]]></code>
         <expected>test</expected>
     </test>
-    <test output="text" ignore="yes">
+    <test output="text">
         <task>[retrieval, path] descendant step with parenthesized attribute node</task>
         <code><![CDATA[
             collection('/db/coll')//test/path//(@att.path)/string()
             ]]></code>
         <expected>test</expected>
-    </test>    
-    <test output="xml" ignore="yes">
-        <task>[query, old FT index, qname, indirect] parenthesized element node</task>
-        <code><![CDATA[
-            let $a := collection('/db/coll')//test/(qname)
-            return $a[text:match-any(., 'test')]
-            ]]></code>
-        <expected>
-            <qname att.qname="test">this is a test document</qname>
-        </expected>
     </test>
-    
     <test output="xml">
         <task>[query, range index, qname, direct] parenthesized element node</task>
         <code><![CDATA[
@@ -229,14 +242,14 @@
             ]]></code>
         <expected>test</expected>
     </test>
-    <test output="text" ignore="yes">
+    <test output="text">
         <task>[query, range index, qname, direct] descendant step with parenthesized attribute node</task>
         <code><![CDATA[
             collection('/db/coll')//test/qname//(@att.qname)[matches(., 'test')]/string()
             ]]></code>
         <expected>test</expected>
     </test>
-    <test output="text" ignore="yes">
+    <test output="text">
         <task>[query, range index, qname, indirect] descendant step with parenthesized attribute node</task>
         <code><![CDATA[
             let $a := collection('/db/coll')//test/qname//(@att.qname)
@@ -325,7 +338,7 @@
             <term freq="1" docs="1" n="1">test</term>
         </expected>
     </test>
-    <test output="xml" ignore="yes">
+    <test output="xml">
         <task>[index, range index, qname] descendant step with parenthesized attribute node</task>
         <code><![CDATA[
             let $a := collection('/db/coll')//test/qname//(@att.qname)
@@ -345,7 +358,7 @@
             <term freq="1" docs="1" n="1">test</term>
         </expected>
     </test>    
-    <test output="xml" ignore="yes">
+    <test output="xml">
         <task>[index, range index, path] descendant step with parenthesized attribute node</task>
         <code><![CDATA[
             let $a := collection('/db/coll')//test/path//(@att.path)

--- a/extensions/indexes/lucene/pom.xml
+++ b/extensions/indexes/lucene/pom.xml
@@ -240,6 +240,7 @@
                                 <include>pom.xml</include>
                                 <include>src/test/resources-filtered/conf.xml</include>
                                 <include>src/test/resources/log4j2.xml</include>
+                                <include>src/test/xquery/lucene/parenthesizedLocationStep_ftquery_Tests.xml</include>
                                 <include>src/main/java/org/exist/indexing/lucene/AbstractFieldConfig.java</include>
                                 <include>src/main/java/org/exist/indexing/lucene/AbstractTextExtractor.java</include>
                                 <include>src/main/java/org/exist/indexing/lucene/AnalyzerConfig.java</include>
@@ -277,6 +278,7 @@
                                 <exclude>src/test/resources-filtered/conf.xml</exclude>
                                 <exclude>src/test/resources/log4j2.xml</exclude>
                                 <exclude>src/test/xquery/lucene/fields.xqm</exclude>
+                                <exclude>src/test/xquery/lucene/parenthesizedLocationStep_ftquery_Tests.xml</exclude>
                                 <exclude>src/main/java/org/exist/indexing/lucene/AbstractFieldConfig.java</exclude>
                                 <exclude>src/main/java/org/exist/indexing/lucene/AbstractTextExtractor.java</exclude>
                                 <exclude>src/main/java/org/exist/indexing/lucene/AnalyzerConfig.java</exclude>

--- a/extensions/indexes/lucene/src/test/xquery/lucene/parenthesizedLocationStep_ftquery_Tests.xml
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/parenthesizedLocationStep_ftquery_Tests.xml
@@ -1,5 +1,29 @@
 <!--
 
+    Elemental
+    Copyright (C) 2024, Evolved Binary Ltd
+
+    admin@evolvedbinary.com
+    https://www.evolvedbinary.com | https://www.elemental.xyz
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; version 2.1.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+    NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+          The original license header is included below.
+
+    =====================================================================
+
     eXist-db Open Source Native XML Database
     Copyright (C) 2001 The eXist-db Authors
 
@@ -77,7 +101,7 @@
         <remove-collection collection="/db/test"/>
         <remove-collection collection="/db/system/config/db/test"/>
     </tearDown>
-    <test output="xml" ignore="yes">
+    <test output="xml">
         <task>[element] parenthesized final location step, non-parenthesized preceding step</task>
         <code><![CDATA[
             collection('/db/test')//level1//(el1)[ft:query(., 'test')]

--- a/extensions/indexes/lucene/src/test/xquery/lucene/parenthesizedLocationStep_ftquery_Tests.xml
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/parenthesizedLocationStep_ftquery_Tests.xml
@@ -141,7 +141,7 @@
             <el1 att1="test">test</el1>
         </expected>
     </test>
-    <test output="xml" ignore="yes">
+    <test output="xml">
         <task>[attribute] parenthesized final location step, non-parenthesized preceding step</task>
         <code><![CDATA[
             for $a in collection('/db/test')//level1//(@att1)[ft:query(., 'test')]
@@ -152,7 +152,7 @@
             <result att1="test"/>
         </expected>
     </test>
-    <test output="xml" ignore="yes">
+    <test output="xml">
         <task>[attribute] parenthesized final location step, no preceding step</task>
         <code><![CDATA[
             for $a in collection('/db/test')//(@att1)[ft:query(., 'test')]
@@ -163,7 +163,7 @@
             <result att1="test"/>
         </expected>
     </test>    
-    <test output="xml" ignore="yes">
+    <test output="xml">
         <task>[attribute] parenthesized final location step, parenthesized preceding step</task>
         <code><![CDATA[
             for $a in collection('/db/test')//(level1)//(@att1)[ft:query(., 'test')]
@@ -174,7 +174,7 @@
             <result att1="test"/>
         </expected>
     </test>    
-    <test output="xml" ignore="yes">
+    <test output="xml">
         <task>[attribute] parenthesized final location step, non-parenthesized preceding step with self selector</task>
         <code><![CDATA[
             for $a in collection('/db/test')//level1//.//(@att1)[ft:query(., 'test')] 
@@ -185,7 +185,7 @@
             <result att1="test"/>
         </expected>
     </test>
-    <test output="xml" ignore="yes">
+    <test output="xml">
         <task>[attribute retrieval] parenthesized final location step</task>
         <code><![CDATA[
             for $a in collection('/db/test')//level1//(@att1)
@@ -207,7 +207,7 @@
             <result att1="test"/>
         </expected>
     </test>
-    <test output="xml" ignore="yes">
+    <test output="xml">
         <task>[attribute retrieval] parenthesized attribute context node causes 'bleed-through' when name equals element name</task>
         <code><![CDATA[
             for $a in collection('/db/test')//level1//(@el1)


### PR DESCRIPTION
1. Fixes a number of bugs in Axes navigation for the expressions:
    * `//following::node()`
    * `//function(following::node())`
    * `//preceding::node()`
    * `//function(preceding::node())`
    * `//(@my-attribute)`

2. Fixes a bug in removing duplicate nodes from Sequences.

3. Reduced the memory used by `intersect` and `except` expressions whilst also increasing their performance.

4. Reduced the memory needed to Sequences and increased their performance.