### PR TITLE
[6.x.x] Fix a memory leak in the util:eval XPath functions

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/Context.java
+++ b/exist-core/src/main/java/org/exist/xquery/Context.java
@@ -98,6 +98,12 @@ public interface Context {
 
     XQueryContext getRootContext();
 
+    /**
+     * Create a new context ("Inner Context") that will share some state with this context.
+     * After calling this {@link #setShared(boolean)} should be set to true.
+     *
+     * @return an inner context.
+     */
     XQueryContext copyContext();
 
     /**
@@ -334,6 +340,13 @@ public interface Context {
 
     void addLockedDocument(DocumentImpl doc);
 
+    /**
+     * When set as true, it indicates that this Context (often known as the Inner Context)
+     * shares some state with another Context (often known as the Outer Context).
+     * This should be set to true after any call to {@link #copyContext()}.
+     *
+     * @param shared set to true if this context shares state with another context, false otherwise.
+     */
     void setShared(boolean shared);
 
     boolean isShared();

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -1554,15 +1554,17 @@ public class XQueryContext implements BinaryValueManager, Context {
             watchdog.reset();
         }
 
-        /*
-            NOTE: we use `modules` (and not `allModules`) here so as to only reset
-            the modules of this module.
-            The inner call to `module.reset` will be called on sub-modules
-            which in-turn will reset their modules, and so on.
-         */
-        for (final Module[] modules : modules.values()) {
-            for (final Module module : modules) {
-                module.reset(this, keepGlobals);
+        if (!isShared) {
+            /*
+                NOTE: we use `modules` (and not `allModules`) here so as to only reset
+                the modules of this module.
+                The inner call to `module.reset` will be called on sub-modules
+                which in-turn will reset their modules, and so on.
+            */
+            for (final Module[] modules : modules.values()) {
+                for (final Module module : modules) {
+                    module.reset(this, keepGlobals);
+                }
             }
         }
 
@@ -1576,7 +1578,9 @@ public class XQueryContext implements BinaryValueManager, Context {
 
         clearUpdateListeners();
 
-        profiler.reset();
+        if (!isShared) {
+            profiler.reset();
+        }
 
         if (!keepGlobals) {
             httpContext = null;

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/Eval.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/Eval.java
@@ -469,7 +469,7 @@ public class Eval extends BasicFunction {
                 compiled.getContext().prepareForReuse();
             }
 
-            Sequence sequence = xqueryService.execute(broker, compiled, exprContext, outputProperties, false);
+            Sequence sequence = xqueryService.execute(broker, compiled, exprContext, outputProperties, true);
             ValueSequence newSeq = new ValueSequence();
             newSeq.keepUnOrdered(unordered);
             boolean hasSupplements = false;
@@ -496,10 +496,9 @@ public class Eval extends BasicFunction {
                 if (compiled.getContext() != null) {
                     compiled.getContext().runCleanupTasks();
                 }
+
                 if (cache) {
                     pool.returnCompiledXQuery(querySource, compiled);
-                } else {
-                    compiled.reset();
                 }
             }
         }


### PR DESCRIPTION
Backport of https://github.com/evolvedbinary/elemental/pull/180

Previously The XQueryContext used by the XPath function `util:eval` was not correctly reset, which lead to a leak ofUpdate Listeners that can often hold large context sequences from Binding Expressions. This PR fixes that.