### PR TITLE
[7.x.x] Fix a memory/resource leak in the sql:execute XPath functions

### DIFF
--- a/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/ExecuteFunction.java
+++ b/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/ExecuteFunction.java
@@ -428,8 +428,9 @@ public class ExecuteFunction extends BasicFunction {
                                 //get the content
                                 if (rsmd.getColumnType(i + 1) == Types.SQLXML) {
                                     //parse sqlxml value
+                                    @Nullable SQLXML sqlXml = null;
                                     try {
-                                        final SQLXML sqlXml = rs.getSQLXML(i + 1);
+                                        sqlXml = rs.getSQLXML(i + 1);
 
                                         if (rs.wasNull()) {
                                             // Add a null indicator attribute if the value was SQL Null
@@ -455,7 +456,12 @@ public class ExecuteFunction extends BasicFunction {
                                         }
                                     } catch (final Exception e) {
                                         throw new XPathException(this, "Could not parse column of type SQLXML: " + e.getMessage(), e);
+                                    } finally {
+                                        if (sqlXml != null) {
+                                            sqlXml.free();
+                                        }
                                     }
+
                                 } else {
                                     //otherwise assume string value
                                     final String colValue = rs.getString(i + 1);


### PR DESCRIPTION
Any SQLXML JDBC objects were not previously being freed. This PR fixes that.