### PR TITLE
[7.x.x] Enable sql-oracle module by default

### DIFF
--- a/extensions/modules/pom.xml
+++ b/extensions/modules/pom.xml
@@ -87,7 +87,7 @@
         <module>scheduler</module>
         <module>simpleql</module>
         <module>sql</module>
-        <!-- module>sql-oracle</module -->  <!-- Requires registration with Oracle! -->
+        <module>sql-oracle</module>
         <module>xmldiff</module>
         <module>xslfo</module>
     </modules>

--- a/extensions/modules/sql-oracle/pom.xml
+++ b/extensions/modules/sql-oracle/pom.xml
@@ -101,6 +101,7 @@
                             </multi>
                             <includes>
                                 <include>pom.xml</include>
+                                <include>src/main/java/**</include>
                             </includes>
                         </licenseSet>
 
@@ -111,6 +112,7 @@
                             <header>${project.parent.relativePath}/../../exist-parent/existdb-LGPL-21-license.template.txt</header>
                             <excludes>
                                 <exclude>pom.xml</exclude>
+                                <exclude>src/main/java/**</exclude>
                             </excludes>
                         </licenseSet>
 
@@ -131,6 +133,11 @@
             <artifactId>exist-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>xyz.elemental.fork.org.exist-db</groupId>
+            <artifactId>exist-sql</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
@@ -144,18 +151,5 @@
         </dependency>
 
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>maven.oracle.com</id>
-            <name>oracle-maven-repo</name>
-            <url>https://maven.oracle.com</url>
-            <layout>default</layout>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </releases>
-        </repository>
-    </repositories>
 
 </project>

--- a/extensions/modules/sql-oracle/src/main/java/org/exist/xquery/modules/oracle/ExecuteFunction.java
+++ b/extensions/modules/sql-oracle/src/main/java/org/exist/xquery/modules/oracle/ExecuteFunction.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -65,16 +89,13 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 /**
- * eXist Oracle Module Extension ExecuteFunction
+ * eXist-db Oracle Module Extension ExecuteFunction
  * 
  * Execute a PL/SQL stored procedure within an Oracle RDBMS.
  * 
  * @author <a href="mailto:robert.walpole@metoffice.gov.uk">Robert Walpole</a>
  * @serial 2009-03-23
  * @version 1.0
- * 
- * @see org.exist.xquery.BasicFunction#BasicFunction(org.exist.xquery.XQueryContext,
- *      org.exist.xquery.FunctionSignature)
  */
 public class ExecuteFunction extends BasicFunction {
 		
@@ -124,17 +145,17 @@ public class ExecuteFunction extends BasicFunction {
     private final static String TYPE_ATTRIBUTE_NAME = "type";
     private final static String POSITION_ATTRIBUTE_NAME = "pos";
     
-    private DateFormat xmlDf;
+    private final DateFormat xmlDf;
 
 	/**
      * ExecuteFunction Constructor
      *
-     * @param context
-     *            The Context of the calling XQuery
+     * @param context The Context of the calling XQuery.
+	 * @param signature The signature of the function
      */
-    public ExecuteFunction( XQueryContext context, FunctionSignature signature ) {
-        super( context, signature );
-        xmlDf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+    public ExecuteFunction(final XQueryContext context, final FunctionSignature signature)  {
+        super(context, signature);
+        this.xmlDf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
     }
     
 	@Override
@@ -372,12 +393,13 @@ public class ExecuteFunction extends BasicFunction {
 	}
 	
 	/**
-	 * Release DB resources
-	 * @param connection
-	 * @param statement
-	 * @param rs
+	 * Release DB resources.
+	 *
+	 * @param connection the database connection.
+	 * @param statement the query statement.
+	 * @param rs the query results.
 	 */
-	protected void release(Connection connection, Statement statement, ResultSet rs) {
+	protected void release(final Connection connection, final Statement statement, final ResultSet rs) {
 		if (rs != null) {
 			try {
 				rs.close();

--- a/extensions/modules/sql-oracle/src/main/java/org/exist/xquery/modules/oracle/OracleModule.java
+++ b/extensions/modules/sql-oracle/src/main/java/org/exist/xquery/modules/oracle/OracleModule.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -27,9 +51,9 @@ import org.exist.xquery.AbstractInternalModule;
 import org.exist.xquery.FunctionDef;
 
 /**
- * eXist Oracle Module Extension
+ * eXist-db Oracle Module Extension
  * 
- * An extension module for the eXist Native XML Database that allows execution of
+ * An extension module for the eXist-db Native XML Database that allows execution of
  * PL/SQL Stored Procedures within an Oracle RDBMS, returning an XML representation
  * of the result set. In particular, this module gives access to a <code>ResultSet</code>
  * returned in an <code>OracleType.CURSOR</code>, functionality which is not provided by
@@ -40,23 +64,40 @@ import org.exist.xquery.FunctionDef;
  * @author <a href="mailto:robert.walpole@metoffice.gov.uk">Robert Walpole</a>
  * @serial 2010-03-23
  * @version 1.0
- * 
- * @see org.exist.xquery.AbstractInternalModule#AbstractInternalModule(org.exist.xquery.FunctionDef[])
  */
 public class OracleModule extends AbstractInternalModule{
-	
+
+	/**
+	 * Namespace URI for the OracleModule functions.
+	 */
 	public final static String NAMESPACE_URI = "http://exist-db.org/xquery/oracle";
-	
+
+	/**
+	 * Namespace prefix for the OracleModule functions.
+	 */
 	public final static String PREFIX = "oracle";
+
+	/**
+	 * Date that the OracleModule was added to eXist-db.
+	 */
 	public final static String INCLUSION_DATE = "2010-03-23";
+
+	/**
+	 * Version of eXist-db that first had the OracleModule.
+	 */
 	public final static String RELEASED_IN_VERSION = "eXist-2.0";
 	
 	private final static FunctionDef[] functions = {
         new FunctionDef(ExecuteFunction.signatures[0], ExecuteFunction.class),
         new FunctionDef(ExecuteFunction.signatures[1], ExecuteFunction.class)
     };
-	
-	public OracleModule(Map<String, List<? extends Object>> parameters) {
+
+	/**
+	 * Default Constructor.
+	 *
+	 * @param parameters parameters for configuring the module.
+	 */
+	public OracleModule(final Map<String, List<? extends Object>> parameters) {
         super(functions, parameters);
     }
 


### PR DESCRIPTION
Enables the `sql-oracle` module as the ojdbc dependency is now freely available from Maven Central