### PR TITLE
[7.x.x] Fix a memory leak in XPath 3.1 inline function implementation

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1226,6 +1226,7 @@
                                 <include>src/test/java/org/exist/xquery/ForwardReferenceTest.java</include>
                                 <include>src/main/java/org/exist/xquery/Function.java</include>
                                 <include>src/main/java/org/exist/xquery/FunctionFactory.java</include>
+                                <include>src/main/java/org/exist/xquery/InlineFunction.java</include>
                                 <include>src/main/java/org/exist/xquery/Intersect.java</include>
                                 <include>src/test/java/org/exist/xquery/LexerTest.java</include>
                                 <include>src/main/java/org/exist/xquery/LocationStep.java</include>
@@ -2037,6 +2038,7 @@
                                 <exclude>src/test/resources-filtered/org/exist/xquery/import-from-pkg-test.conf.xml</exclude>
                                 <exclude>src/test/java/org/exist/xquery/ImportFromPkgTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/ImportModuleTest.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/InlineFunction.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/Intersect.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/JavaBinding.java</exclude>
                                 <exclude>src/test/resources-filtered/org/exist/xquery/JavaBindingTest.conf.xml</exclude>

--- a/exist-core/src/main/java/org/exist/xquery/InlineFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/InlineFunction.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -33,67 +57,65 @@ import org.exist.xquery.value.Type;
 
 /**
  * An XQuery 3.0 inline function expression.
- * 
- * @author wolf
  *
+ * @author wolf
  */
 public class InlineFunction extends AbstractExpression {
 
-	public final static QName INLINE_FUNCTION_QNAME = QName.EMPTY_QNAME;
-	
-	private UserDefinedFunction function;
-	private ArrayDeque<FunctionCall> calls = new ArrayDeque<>();
-	
+    public static final QName INLINE_FUNCTION_QNAME = QName.EMPTY_QNAME;
+
+    private final UserDefinedFunction function;
+    private final ArrayDeque<FunctionCall> calls = new ArrayDeque<>();
+
     private AnalyzeContextInfo cachedContextInfo;
 
-    public InlineFunction(XQueryContext context, UserDefinedFunction function) {
-		super(context);
-		this.function = function;
-	}
+    public InlineFunction(final XQueryContext context, final UserDefinedFunction function) {
+        super(context);
+        this.function = function;
+    }
 
-	@Override
-	public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
-
+    @Override
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
         cachedContextInfo = new AnalyzeContextInfo(contextInfo);
         cachedContextInfo.addFlag(SINGLE_STEP_EXECUTION);
         cachedContextInfo.setParent(this);
-	}
-
-	@Override
-	public void dump(ExpressionDumper dumper) {
-		dumper.display("function");
-		function.dump(dumper);
-	}
-
-	/**
-	 * Wraps a function call around the function and returns a
-	 * reference to it. Make sure local variables in the context
-	 * are visible.
-	 */
-	public Sequence eval(Sequence contextSequence, Item contextItem)
-			throws XPathException {
-		// local variable context is known within inline function
-		final List<ClosureVariable> closureVars = context.getLocalStack();
-		
-		final FunctionCall call = new FunctionCall(context, function);
-		call.getFunction().setClosureVariables(closureVars);
-		call.setLocation(function.getLine(), function.getColumn());
-		call.analyze(new AnalyzeContextInfo(cachedContextInfo));
-
-		// push the created function call to the stack so we can clear
-        // it after execution
-		calls.push(call);
-
-		return new FunctionReference(this, call);
-	}
-
-	@Override
-	public int returnsType() {
-		return Type.FUNCTION;
-	}
+    }
 
     @Override
-    public void resetState(boolean postOptimization) {
+    public void dump(final ExpressionDumper dumper) {
+        dumper.display("function");
+        function.dump(dumper);
+    }
+
+    /**
+     * Wraps a function call around the function and returns a
+     * reference to it. Make sure local variables in the context
+     * are visible.
+     */
+    @Override
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
+        // local variable context is known within inline function
+        final List<ClosureVariable> closureVars = context.getLocalStack();
+
+        final FunctionCall call = new FunctionCall(context, function);
+        call.getFunction().setClosureVariables(closureVars);
+        call.setLocation(function.getLine(), function.getColumn());
+        call.analyze(new AnalyzeContextInfo(cachedContextInfo));
+
+        // push the created function call to the stack so we can clear
+        // it after execution
+        calls.push(call);
+
+        return new FunctionReference(this, call);
+    }
+
+    @Override
+    public int returnsType() {
+        return Type.FUNCTION;
+    }
+
+    @Override
+    public void resetState(final boolean postOptimization) {
         super.resetState(postOptimization);
         calls.clear();
         function.resetState(postOptimization);

--- a/exist-core/src/main/java/org/exist/xquery/InlineFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/InlineFunction.java
@@ -45,7 +45,6 @@
  */
 package org.exist.xquery;
 
-import java.util.ArrayDeque;
 import java.util.List;
 
 import org.exist.dom.QName;
@@ -59,13 +58,13 @@ import org.exist.xquery.value.Type;
  * An XQuery 3.0 inline function expression.
  *
  * @author wolf
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
 public class InlineFunction extends AbstractExpression {
 
     public static final QName INLINE_FUNCTION_QNAME = QName.EMPTY_QNAME;
 
     private final UserDefinedFunction function;
-    private final ArrayDeque<FunctionCall> calls = new ArrayDeque<>();
 
     private AnalyzeContextInfo cachedContextInfo;
 
@@ -102,10 +101,6 @@ public class InlineFunction extends AbstractExpression {
         call.setLocation(function.getLine(), function.getColumn());
         call.analyze(new AnalyzeContextInfo(cachedContextInfo));
 
-        // push the created function call to the stack so we can clear
-        // it after execution
-        calls.push(call);
-
         return new FunctionReference(this, call);
     }
 
@@ -117,7 +112,11 @@ public class InlineFunction extends AbstractExpression {
     @Override
     public void resetState(final boolean postOptimization) {
         super.resetState(postOptimization);
-        calls.clear();
+
+        if (!postOptimization) {
+            function.setClosureVariables(null);
+        }
+
         function.resetState(postOptimization);
     }
 }


### PR DESCRIPTION
The Inline Function implementation previously accumulated references to function calls that closed over in-scope global or local variables. This meant that they would be kept in-memory if the compiled query was sent to the XQuery Pool for reuse. This PR fixes that issue so that the memory is correctly freed when the query completes execution.