### PR TITLE
[6.x.x] Correct typo of 'getContextItemDeclartion' to 'getContextItemDeclaration'

### DIFF
--- a/exist-core/src/main/java/org/exist/http/urlrewrite/ModuleCall.java
+++ b/exist-core/src/main/java/org/exist/http/urlrewrite/ModuleCall.java
@@ -115,7 +115,7 @@ public class ModuleCall extends URLRewrite {
     @Override
     public void doRewrite(final HttpServletRequest request, final HttpServletResponse response) throws ServletException {
         try {
-            final ContextItemDeclaration cid = call.getContext().getContextItemDeclartion();
+            final ContextItemDeclaration cid = call.getContext().getContextItemDeclaration();
             final Sequence contextSequence;
             if (cid != null) {
                 contextSequence = cid.eval(null, null);

--- a/exist-core/src/main/java/org/exist/security/internal/SMEvents.java
+++ b/exist-core/src/main/java/org/exist/security/internal/SMEvents.java
@@ -123,7 +123,7 @@ public class SMEvents implements Configurable {
     	            }
 
 					final Sequence contextSequence;
-					final ContextItemDeclaration cid = context.getContextItemDeclartion();
+					final ContextItemDeclaration cid = context.getContextItemDeclaration();
 					if(cid != null) {
 						contextSequence = cid.eval(null, null);
 					} else {

--- a/exist-core/src/main/java/org/exist/xquery/RootNode.java
+++ b/exist-core/src/main/java/org/exist/xquery/RootNode.java
@@ -72,7 +72,7 @@ public class RootNode extends Step {
         }
 
         // second, check if a context item is declared
-        final ContextItemDeclaration decl = context.getContextItemDeclartion();
+        final ContextItemDeclaration decl = context.getContextItemDeclaration();
         if (decl != null) {
             final Sequence seq = decl.eval(null, null);
             if (!seq.isEmpty()) {

--- a/exist-core/src/main/java/org/exist/xquery/XQuery.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQuery.java
@@ -411,8 +411,8 @@ public class XQuery {
 
                 // support for XQuery 3.0 - declare context item :=
                 if(contextSequence == null) {
-                    if(context.getContextItemDeclartion() != null) {
-                        contextSequence = context.getContextItemDeclartion().eval(null, null);
+                    if(context.getContextItemDeclaration() != null) {
+                        contextSequence = context.getContextItemDeclaration().eval(null, null);
                     }
                 }
 

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -799,7 +799,7 @@ public class XQueryContext implements BinaryValueManager, Context {
         this.contextItemDeclaration = contextItemDeclaration;
     }
 
-    public ContextItemDeclaration getContextItemDeclartion() {
+    public ContextItemDeclaration getContextItemDeclaration() {
         return contextItemDeclaration;
     }
 

--- a/extensions/indexes/range/src/main/java/org/exist/indexing/range/RangeIndexConfigAttributeCondition.java
+++ b/extensions/indexes/range/src/main/java/org/exist/indexing/range/RangeIndexConfigAttributeCondition.java
@@ -47,7 +47,6 @@ package org.exist.indexing.range;
 
 import org.exist.dom.QName;
 import org.exist.dom.persistent.ElementImpl;
-import org.exist.dom.persistent.NodeImpl;
 import org.exist.storage.ElementValue;
 import org.exist.storage.NodePath;
 import org.exist.util.DatabaseConfigurationException;
@@ -456,7 +455,7 @@ public class RangeIndexConfigAttributeCondition extends RangeIndexConfigConditio
         } else if (expr instanceof VariableReference || expr instanceof Function) {
             try {
                 final Sequence contextSequence;
-                final ContextItemDeclaration cid = expr.getContext().getContextItemDeclartion();
+                final ContextItemDeclaration cid = expr.getContext().getContextItemDeclaration();
                 if(cid != null) {
                     contextSequence = cid.eval(null, null);
                 } else {


### PR DESCRIPTION
Backport of https://github.com/evolvedbinary/elemental/pull/197

Fixes a simple typo in a method name of XQueryContext.