### PR TITLE
[6.x.x] Fix a memory leak in the XPath 3.1 Lookup Operator implementation

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -1192,10 +1192,12 @@
                                 <include>src/main/java/org/exist/xquery/Intersect.java</include>
                                 <include>src/test/java/org/exist/xquery/LexerTest.java</include>
                                 <include>src/main/java/org/exist/xquery/LocationStep.java</include>
+                                <include>src/main/java/org/exist/xquery/Lookup.java</include>
                                 <include>src/main/java/org/exist/xquery/Module.java</include>
                                 <include>src/main/java/org/exist/xquery/NamedFunctionReference.java</include>
                                 <include>src/main/java/org/exist/xquery/NameTest.java</include>
                                 <include>src/test/java/org/exist/xquery/NodeTypeTest.java</include>
+                                <include>src/main/java/org/exist/xquery/OpNumeric.java</include>
                                 <include>src/main/java/org/exist/xquery/Optimizer.java</include>
                                 <include>src/main/java/org/exist/xquery/Option.java</include>
                                 <include>src/main/java/org/exist/xquery/PathExpr.java</include>
@@ -1981,11 +1983,13 @@
                                 <exclude>src/test/java/org/exist/xquery/JavaBindingTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/LexerTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/LocationStep.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/Lookup.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/Materializable.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/Module.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/NamedFunctionReference.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/NameTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/NodeTypeTest.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/OpNumeric.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/Optimizer.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/Option.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/PathExpr.java</exclude>

--- a/exist-core/src/main/java/org/exist/xquery/Lookup.java
+++ b/exist-core/src/main/java/org/exist/xquery/Lookup.java
@@ -200,6 +200,7 @@ public class Lookup extends AbstractExpression {
         }
 
         if (keyExpression != null) {
+            keys = null;
             keyExpression.resetState(postOptimization);
         }
     }

--- a/exist-core/src/main/java/org/exist/xquery/Lookup.java
+++ b/exist-core/src/main/java/org/exist/xquery/Lookup.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -27,6 +51,8 @@ import org.exist.xquery.functions.map.AbstractMapType;
 import org.exist.xquery.util.ExpressionDumper;
 import org.exist.xquery.value.*;
 
+import javax.annotation.Nullable;
+
 /**
  * Implements the XQuery 3.1 lookup operator on maps and arrays.
  *
@@ -34,32 +60,32 @@ import org.exist.xquery.value.*;
  */
 public class Lookup extends AbstractExpression {
 
-    private Expression contextExpression;
-    private Sequence keys = null;
-    private Expression keyExpression = null;
+    private final Expression contextExpression;
+    private @Nullable Sequence keys = null;
+    private @Nullable Expression keyExpression = null;
 
-    public Lookup(XQueryContext context, Expression ctxExpr) {
+    public Lookup(final XQueryContext context, final Expression contextExpression) {
         super(context);
-        this.contextExpression = ctxExpr;
+        this.contextExpression = contextExpression;
     }
 
-    public Lookup(XQueryContext context, Expression ctxExpr, String keyString) {
-        this(context, ctxExpr);
-        this.keys = new StringValue(ctxExpr, keyString);
+    public Lookup(final XQueryContext context, final Expression contextExpression, final String keyString) {
+        this(context, contextExpression);
+        this.keys = new StringValue(contextExpression, keyString);
     }
 
-    public Lookup(XQueryContext context, Expression ctxExpr, int position) {
-        this(context, ctxExpr);
-        this.keys = new IntegerValue(ctxExpr, position);
+    public Lookup(final XQueryContext context, final Expression contextExpression, final int position) {
+        this(context, contextExpression);
+        this.keys = new IntegerValue(contextExpression, position);
     }
 
-    public Lookup(XQueryContext context, Expression ctxExpr, Expression keyExpression) {
-        this(context, ctxExpr);
+    public Lookup(final XQueryContext context, final Expression contextExpression, @Nullable final Expression keyExpression) {
+        this(context, contextExpression);
         this.keyExpression = keyExpression;
     }
 
     @Override
-    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
         final AnalyzeContextInfo contextCopy = new AnalyzeContextInfo(contextInfo);
         if (contextExpression != null) {
             contextExpression.analyze(contextCopy);
@@ -70,16 +96,18 @@ public class Lookup extends AbstractExpression {
     }
 
     @Override
-    public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
+    public Sequence eval(Sequence contextSequence, final Item contextItem) throws XPathException {
         if (contextItem != null) {
             contextSequence = contextItem.toSequence();
         }
-        Sequence leftSeq;
+
+        final Sequence leftSeq;
         if (contextExpression == null && contextSequence == null) {
-            throw new XPathException(this, ErrorCodes.XPDY0002,
-                    "Lookup has nothing to select, the context item is absent");
+            throw new XPathException(this, ErrorCodes.XPDY0002, "Lookup has nothing to select, the context item is absent");
+
         } else if (contextExpression == null) {
             leftSeq = contextSequence;
+
         } else {
             leftSeq = contextExpression.eval(contextSequence, null);
         }
@@ -90,39 +118,44 @@ public class Lookup extends AbstractExpression {
             return Sequence.EMPTY_SEQUENCE;
         }
 
-
         if (!(Type.subTypeOf(contextType, Type.MAP) || Type.subTypeOf(contextType, Type.ARRAY))) {
-            throw new XPathException(this, ErrorCodes.XPTY0004,
-                    "expression to the left of a lookup operator needs to be a sequence of maps or arrays");
+            throw new XPathException(this, ErrorCodes.XPTY0004, "expression to the left of a lookup operator needs to be a sequence of maps or arrays");
         }
+
         if (keyExpression != null) {
             keys = keyExpression.eval(contextSequence, null);
             if (keys.isEmpty()) {
                 return Sequence.EMPTY_SEQUENCE;
             }
         }
+
         try {
             final ValueSequence result = new ValueSequence();
-            for (SequenceIterator i = leftSeq.iterate(); i.hasNext(); ) {
+            for (final SequenceIterator i = leftSeq.iterate(); i.hasNext(); ) {
                 final LookupSupport item = (LookupSupport) i.nextItem();
+
                 if (keys != null) {
-                    for (SequenceIterator j = keys.iterate(); j.hasNext(); ) {
+                    for (final SequenceIterator j = keys.iterate(); j.hasNext(); ) {
                         final AtomicValue key = j.nextItem().atomize();
-                        Sequence value = item.get(key);
+                        final Sequence value = item.get(key);
                         if (value != null) {
                             result.addAll(value);
                         }
                     }
-                } else if(item instanceof ArrayType) {
+
+                } else if (item instanceof ArrayType) {
                     result.addAll(item.keys());
-                } else if(item instanceof AbstractMapType) {
-                    for(final IEntry<AtomicValue, Sequence> entry : ((AbstractMapType)item)) {
+
+                } else if (item instanceof AbstractMapType) {
+                    for (final IEntry<AtomicValue, Sequence> entry : ((AbstractMapType)item)) {
                         result.addAll(entry.value());
                     }
                 }
             }
+
             return result;
-        } catch (XPathException e) {
+
+        } catch (final XPathException e) {
             e.setLocation(getLine(), getColumn(), getSource());
             throw e;
         }
@@ -139,28 +172,33 @@ public class Lookup extends AbstractExpression {
     }
 
     @Override
-    public void dump(ExpressionDumper dumper) {
+    public void dump(final ExpressionDumper dumper) {
         if (contextExpression != null) {
             contextExpression.dump(dumper);
         }
+
         dumper.display("?");
+
         if (keyExpression == null && keys != null && keys.getItemCount() > 0) {
             try {
                 dumper.display(keys.itemAt(0).getStringValue());
-            } catch (XPathException e) {
+            } catch (final XPathException e) {
                 // impossible
             }
+
         } else if (keyExpression != null) {
             keyExpression.dump(dumper);
         }
     }
 
     @Override
-    public void resetState(boolean postOptimization) {
+    public void resetState(final boolean postOptimization) {
         super.resetState(postOptimization);
+
         if (contextExpression != null) {
             contextExpression.resetState(postOptimization);
         }
+
         if (keyExpression != null) {
             keyExpression.resetState(postOptimization);
         }

--- a/exist-core/src/main/java/org/exist/xquery/OpNumeric.java
+++ b/exist-core/src/main/java/org/exist/xquery/OpNumeric.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -25,7 +49,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
-import org.exist.dom.persistent.NodeSet;
 import org.exist.storage.DBBroker;
 import org.exist.xquery.Constants.ArithmeticOperator;
 import org.exist.xquery.util.ExpressionDumper;
@@ -36,14 +59,13 @@ import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.Type;
 
 /**
- * numeric operation on two operands by +, -, *, div, mod etc..
+ * numeric operation on two operands by +, -, *, div, mod etc.
  *
  */
 public class OpNumeric extends BinaryOp {
 
     protected final ArithmeticOperator operator;
     protected int returnType = Type.ATOMIC;
-    protected NodeSet temp = null;
     protected DBBroker broker;
 
     public OpNumeric(XQueryContext context, ArithmeticOperator operator) {


### PR DESCRIPTION
Backport of https://github.com/evolvedbinary/elemental/pull/182

The Lookup Operator implementation previously did not free the reference to its lookup keys. This meant that its keys would be kept in-memory if the compiled query was sent to the XQuery Pool for reuse. This PR fixes that issue so that the memory is correctly freed when the query completes execution.

When combined with https://github.com/evolvedbinary/elemental/pull/177 this closes https://github.com/eXist-db/exist/issues/5375