### PR TITLE
[7.x.x] Make eXist-db 6.4.0 the minimum compatible version for EXPath Packages

### DIFF
--- a/elemental-parent/pom.xml
+++ b/elemental-parent/pom.xml
@@ -88,7 +88,7 @@
         <project.parent.relativePath>.</project.parent.relativePath>
 
         <!-- NOTE: this needs to be set to the latest eXist-db compatible version of the EXPath packages that we want -->
-        <exist-db.expath.pkg.compatible.version>6.3.0</exist-db.expath.pkg.compatible.version>
+        <exist-db.expath.pkg.compatible.version>6.4.0</exist-db.expath.pkg.compatible.version>
 
         <!-- Sonar cloud-->
         <sonar.projectKey>evolvedbinary_elemental</sonar.projectKey>

--- a/exist-core/src/main/java/org/exist/repo/Deployment.java
+++ b/exist-core/src/main/java/org/exist/repo/Deployment.java
@@ -329,7 +329,7 @@ public class Deployment {
 
     private void checkExistDbProcessorVersion(final PackageLoader.Version version) throws PackageException {
         final String procVersion = SystemProperties.getInstance().getSystemProperty("product-version", "1.0.0");
-        final String eXistCompatibleProcVersion = SystemProperties.getInstance().getSystemProperty("exist-db-expath-pkg-compatible-version", "6.3.0");
+        final String eXistCompatibleProcVersion = SystemProperties.getInstance().getSystemProperty("exist-db-expath-pkg-compatible-version", "6.4.0");
 
         final DependencyVersion depVersion = version.getDependencyVersion();
         if (!depVersion.isCompatible(eXistCompatibleProcVersion)) {


### PR DESCRIPTION
We have increased the minimum compatible version of eXist-db processor to 6.4.0 for eXist-db EXPath Packages. This enables us access to newer versions of eXide, Monex, etc.