### PR TITLE
[6.x.x] Support for executing XQuery from XML Calabash 3

### DIFF
--- a/elemental-parent/pom.xml
+++ b/elemental-parent/pom.xml
@@ -374,9 +374,9 @@
                     <version>3.4.0</version>
                 </plugin>
                 <plugin>
-                    <groupId>com.code54.mojo</groupId>
-                    <artifactId>buildversion-plugin</artifactId>
-                    <version>1.0.3</version>
+                    <groupId>com.evolvedbinary.maven.plugins</groupId>
+                    <artifactId>buildversion-maven-plugin</artifactId>
+                    <version>2.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -620,8 +620,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.code54.mojo</groupId>
-                <artifactId>buildversion-plugin</artifactId>
+                <groupId>com.evolvedbinary.maven.plugins</groupId>
+                <artifactId>buildversion-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <phase>validate</phase>
@@ -813,20 +813,5 @@
             </build>
         </profile>
     </profiles>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>clojars.org</id>
-            <url>https://clojars.org/repo</url>
-        </pluginRepository>
-    </pluginRepositories>
-
-    <distributionManagement>
-        <repository>
-            <id>central-ossrh-staging</id>
-            <name>Central Portal - OSSRH Staging API</name>
-            <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 
 </project>

--- a/exist-core/src/main/java/org/exist/Namespaces.java
+++ b/exist-core/src/main/java/org/exist/Namespaces.java
@@ -60,6 +60,7 @@ public interface Namespaces {
     String DTD_NS = XMLConstants.XML_DTD_NS_URI;
 
 	String SCHEMA_NS = XMLConstants.W3C_XML_SCHEMA_NS_URI;
+	String SCHEMA_NS_PREFIX = "xs";
     String SCHEMA_DATATYPES_NS = "http://www.w3.org/2001/XMLSchema-datatypes";
 	String SCHEMA_INSTANCE_NS = XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI;
     

--- a/exist-core/src/main/java/org/exist/client/CommandlineOptions.java
+++ b/exist-core/src/main/java/org/exist/client/CommandlineOptions.java
@@ -83,6 +83,10 @@ public class CommandlineOptions {
             .description("do not make embedded mode available")
             .defaultValue(false)
             .build();
+    private static final Argument<Boolean> noAutoDeployArg = optionArgument("-a", "--no-auto-deploy")
+        .description("Disable auto-deployment of EXPath Packages")
+        .defaultValue(false)
+        .build();
 
 
     /* gui arguments */
@@ -168,7 +172,7 @@ public class CommandlineOptions {
 
     public static CommandlineOptions parse(final String[] args) throws ArgumentException, URISyntaxException {
         final ParsedArguments arguments = CommandLineParser
-                .withArguments(userArg, passwordArg, useSslArg, embeddedArg, embeddedConfigArg, noEmbeddedModeArg)
+                .withArguments(userArg, passwordArg, useSslArg, embeddedArg, embeddedConfigArg, noEmbeddedModeArg, noAutoDeployArg)
                 .andArguments(noGuiArg, guiQueryDialogArg)
                 .andArguments(mkColArg, rmColArg, setColArg)
                 .andArguments(parseDocsArg, getDocArg, rmDocArg)
@@ -189,6 +193,7 @@ public class CommandlineOptions {
         final boolean embedded = getBool(arguments, embeddedArg);
         final Optional<Path> embeddedConfig = getPathOpt(arguments, embeddedConfigArg);
         final boolean noEmbeddedMode = getBool(arguments, noEmbeddedModeArg);
+        final boolean noAutoDeploy = getBool(arguments, noAutoDeployArg);
 
         final boolean startGUI = !getBool(arguments, noGuiArg);
         final boolean openQueryGUI = getBool(arguments, guiQueryDialogArg);
@@ -233,6 +238,7 @@ public class CommandlineOptions {
                 embedded,
                 embeddedConfig,
                 noEmbeddedMode,
+                noAutoDeploy,
                 startGUI,
                 openQueryGUI,
                 mkCol,
@@ -252,7 +258,7 @@ public class CommandlineOptions {
         );
     }
 
-    public CommandlineOptions(boolean quiet, boolean verbose, Optional<Path> outputFile, Map<String, String> options, Optional<String> username, Optional<String> password, boolean useSSL, boolean embedded, Optional<Path> embeddedConfig, boolean noEmbeddedMode, boolean startGUI, boolean openQueryGUI, Optional<XmldbURI> mkCol, Optional<XmldbURI> rmCol, Optional<XmldbURI> setCol, List<Path> parseDocs, Optional<XmldbURI> getDoc, Optional<String> rmDoc, Optional<String> xpath, List<Path> queryFiles, Optional<Integer> howManyResults, Optional<Path> traceQueriesFile, Optional<String> setDoc, Optional<Path> xupdateFile, boolean reindex, boolean reindexRecurse) {
+    public CommandlineOptions(boolean quiet, boolean verbose, Optional<Path> outputFile, Map<String, String> options, Optional<String> username, Optional<String> password, boolean useSSL, boolean embedded, Optional<Path> embeddedConfig, boolean noEmbeddedMode, boolean noAutoDeploy, boolean startGUI, boolean openQueryGUI, Optional<XmldbURI> mkCol, Optional<XmldbURI> rmCol, Optional<XmldbURI> setCol, List<Path> parseDocs, Optional<XmldbURI> getDoc, Optional<String> rmDoc, Optional<String> xpath, List<Path> queryFiles, Optional<Integer> howManyResults, Optional<Path> traceQueriesFile, Optional<String> setDoc, Optional<Path> xupdateFile, boolean reindex, boolean reindexRecurse) {
         this.quiet = quiet;
         this.verbose = verbose;
         this.outputFile = outputFile;
@@ -263,6 +269,7 @@ public class CommandlineOptions {
         this.embedded = embedded;
         this.embeddedConfig = embeddedConfig;
         this.noEmbeddedMode = noEmbeddedMode;
+        this.noAutoDeploy = noAutoDeploy;
         this.startGUI = startGUI;
         this.openQueryGUI = openQueryGUI;
         this.mkCol = mkCol;
@@ -292,6 +299,7 @@ public class CommandlineOptions {
     final boolean embedded;
     final Optional<Path> embeddedConfig;
     final boolean noEmbeddedMode;
+    final boolean noAutoDeploy;
 
     final boolean startGUI;
     final boolean openQueryGUI;

--- a/exist-core/src/main/java/org/exist/client/InteractiveClient.java
+++ b/exist-core/src/main/java/org/exist/client/InteractiveClient.java
@@ -147,6 +147,7 @@ public class InteractiveClient {
     public static final String CREATE_DATABASE = "create-database";
     public static final String LOCAL_MODE = "local-mode-opt";
     public static final String NO_EMBED_MODE = "NO_EMBED_MODE";
+    public static final String NO_AUTO_DEPLOY = "no-autodeploy";
 
     // values
     protected static final String EDIT_CMD = "emacsclient -t $file";
@@ -155,6 +156,7 @@ public class InteractiveClient {
     protected static final String SSL_ENABLE_DEFAULT = "FALSE";
     protected static final String LOCAL_MODE_DEFAULT = "FALSE";
     protected static final String NO_EMBED_MODE_DEFAULT = "FALSE";
+    protected static final String NO_AUTO_DEPLOY_DEFAULT = "FALSE";
     protected static final String USER_DEFAULT = SecurityManager.DBA_USER;
 
     protected static final String driver = "org.exist.xmldb.DatabaseImpl";
@@ -173,6 +175,7 @@ public class InteractiveClient {
         defaultProps.setProperty(PERMISSIONS, "false");
         defaultProps.setProperty(EXPAND_XINCLUDES, "true");
         defaultProps.setProperty(SSL_ENABLE, SSL_ENABLE_DEFAULT);
+        defaultProps.setProperty(NO_AUTO_DEPLOY, NO_AUTO_DEPLOY_DEFAULT);
     }
 
     protected static final int colSizes[] = new int[]{10, 10, 10, -1};
@@ -333,6 +336,7 @@ public class InteractiveClient {
         // Configure database
         database.setProperty(CREATE_DATABASE, "true");
         database.setProperty(SSL_ENABLE, properties.getProperty(SSL_ENABLE));
+        database.setProperty(NO_AUTO_DEPLOY, properties.getProperty(NO_AUTO_DEPLOY));
 
         // secure empty configuration
         final String configProp = properties.getProperty(InteractiveClient.CONFIGURATION);
@@ -1970,6 +1974,9 @@ public class InteractiveClient {
         options.embeddedConfig.ifPresent(config -> properties.setProperty(CONFIGURATION, config.toAbsolutePath().toString()));
         if(options.noEmbeddedMode) {
             props.setProperty(NO_EMBED_MODE, "TRUE");
+        }
+        if (options.noAutoDeploy) {
+            props.setProperty(NO_AUTO_DEPLOY, "TRUE");
         }
     }
 

--- a/exist-core/src/main/java/org/exist/collections/MutableCollection.java
+++ b/exist-core/src/main/java/org/exist/collections/MutableCollection.java
@@ -481,7 +481,7 @@ public class MutableCollection implements Collection {
         if(recursive && subColls != null) {
             // process the child collections
             for(final XmldbURI subCol : subColls) {
-                try(final Collection child = broker.openCollection(subCol, NO_LOCK)) {      // NOTE: the recursive call below to child.addDocs will take a lock
+                try(final Collection child = broker.openCollection(subCol, INTENTION_READ)) {      // NOTE: the recursive call below to child.addDocs will take a lock
                     //A collection may have been removed in the meantime, so check first
                     if(child != null) {
                         child.allDocs(broker, docs, recursive, lockMap);

--- a/exist-core/src/main/java/org/exist/http/RESTServer.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServer.java
@@ -335,14 +335,26 @@ public class RESTServer {
                 query = getParameter(request, Query);
             }
         }
-        final String _var = getParameter(request, Variables);
-        ElementImpl variables = null;
+
+        @Nullable final String _contextItem = getParameter(request, Context_Item);
+        @Nullable ElementImpl contextItemParam = null;
         try {
-            if (_var != null) {
-                variables = parseXML(broker.getBrokerPool(), _var);
+            if (_contextItem != null) {
+                contextItemParam = parseXML(broker.getBrokerPool(), _contextItem);
             }
         } catch (final SAXException e) {
-            final XPathException x = new XPathException(variables != null ? variables.getExpression() : null, e.toString());
+            final XPathException x = new XPathException(contextItemParam != null ? contextItemParam.getExpression() : null, e.toString());
+            writeXPathException(response, HttpServletResponse.SC_BAD_REQUEST, UTF_8.name(), query, path, x);
+        }
+
+        @Nullable final String _var = getParameter(request, Variables);
+        @Nullable ElementImpl variablesParam = null;
+        try {
+            if (_var != null) {
+                variablesParam = parseXML(broker.getBrokerPool(), _var);
+            }
+        } catch (final SAXException e) {
+            final XPathException x = new XPathException(variablesParam != null ? variablesParam.getExpression() : null, e.toString());
             writeXPathException(response, HttpServletResponse.SC_BAD_REQUEST, UTF_8.name(), query, path, x);
         }
 
@@ -417,7 +429,7 @@ public class RESTServer {
         if (query != null) {
             // query parameter specified, search method does all the rest of the work
             try {
-                search(broker, transaction, query, path, null, variables, howmany, start, typed, outputProperties,
+                search(broker, transaction, query, path, null, contextItemParam, variablesParam, howmany, start, typed, outputProperties,
                         wrap, cache, request, response);
 
             } catch (final XPathException e) {
@@ -762,7 +774,8 @@ public class RESTServer {
             int howmany = 10;
             int start = 1;
             boolean typed = false;
-            ElementImpl variables = null;
+            @Nullable ElementImpl contextItemParam = null;
+            @Nullable ElementImpl variablesParam = null;
             boolean enclose = true;
             boolean cache = false;
             String query = null;
@@ -847,8 +860,11 @@ public class RESTServer {
                                     }
                                     query = buf.toString();
 
+                                } else if (Context_Item.xmlKey().equals(child.getLocalName())) {
+                                    contextItemParam = (ElementImpl) child;
+
                                 } else if (Variables.xmlKey().equals(child.getLocalName())) {
-                                    variables = (ElementImpl) child;
+                                    variablesParam = (ElementImpl) child;
 
                                 } else if (Properties.xmlKey().equals(child.getLocalName())) {
                                     Node node = child.getFirstChild();
@@ -877,7 +893,7 @@ public class RESTServer {
                     if (query != null) {
 
                         try {
-                            search(broker, transaction, query, path, null, variables,
+                            search(broker, transaction, query, path, null, contextItemParam, variablesParam,
                                     howmany, start, typed, outputProperties,
                                     enclose, cache, request, response);
                         } catch (final XPathException e) {
@@ -1273,7 +1289,8 @@ public class RESTServer {
      * @param query the XQuery
      * @param path the path of the request
      * @param namespaces any XQuery namespace bindings
-     * @param variables any XQuery variable bindings
+     * @param contextItemParam optional XQuery Context Item
+     * @param variablesParam any XQuery variable bindings
      * @param howmany the number of items in the results to return
      * @param start the start position in the results to return
      * @param typed whether the result nodes should be typed
@@ -1289,7 +1306,8 @@ public class RESTServer {
      */
     protected void search(final DBBroker broker, final Txn transaction, final String query,
         final String path, @Nullable final List<Namespace> namespaces,
-        @Nullable final ElementImpl variables, final int howmany,
+        @Nullable final ElementImpl contextItemParam,
+        @Nullable final ElementImpl variablesParam, final int howmany,
         final int start, final boolean typed,
         final Properties outputProperties, final boolean wrap,
         final boolean cache, final HttpServletRequest request,
@@ -1362,10 +1380,13 @@ public class RESTServer {
                 compilationTime = 0;
             }
 
-            declareVariables(context, variables, request, response);
+            declareVariables(context, variablesParam, request, response);
+
+            @Nullable final Item contextItem = extractContextItem(contextItemParam);
+            final Sequence contextSequence = contextItem != null ? new ValueSequence(contextItem) : null;
 
             final long executeStart = System.currentTimeMillis();
-            final Sequence resultSequence = xquery.execute(broker, compiled, null, outputProperties);
+            final Sequence resultSequence = xquery.execute(broker, compiled, contextSequence, outputProperties);
             final long executionTime = System.currentTimeMillis() - executeStart;
 
             if (LOG.isDebugEnabled()) {
@@ -1405,15 +1426,42 @@ public class RESTServer {
     }
 
     /**
+     * Extract the Context Item from the Element parameter.
+     *
+     * @param contextItem a parameter specifying the Context Item for the XQuery, or null
+     *
+     * @throws XPathException if an error occurs extracting the Context Item.
+     */
+    private @Nullable Item extractContextItem(@Nullable final ElementImpl contextItem) throws XPathException {
+        if (contextItem == null) {
+            return null;
+        }
+
+        @Nullable final NodeImpl value = contextItem.getFirstChild(new NameTest(Type.ELEMENT, Marshaller.VALUE_ELEMENT_QNAME));
+        if (value == null) {
+            return null;
+        }
+
+        try {
+            return Marshaller.demarshallValue(null, (ElementImpl) value);
+        } catch (final XMLStreamException xe) {
+            throw new XPathException((Expression) null, xe.toString());
+        }
+    }
+
+    /**
      * Pass the request, response and session objects to the XQuery context.
      *
-     * @param context
-     * @param request
-     * @param response
-     * @throws XPathException
+     * @param context the context for the XQuery
+     * @param variables variable bindings for the XQuery, or null
+     * @param request the HTTP request
+     * @param response the HTTP response
+     *
+     * @throws XPathException if an error occurs declaring variables
      */
     private HttpRequestWrapper declareVariables(final XQueryContext context,
-        final ElementImpl variables, final HttpServletRequest request,
+        @Nullable final ElementImpl variables,
+        final HttpServletRequest request,
         final HttpServletResponse response) throws XPathException {
 
         final HttpRequestWrapper reqw = new HttpRequestWrapper(request, formEncoding, containerEncoding);
@@ -1491,7 +1539,7 @@ public class RESTServer {
             }
 
             // get serialized sequence
-            final NodeImpl value = variable.getFirstChild(new NameTest(Type.ELEMENT, Marshaller.SEQUENCE_ELEMENT_QNAME));
+            @Nullable final NodeImpl value = variable.getFirstChild(new NameTest(Type.ELEMENT, Marshaller.SEQUENCE_ELEMENT_QNAME));
             final Sequence sequence;
             try {
                 sequence = value == null ? Sequence.EMPTY_SEQUENCE : Marshaller.demarshall(context, value);

--- a/exist-core/src/main/java/org/exist/http/RESTServer.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServer.java
@@ -107,7 +107,6 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.AttributesImpl;
-import org.xml.sax.helpers.XMLFilterImpl;
 import xyz.elemental.mediatype.MediaType;
 import xyz.elemental.mediatype.MediaTypeResolver;
 
@@ -337,13 +336,10 @@ public class RESTServer {
             }
         }
         final String _var = getParameter(request, Variables);
-        List /*<Namespace>*/ namespaces = null;
         ElementImpl variables = null;
         try {
             if (_var != null) {
-                final NamespaceExtractor nsExtractor = new NamespaceExtractor();
-                variables = parseXML(broker.getBrokerPool(), _var, nsExtractor);
-                namespaces = nsExtractor.getNamespaces();
+                variables = parseXML(broker.getBrokerPool(), _var);
             }
         } catch (final SAXException e) {
             final XPathException x = new XPathException(variables != null ? variables.getExpression() : null, e.toString());
@@ -421,7 +417,7 @@ public class RESTServer {
         if (query != null) {
             // query parameter specified, search method does all the rest of the work
             try {
-                search(broker, transaction, query, path, namespaces, variables, howmany, start, typed, outputProperties,
+                search(broker, transaction, query, path, null, variables, howmany, start, typed, outputProperties,
                         wrap, cache, request, response);
 
             } catch (final XPathException e) {
@@ -773,8 +769,7 @@ public class RESTServer {
 
             try {
                 final String content = getRequestContent(request);
-                final NamespaceExtractor nsExtractor = new NamespaceExtractor();
-                final ElementImpl root = parseXML(broker.getBrokerPool(), content, nsExtractor);
+                final ElementImpl root = parseXML(broker.getBrokerPool(), content);
                 final String rootNS = root.getNamespaceURI();
 
                 if (rootNS != null && rootNS.equals(Namespaces.EXIST_NS)) {
@@ -882,7 +877,7 @@ public class RESTServer {
                     if (query != null) {
 
                         try {
-                            search(broker, transaction, query, path, nsExtractor.getNamespaces(), variables,
+                            search(broker, transaction, query, path, null, variables,
                                     howmany, start, typed, outputProperties,
                                     enclose, cache, request, response);
                         } catch (final XPathException e) {
@@ -979,22 +974,19 @@ public class RESTServer {
         }
     }
 
-    private ElementImpl parseXML(final BrokerPool pool, final String content,
-            final NamespaceExtractor nsExtractor)
-            throws SAXException, IOException {
+    private ElementImpl parseXML(final BrokerPool pool, final String content) throws SAXException, IOException {
         final InputSource src = new InputSource(new StringReader(content));
         final XMLReaderPool parserPool = pool.getParserPool();
         XMLReader reader = null;
         try {
             reader = parserPool.borrowXMLReader();
             final SAXAdapter adapter = new SAXAdapter((Expression) null);
-            nsExtractor.setContentHandler(adapter);
+
+            reader.setContentHandler(adapter);
             reader.setProperty(Namespaces.SAX_LEXICAL_HANDLER, adapter);
-            nsExtractor.setParent(reader);
-            nsExtractor.parse(src);
+            reader.parse(src);
 
             final Document doc = adapter.getDocument();
-
             return (ElementImpl) doc.getDocumentElement();
         } finally {
             if (reader != null) {
@@ -1003,41 +995,13 @@ public class RESTServer {
         }
     }
 
-    private class NamespaceExtractor extends XMLFilterImpl {
-
-        final List<Namespace> namespaces = new ArrayList<>();
-
-        @Override
-        public void startPrefixMapping(final String prefix, final String uri)
-            throws SAXException {
-            if (!Namespaces.EXIST_NS.equals(uri)) {
-                final Namespace ns = new Namespace(prefix, uri);
-                namespaces.add(ns);
-            }
-            super.startPrefixMapping(prefix, uri);
-        }
-
-        public List<Namespace> getNamespaces() {
-            return namespaces;
-        }
-    }
-
     public static class Namespace {
-
-        private final String prefix;
-        private final String uri;
+        final String prefix;
+        final String uri;
 
         public Namespace(final String prefix, final String uri) {
             this.prefix = prefix;
             this.uri = uri;
-        }
-
-        public String getPrefix() {
-            return prefix;
-        }
-
-        public String getUri() {
-            return uri;
         }
     }
 
@@ -1324,11 +1288,11 @@ public class RESTServer {
      * @throws XPathException if the XQuery raises an error
      */
     protected void search(final DBBroker broker, final Txn transaction, final String query,
-        final String path, final List<Namespace> namespaces,
-        final ElementImpl variables, final int howmany, final int start,
-        final boolean typed, final Properties outputProperties,
-        final boolean wrap, final boolean cache,
-        final HttpServletRequest request,
+        final String path, @Nullable final List<Namespace> namespaces,
+        @Nullable final ElementImpl variables, final int howmany,
+        final int start, final boolean typed,
+        final Properties outputProperties, final boolean wrap,
+        final boolean cache, final HttpServletRequest request,
         final HttpServletResponse response) throws BadRequestException,
         PermissionDeniedException, XPathException {
 
@@ -1430,15 +1394,13 @@ public class RESTServer {
         }
     }
 
-    private void declareNamespaces(final XQueryContext context,
-        final List<Namespace> namespaces) throws XPathException {
-
+    private void declareNamespaces(final XQueryContext context, @Nullable final List<Namespace> namespaces) throws XPathException {
         if (namespaces == null) {
             return;
         }
 
         for (final Namespace ns : namespaces) {
-            context.declareNamespace(ns.getPrefix(), ns.getUri());
+            context.declareNamespace(ns.prefix, ns.uri);
         }
     }
 

--- a/exist-core/src/main/java/org/exist/http/RESTServer.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServer.java
@@ -1458,7 +1458,7 @@ public class RESTServer {
         final ResponseWrapper respw = new HttpResponseWrapper(response);
         context.setHttpContext(new XQueryContext.HttpContext(reqw, respw));
 
-        //enable EXQuery Request Module (if present)
+        // enable EXQuery Request Module (if present)
         try {
             if(xqueryContextExqueryRequestAttribute != null && cstrHttpServletRequestAdapter != null) {
                 final HttpRequest exqueryRequestAdapter = cstrHttpServletRequestAdapter.apply(request, () -> (String)context.getBroker().getConfiguration().getProperty(Configuration.BINARY_CACHE_CLASS_PROPERTY));
@@ -2050,10 +2050,10 @@ public class RESTServer {
             serializer.setOutput(writer, defaultProperties);
 
             serializer.startDocument();
-            serializer.startPrefixMapping("exist", Namespaces.EXIST_NS);
+            serializer.startPrefixMapping(Namespaces.EXIST_NS_PREFIX, Namespaces.EXIST_NS);
 
             if (wrap) {
-                serializer.startElement(Namespaces.EXIST_NS, "result", "exist:result", null);
+                serializer.startElement(Namespaces.EXIST_NS, "result", Namespaces.EXIST_NS_PREFIX + ":result", null);
             }
 
             final AttributesImpl attrs = new AttributesImpl();
@@ -2073,8 +2073,7 @@ public class RESTServer {
 
             addPermissionAttributes(attrs, collection.getPermissionsNoLock());
 
-            serializer.startElement(Namespaces.EXIST_NS, "collection",
-                    "exist:collection", attrs);
+            serializer.startElement(Namespaces.EXIST_NS, "collection", Namespaces.EXIST_NS_PREFIX + ":collection", attrs);
 
             for (final Iterator<XmldbURI> i = collection.collectionIterator(broker); i.hasNext();) {
                 final XmldbURI child = i.next();
@@ -2097,8 +2096,8 @@ public class RESTServer {
                     }
 
                     addPermissionAttributes(attrs, childCollection.getPermissionsNoLock());
-                    serializer.startElement(Namespaces.EXIST_NS, "collection", "exist:collection", attrs);
-                    serializer.endElement(Namespaces.EXIST_NS, "collection", "exist:collection");
+                    serializer.startElement(Namespaces.EXIST_NS, "collection", Namespaces.EXIST_NS_PREFIX + ":collection", attrs);
+                    serializer.endElement(Namespaces.EXIST_NS, "collection", Namespaces.EXIST_NS_PREFIX + ":collection");
                 }
             }
 
@@ -2135,15 +2134,15 @@ public class RESTServer {
                     }
 
                     addPermissionAttributes(attrs, doc.getPermissions());
-                    serializer.startElement(Namespaces.EXIST_NS, "resource", "exist:resource", attrs);
-                    serializer.endElement(Namespaces.EXIST_NS, "resource", "exist:resource");
+                    serializer.startElement(Namespaces.EXIST_NS, "resource", Namespaces.EXIST_NS_PREFIX + ":resource", attrs);
+                    serializer.endElement(Namespaces.EXIST_NS, "resource", Namespaces.EXIST_NS_PREFIX + ":resource");
                 }
             }
 
-            serializer.endElement(Namespaces.EXIST_NS, "collection", "exist:collection");
+            serializer.endElement(Namespaces.EXIST_NS, "collection", Namespaces.EXIST_NS_PREFIX + ":collection");
 
             if (wrap) {
-                serializer.endElement(Namespaces.EXIST_NS, "result", "exist:result");
+                serializer.endElement(Namespaces.EXIST_NS, "result", Namespaces.EXIST_NS_PREFIX + ":result");
             }
 
             serializer.endDocument();

--- a/exist-core/src/main/java/org/exist/http/RESTServer.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServer.java
@@ -347,6 +347,17 @@ public class RESTServer {
             writeXPathException(response, HttpServletResponse.SC_BAD_REQUEST, UTF_8.name(), query, path, x);
         }
 
+        @Nullable final String _defaultCollection = getParameter(request, Default_Collection);
+        @Nullable ElementImpl defaultCollectionParam = null;
+        try {
+            if (_defaultCollection != null) {
+                defaultCollectionParam = parseXML(broker.getBrokerPool(), _defaultCollection);
+            }
+        } catch (final SAXException e) {
+            final XPathException x = new XPathException(defaultCollectionParam != null ? defaultCollectionParam.getExpression() : null, e.toString());
+            writeXPathException(response, HttpServletResponse.SC_BAD_REQUEST, UTF_8.name(), query, path, x);
+        }
+
         @Nullable final String _var = getParameter(request, Variables);
         @Nullable ElementImpl variablesParam = null;
         try {
@@ -429,7 +440,7 @@ public class RESTServer {
         if (query != null) {
             // query parameter specified, search method does all the rest of the work
             try {
-                search(broker, transaction, query, path, null, contextItemParam, variablesParam, howmany, start, typed, outputProperties,
+                search(broker, transaction, query, path, null, contextItemParam, defaultCollectionParam, variablesParam, howmany, start, typed, outputProperties,
                         wrap, cache, request, response);
 
             } catch (final XPathException e) {
@@ -775,6 +786,7 @@ public class RESTServer {
             int start = 1;
             boolean typed = false;
             @Nullable ElementImpl contextItemParam = null;
+            @Nullable ElementImpl defaultCollectionParam = null;
             @Nullable ElementImpl variablesParam = null;
             boolean enclose = true;
             boolean cache = false;
@@ -863,6 +875,9 @@ public class RESTServer {
                                 } else if (Context_Item.xmlKey().equals(child.getLocalName())) {
                                     contextItemParam = (ElementImpl) child;
 
+                                } else if (Default_Collection.xmlKey().equals(child.getLocalName())) {
+                                    defaultCollectionParam = (ElementImpl) child;
+
                                 } else if (Variables.xmlKey().equals(child.getLocalName())) {
                                     variablesParam = (ElementImpl) child;
 
@@ -893,7 +908,7 @@ public class RESTServer {
                     if (query != null) {
 
                         try {
-                            search(broker, transaction, query, path, null, contextItemParam, variablesParam,
+                            search(broker, transaction, query, path, null, contextItemParam, defaultCollectionParam, variablesParam,
                                     howmany, start, typed, outputProperties,
                                     enclose, cache, request, response);
                         } catch (final XPathException e) {
@@ -1290,6 +1305,7 @@ public class RESTServer {
      * @param path the path of the request
      * @param namespaces any XQuery namespace bindings
      * @param contextItemParam optional XQuery Context Item
+     * @param defaultCollectionParam optional XQuery Default Collection
      * @param variablesParam any XQuery variable bindings
      * @param howmany the number of items in the results to return
      * @param start the start position in the results to return
@@ -1307,6 +1323,7 @@ public class RESTServer {
     protected void search(final DBBroker broker, final Txn transaction, final String query,
         final String path, @Nullable final List<Namespace> namespaces,
         @Nullable final ElementImpl contextItemParam,
+        @Nullable final ElementImpl defaultCollectionParam,
         @Nullable final ElementImpl variablesParam, final int howmany,
         final int start, final boolean typed,
         final Properties outputProperties, final boolean wrap,
@@ -1380,6 +1397,7 @@ public class RESTServer {
                 compilationTime = 0;
             }
 
+            setupDefaultCollection(context, defaultCollectionParam);
             declareVariables(context, variablesParam, request, response);
 
             @Nullable final Item contextItem = extractContextItem(contextItemParam);
@@ -1444,6 +1462,26 @@ public class RESTServer {
 
         try {
             return Marshaller.demarshallValue(null, (ElementImpl) value);
+        } catch (final XMLStreamException xe) {
+            throw new XPathException((Expression) null, xe.toString());
+        }
+    }
+
+    private void setupDefaultCollection(final XQueryContext context, @Nullable final ElementImpl defaultCollectionParam) throws XPathException {
+        if (defaultCollectionParam == null) {
+            return;
+        }
+
+        @Nullable final NodeImpl value = defaultCollectionParam.getFirstChild(new NameTest(Type.ELEMENT, Marshaller.SEQUENCE_ELEMENT_QNAME));
+        if (value == null) {
+            return;
+        }
+
+        try {
+            @Nullable final Sequence sequence = Marshaller.demarshall(context, value);
+            if (sequence != null) {
+                context.addDynamicallyAvailableCollection("", (broker, txn, uri) -> sequence);
+            }
         } catch (final XMLStreamException xe) {
             throw new XPathException((Expression) null, xe.toString());
         }

--- a/exist-core/src/main/java/org/exist/http/RESTServerParameter.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServerParameter.java
@@ -25,7 +25,7 @@ package org.exist.http;
  * Enumeration of each Parameter
  * used by the RESTServer
  * 
- * @author <a href="mailto:adam@exist-db.org">Adam Retter</a>
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
 enum RESTServerParameter {
         
@@ -76,11 +76,27 @@ enum RESTServerParameter {
      *  encoding? = string
      *  method? = string>
      *      (exist:text,
+     *      exist:context-item?,
      *      exist:variables?,
      *      exist:properties?)
      * </exist:query>
      */
     Query,
+
+    /**
+     * Can be used in either the Query String of a GET request
+     * or in the body of a POST request to specify a value
+     * for the XQuery Context item.
+     *
+     * Contexts: GET, POST
+     *
+     * The value of this prarameter, is an XML element with the format
+     *
+     * <exist:context-item>
+     *     (sx:value)
+     * </exist:context-item>
+     */
+    Context_Item,
 
     /**
      * Can be used in either the Query String of a GET request

--- a/exist-core/src/main/java/org/exist/http/RESTServerParameter.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServerParameter.java
@@ -77,6 +77,7 @@ enum RESTServerParameter {
      *  method? = string>
      *      (exist:text,
      *      exist:context-item?,
+     *      exist:default-collection?
      *      exist:variables?,
      *      exist:properties?)
      * </exist:query>
@@ -97,6 +98,21 @@ enum RESTServerParameter {
      * </exist:context-item>
      */
     Context_Item,
+
+    /**
+     * Can be used in either the Query String of a GET request
+     * or in the body of a POST request to specify the values
+     * for the Default Collection of the XQuery Dynamic Context.
+     *
+     * Contexts: GET, POST
+     *
+     * The value of this prarameter, is an XML element with the format
+     *
+     * <exist:default-collection>
+     *     (sx:sequence)
+     * </exist:default-collection>
+     */
+    Default_Collection,
 
     /**
      * Can be used in either the Query String of a GET request

--- a/exist-core/src/main/java/org/exist/jetty/JettyStart.java
+++ b/exist-core/src/main/java/org/exist/jetty/JettyStart.java
@@ -65,12 +65,18 @@ import org.exist.start.StartException;
 import org.exist.storage.BrokerPool;
 import org.exist.util.ConfigurationHelper;
 import org.exist.util.FileUtils;
+import org.exist.util.OSUtil;
 import org.exist.util.SingleInstanceConfiguration;
+import org.exist.util.SystemExitCodes;
 import org.exist.validation.XmlLibraryChecker;
 import org.exist.xmldb.DatabaseImpl;
 import org.exist.xmldb.ShutdownListener;
 import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Database;
+import se.softhouse.jargo.Argument;
+import se.softhouse.jargo.ArgumentException;
+import se.softhouse.jargo.CommandLineParser;
+import se.softhouse.jargo.ParsedArguments;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -83,7 +89,10 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static org.exist.repo.AutoDeploymentTrigger.AUTODEPLOY_PROPERTY;
+import static org.exist.util.ArgumentUtil.getBool;
 import static org.exist.util.ThreadUtils.newGlobalThread;
+import static se.softhouse.jargo.Arguments.*;
 
 /**
  * This class provides a main method to start Jetty with eXist. It registers shutdown
@@ -108,6 +117,19 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
     private final static int STATUS_STOPPING = 2;
     private final static int STATUS_STOPPED = 3;
 
+    /* general arguments */
+    private static final Argument<String> jettyConfigFilePath = stringArgument()
+            .description("Path to Jetty Config File")
+            .build();
+    private static final Argument<String> existConfigFilePath = stringArgument()
+            .description("Path to Elemental Config File")
+            .build();
+    private static final Argument<Boolean> noAutoDeployArg = optionArgument("-a", "--no-auto-deploy")
+        .description("Disable auto-deployment of EXPath Packages")
+        .defaultValue(false)
+        .build();
+    private static final Argument<?> helpArg = helpArgument("-h", "--help");
+
     @GuardedBy("this") private int status = STATUS_STOPPED;
     @GuardedBy("this") private Optional<Thread> shutdownHookThread = Optional.empty();
     @GuardedBy("this") private int primaryPort = 8080;
@@ -116,11 +138,26 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
     public static void main(final String[] args) {
         try {
             CompatibleJavaVersionCheck.checkForCompatibleJavaVersion();
+
+            final ParsedArguments arguments = CommandLineParser
+                    .withArguments(jettyConfigFilePath, existConfigFilePath)
+                    .andArguments(noAutoDeployArg, helpArg)
+                    .programName("startup" + (OSUtil.IS_WINDOWS ? ".bat" : ".sh"))
+                    .parse(args);
+
+            final boolean noAutoDeploy = getBool(arguments, noAutoDeployArg);
+            if (noAutoDeploy) {
+                System.setProperty(AUTODEPLOY_PROPERTY, "off");
+            }
+
         } catch (final StartException e) {
             if (e.getMessage() != null && !e.getMessage().isEmpty()) {
                 System.err.println(e.getMessage());
             }
             System.exit(e.getErrorCode());
+        } catch (final ArgumentException e) {
+            System.out.println(e.getMessageAndUsage());
+            System.exit(SystemExitCodes.INVALID_ARGUMENT_EXIT_CODE);
         }
 
         final JettyStart start = new JettyStart();

--- a/exist-core/src/main/java/org/exist/storage/serializers/Serializer.java
+++ b/exist-core/src/main/java/org/exist/storage/serializers/Serializer.java
@@ -52,6 +52,7 @@ import java.net.URISyntaxException;
 import java.util.*;
 
 import javax.annotation.Nullable;
+import javax.xml.XMLConstants;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Source;
 import javax.xml.transform.Templates;
@@ -1087,7 +1088,7 @@ public abstract class Serializer implements XMLReader {
             documentStarted = true;
         }
         if (wrap) {
-            receiver.startPrefixMapping("exist", Namespaces.EXIST_NS);
+            receiver.startPrefixMapping(Namespaces.EXIST_NS_PREFIX, Namespaces.EXIST_NS);
             receiver.startElement(ELEM_RESULT_QNAME, attrs);
         }
 
@@ -1102,7 +1103,7 @@ public abstract class Serializer implements XMLReader {
 
         if (wrap) {
             receiver.endElement(ELEM_RESULT_QNAME);
-            receiver.endPrefixMapping("exist");
+            receiver.endPrefixMapping(Namespaces.EXIST_NS_PREFIX);
         }
         receiver.endDocument();
     }
@@ -1174,7 +1175,7 @@ public abstract class Serializer implements XMLReader {
         }
 
         if (wrap) {
-            receiver.startPrefixMapping("exist", Namespaces.EXIST_NS);
+            receiver.startPrefixMapping(Namespaces.EXIST_NS_PREFIX, Namespaces.EXIST_NS);
             receiver.startElement(ELEM_RESULT_QNAME, attrs);
         }
 
@@ -1182,7 +1183,7 @@ public abstract class Serializer implements XMLReader {
 
         if (wrap) {
             receiver.endElement(ELEM_RESULT_QNAME);
-            receiver.endPrefixMapping("exist");
+            receiver.endPrefixMapping(Namespaces.EXIST_NS_PREFIX);
         }
 
         receiver.endDocument();

--- a/exist-core/src/main/java/org/exist/storage/serializers/Serializer.java
+++ b/exist-core/src/main/java/org/exist/storage/serializers/Serializer.java
@@ -1081,7 +1081,7 @@ public abstract class Serializer implements XMLReader {
             attrs.addAttribute(ATTR_SESSION_ID, outputProperties.getProperty(PROPERTY_SESSION_ID));
         }
         attrs.addAttribute(ATTR_COMPILATION_TIME_QNAME, Long.toString(compilationTime));
-        attrs.addAttribute(ATTR_EXECUTION_TIME_QNAME, Long.toString(compilationTime));
+        attrs.addAttribute(ATTR_EXECUTION_TIME_QNAME, Long.toString(executionTime));
 
         if (!documentStarted) {
             receiver.startDocument();

--- a/exist-core/src/main/java/org/exist/storage/serializers/Serializer.java
+++ b/exist-core/src/main/java/org/exist/storage/serializers/Serializer.java
@@ -1089,6 +1089,9 @@ public abstract class Serializer implements XMLReader {
         }
         if (wrap) {
             receiver.startPrefixMapping(Namespaces.EXIST_NS_PREFIX, Namespaces.EXIST_NS);
+            if (typed) {
+                receiver.startPrefixMapping(Namespaces.SCHEMA_NS_PREFIX, Namespaces.SCHEMA_NS);
+            }
             receiver.startElement(ELEM_RESULT_QNAME, attrs);
         }
 
@@ -1103,6 +1106,9 @@ public abstract class Serializer implements XMLReader {
 
         if (wrap) {
             receiver.endElement(ELEM_RESULT_QNAME);
+            if (typed) {
+                receiver.endPrefixMapping(Namespaces.SCHEMA_NS_PREFIX);
+            }
             receiver.endPrefixMapping(Namespaces.EXIST_NS_PREFIX);
         }
         receiver.endDocument();
@@ -1176,6 +1182,9 @@ public abstract class Serializer implements XMLReader {
 
         if (wrap) {
             receiver.startPrefixMapping(Namespaces.EXIST_NS_PREFIX, Namespaces.EXIST_NS);
+            if (typed) {
+                receiver.startPrefixMapping(Namespaces.SCHEMA_NS_PREFIX, Namespaces.SCHEMA_NS);
+            }
             receiver.startElement(ELEM_RESULT_QNAME, attrs);
         }
 
@@ -1183,6 +1192,9 @@ public abstract class Serializer implements XMLReader {
 
         if (wrap) {
             receiver.endElement(ELEM_RESULT_QNAME);
+            if (typed) {
+                receiver.endPrefixMapping(Namespaces.SCHEMA_NS_PREFIX);
+            }
             receiver.endPrefixMapping(Namespaces.EXIST_NS_PREFIX);
         }
 

--- a/exist-core/src/main/java/org/exist/test/ExistEmbeddedServer.java
+++ b/exist-core/src/main/java/org/exist/test/ExistEmbeddedServer.java
@@ -94,7 +94,7 @@ public class ExistEmbeddedServer extends ExternalResource {
         this(instanceName, configFile, configProperties, false, false);
     }
 
-    public ExistEmbeddedServer(@Nullable final String instanceName, @Nullable final Path configFile, @Nullable final Properties configProperties, @Nullable final boolean disableAutoDeploy, @Nullable final boolean useTemporaryStorage) {
+    public ExistEmbeddedServer(@Nullable final String instanceName, @Nullable final Path configFile, @Nullable final Properties configProperties, final boolean disableAutoDeploy, final boolean useTemporaryStorage) {
         this.instanceName = Optional.ofNullable(instanceName);
         this.configFile = Optional.ofNullable(configFile);
         this.configProperties = Optional.ofNullable(configProperties);

--- a/exist-core/src/main/java/org/exist/test/ExistEmbeddedServer.java
+++ b/exist-core/src/main/java/org/exist/test/ExistEmbeddedServer.java
@@ -52,6 +52,8 @@ public class ExistEmbeddedServer extends ExternalResource {
 
     private static final Logger LOG =  LogManager.getLogger(ExistEmbeddedServer.class);
 
+    public static final String USE_TEMPORARY_STORAGE_PROPERTY = "exist.use-temporary-storage";
+
     private final Optional<String> instanceName;
     private final Optional<Path> configFile;
     private final Optional<Properties> configProperties;
@@ -141,7 +143,8 @@ public class ExistEmbeddedServer extends ExternalResource {
                 }
             });
 
-            if (useTemporaryStorage) {
+            final boolean propUseTemporaryStorage = Boolean.parseBoolean(System.getProperty(USE_TEMPORARY_STORAGE_PROPERTY, "false"));
+            if (useTemporaryStorage || propUseTemporaryStorage) {
                 if (!temporaryStorage.isPresent()) {
                     this.temporaryStorage = Optional.of(Files.createTempDirectory("org.exist.test.ExistEmbeddedServer"));
                 }
@@ -196,7 +199,8 @@ public class ExistEmbeddedServer extends ExternalResource {
             // clear instance variables
             pool = null;
 
-            if(useTemporaryStorage && temporaryStorage.isPresent() && clearTemporaryStorage) {
+            final boolean propUseTemporaryStorage = Boolean.parseBoolean(System.getProperty(USE_TEMPORARY_STORAGE_PROPERTY, "false"));
+            if((useTemporaryStorage || propUseTemporaryStorage) && temporaryStorage.isPresent() && clearTemporaryStorage) {
                 FileUtils.deleteQuietly(temporaryStorage.get());
                 temporaryStorage = Optional.empty();
             }

--- a/exist-core/src/main/java/org/exist/test/ExistWebServer.java
+++ b/exist-core/src/main/java/org/exist/test/ExistWebServer.java
@@ -48,6 +48,8 @@ public class ExistWebServer extends ExternalResource {
 
     private static final Logger LOG =  LogManager.getLogger(ExistWebServer.class);
 
+    public static final String USE_TEMPORARY_STORAGE_PROPERTY = "exist.use-temporary-storage";
+
     private static final String CONFIG_PROP_FILES = "org.exist.db-connection.files";
     private static final String CONFIG_PROP_JOURNAL_DIR = "org.exist.db-connection.recovery.journal-dir";
 
@@ -113,7 +115,8 @@ public class ExistWebServer extends ExternalResource {
         }
 
         if (server == null) {
-            if(useTemporaryStorage) {
+            final boolean propUseTemporaryStorage = Boolean.parseBoolean(System.getProperty(USE_TEMPORARY_STORAGE_PROPERTY, "false"));
+            if(useTemporaryStorage || propUseTemporaryStorage) {
                 this.temporaryStorage = Optional.of(Files.createTempDirectory("org.exist.test.ExistWebServer"));
                 final String absTemporaryStorage = temporaryStorage.get().toAbsolutePath().toString();
                 System.setProperty(CONFIG_PROP_FILES, absTemporaryStorage);
@@ -166,7 +169,8 @@ public class ExistWebServer extends ExternalResource {
             server.shutdown();
             server = null;
 
-            if(useTemporaryStorage && temporaryStorage.isPresent()) {
+            final boolean propUseTemporaryStorage = Boolean.parseBoolean(System.getProperty(USE_TEMPORARY_STORAGE_PROPERTY, "false"));
+            if((useTemporaryStorage || propUseTemporaryStorage) && temporaryStorage.isPresent()) {
                 FileUtils.deleteQuietly(temporaryStorage.get());
                 temporaryStorage = Optional.empty();
                 System.clearProperty(CONFIG_PROP_JOURNAL_DIR);

--- a/exist-core/src/main/java/org/exist/util/Collations.java
+++ b/exist-core/src/main/java/org/exist/util/Collations.java
@@ -274,6 +274,7 @@ public class Collations {
         } else if (uri.startsWith("java:")) {
             // java class specified: this should be a subclass of
             // com.ibm.icu.text.RuleBasedCollator
+            // TODO(AR) RuleBasedCollator is a final class - we should only need to sub-class Collator.class
             final String uriClassName = uri.substring("java:".length());
             try {
                 final Class<?> collatorClass = Class.forName(uriClassName);

--- a/exist-core/src/main/java/org/exist/util/Configuration.java
+++ b/exist-core/src/main/java/org/exist/util/Configuration.java
@@ -166,16 +166,27 @@ public class Configuration implements ErrorHandler
             // firstly, try to read the configuration from a file within the
             // classpath
             try {
-                is = Configuration.class.getClassLoader().getResourceAsStream(configFilename);
 
-                if(is != null) {
-                    LOG.info("Reading configuration from classloader");
+                // 1. we try the root of the class hierarchy
+                is = Configuration.class.getClassLoader().getResourceAsStream(configFilename);
+                if (is != null) {
                     configFilePath = Optional.of(Paths.get(Configuration.class.getClassLoader().getResource(configFilename).toURI()));
+                    LOG.info("Reading configuration from Class Loader: " + configFilePath.get());
                 }
-            } catch(final Exception e) {
+
+                if (is == null) {
+                    // 2. we try the package org.exist.util
+                    is = Configuration.class.getResourceAsStream(configFilename);
+                    if (is != null) {
+                        configFilePath = Optional.of(Paths.get(Configuration.class.getResource(configFilename).toURI()));
+                        LOG.info("Reading configuration from Classpath org.exist.util: " + configFilePath.get());
+                    }
+                }
+
+            } catch (final Exception e) {
                 // EB: ignore and go forward, e.g. in case there is an absolute
                 // file name for configFileName
-                LOG.debug( e );
+                LOG.debug(e);
             }
 
             // otherwise, secondly try to read configuration from file. Guess the

--- a/exist-core/src/main/java/org/exist/xmldb/DatabaseImpl.java
+++ b/exist-core/src/main/java/org/exist/xmldb/DatabaseImpl.java
@@ -50,6 +50,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.exist.repo.AutoDeploymentTrigger.AUTODEPLOY_PROPERTY;
+
 /**
  * The XMLDB driver class for eXist. This driver manages two different
  * internal implementations. The first communicates with a remote
@@ -100,6 +102,8 @@ public class DatabaseImpl implements Database {
     private Boolean ssl_allow_self_signed = true;
     private Boolean ssl_verify_hostname = false;
 
+    private Boolean no_autodeploy = false;
+
     public DatabaseImpl() {
         final String initdb = System.getProperty("exist.initdb");
         if (initdb != null) {
@@ -120,6 +124,10 @@ public class DatabaseImpl implements Database {
             }
             if (journalDir != null) {
                 config.setProperty(Journal.PROPERTY_RECOVERY_JOURNAL_DIR, Paths.get(journalDir));
+            }
+
+            if (no_autodeploy) {
+                System.setProperty(AUTODEPLOY_PROPERTY, "off");
             }
 
             BrokerPool.configure(instanceName, 1, 5, config);
@@ -382,6 +390,7 @@ public class DatabaseImpl implements Database {
     public final static String DATA_DIR = "data-dir";
     public final static String JOURNAL_DIR = "journal-dir";
     public final static String SSL_ENABLE = "ssl-enable";
+    public final static String NO_AUTODEPLOY = "no-autodeploy";
     public final static String SSL_ALLOW_SELF_SIGNED = "ssl-allow-self-signed";
     public final static String SSL_VERIFY_HOSTNAME = "ssl-verify-hostname";
 
@@ -419,6 +428,10 @@ public class DatabaseImpl implements Database {
 
             case SSL_VERIFY_HOSTNAME:
                 value = ssl_verify_hostname.toString();
+                break;
+
+            case NO_AUTODEPLOY:
+                value = no_autodeploy.toString();
                 break;
 
             default:
@@ -460,6 +473,10 @@ public class DatabaseImpl implements Database {
 
             case SSL_VERIFY_HOSTNAME:
                 this.ssl_verify_hostname = Boolean.valueOf(value);
+                break;
+
+            case NO_AUTODEPLOY:
+                this.no_autodeploy = Boolean.valueOf(value);
                 break;
         }
     }

--- a/exist-core/src/main/java/org/exist/xqj/Marshaller.java
+++ b/exist-core/src/main/java/org/exist/xqj/Marshaller.java
@@ -251,7 +251,8 @@ public class Marshaller {
         if (!SEQ_ELEMENT.equals(parser.getLocalName())) {
             throw new XMLStreamException("Root element should be a " + SEQ_ELEMENT_PREFIXED_NAME);
         }
-        final ValueSequence result = new ValueSequence();
+
+        Sequence result = Sequence.EMPTY_SEQUENCE;
         while ((event = parser.next()) != XMLStreamConstants.END_DOCUMENT) {
             switch (event) {
                 case XMLStreamConstants.START_ELEMENT :
@@ -275,6 +276,10 @@ public class Marshaller {
                             item = streamToDOM(type, parser, null);
                         } else {
                             item = new StringValue(null, parser.getElementText()).convertTo(type);
+                        }
+
+                        if (result == Sequence.EMPTY_SEQUENCE) {
+                            result = new ValueSequence();
                         }
                         result.add(item);
                     }
@@ -308,10 +313,14 @@ public class Marshaller {
     }
 
     private static Sequence demarshallValues(final XQueryContext context, final NodeImpl node) throws XMLStreamException, XPathException {
-        final ValueSequence result = new ValueSequence();
         final InMemoryNodeSet sxValues = new InMemoryNodeSet();
         node.selectChildren(new NameTest(Type.ELEMENT, VALUE_ELEMENT_QNAME), sxValues);
 
+        if (sxValues.isEmpty()) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
+        final ValueSequence result = new ValueSequence(sxValues.size());
         for (final SequenceIterator itSxValue = sxValues.iterate(); itSxValue.hasNext();) {
             final ElementImpl sxValue = (ElementImpl) itSxValue.nextItem();
             final Item item = demarshallValue(context, sxValue);

--- a/exist-core/src/main/java/org/exist/xqj/Marshaller.java
+++ b/exist-core/src/main/java/org/exist/xqj/Marshaller.java
@@ -100,15 +100,13 @@ public class Marshaller {
     public final static String NAMESPACE = "http://exist-db.org/xquery/types/serialized";
     public final static String PREFIX = "sx";
 
-    
     private final static Properties DEFAULT_OUTPUT_PROPERTIES = new Properties();
 
     private final static String VALUE_ELEMENT = "value";
-    private final static String VALUE_ELEMENT_QNAME = PREFIX + ":value";
-    private final static QName VALUE_QNAME = new QName(VALUE_ELEMENT,  NAMESPACE, PREFIX);
+    private final static String VALUE_ELEMENT_PREFIXED_NAME = PREFIX + ":value";
     
     private final static String SEQ_ELEMENT = "sequence";
-    private final static String SEQ_ELEMENT_QNAME = PREFIX + ":sequence";
+    private final static String SEQ_ELEMENT_PREFIXED_NAME = PREFIX + ":sequence";
     
     private final static String ATTR_TYPE = "type";
     private final static String ATTR_ITEM_TYPE = "item-type";
@@ -116,6 +114,7 @@ public class Marshaller {
     private final static String ATTR_NAME = "name";
 
     public final static QName SEQUENCE_ELEMENT_QNAME = new QName(SEQ_ELEMENT, NAMESPACE, PREFIX);
+    public final static QName VALUE_ELEMENT_QNAME = new QName(VALUE_ELEMENT,  NAMESPACE, PREFIX);
     public final static QName ENTRY_ELEMENT_QNAME = new QName("entry", NAMESPACE, PREFIX);
     public final static QName KEY_ELEMENT_QNAME = new QName("key", NAMESPACE, PREFIX);
     
@@ -133,11 +132,11 @@ public class Marshaller {
             throws XPathException, SAXException {
         final AttributesImpl attrs = new AttributesImpl();
         attrs.addAttribute("", ATTR_ITEM_TYPE, ATTR_ITEM_TYPE, "CDATA", Type.getTypeName(seq.getItemType()));
-        handler.startElement(NAMESPACE, SEQ_ELEMENT, SEQ_ELEMENT_QNAME, attrs);
+        handler.startElement(NAMESPACE, SEQ_ELEMENT, SEQ_ELEMENT_PREFIXED_NAME, attrs);
         for (final SequenceIterator i = seq.iterate(); i.hasNext(); ) {
             marshallItem(broker, i.nextItem(), handler);
         }
-        handler.endElement(NAMESPACE, SEQ_ELEMENT, SEQ_ELEMENT_QNAME);
+        handler.endElement(NAMESPACE, SEQ_ELEMENT, SEQ_ELEMENT_PREFIXED_NAME);
     }
     
     
@@ -157,12 +156,12 @@ public class Marshaller {
             final ContentHandler handler) throws XPathException, SAXException {
         final AttributesImpl attrs = new AttributesImpl();
         attrs.addAttribute("", ATTR_ITEM_TYPE, ATTR_ITEM_TYPE, "CDATA", Type.getTypeName(seq.getItemType()));
-        handler.startElement(NAMESPACE, SEQ_ELEMENT, SEQ_ELEMENT_QNAME, attrs);
+        handler.startElement(NAMESPACE, SEQ_ELEMENT, SEQ_ELEMENT_PREFIXED_NAME, attrs);
         for (int i = start; i < howmany && i < seq.getItemCount(); i++ ) {
         	
             marshallItem(broker, seq.itemAt(i), handler);
         }
-        handler.endElement(NAMESPACE, SEQ_ELEMENT, SEQ_ELEMENT_QNAME);
+        handler.endElement(NAMESPACE, SEQ_ELEMENT, SEQ_ELEMENT_PREFIXED_NAME);
     }
 
     /**
@@ -200,15 +199,15 @@ public class Marshaller {
             {type = ((NodeValue)item).getNode().getNodeType();}
         attrs.addAttribute("", ATTR_TYPE, ATTR_TYPE, "CDATA", Type.getTypeName(type));
         if (Type.subTypeOf(item.getType(), Type.NODE)) {
-            handler.startElement(NAMESPACE, VALUE_ELEMENT, VALUE_ELEMENT_QNAME, attrs);
+            handler.startElement(NAMESPACE, VALUE_ELEMENT, VALUE_ELEMENT_PREFIXED_NAME, attrs);
             final NodeValue nv = (NodeValue) item;
             nv.toSAX(broker, handler, outputProperties);
-            handler.endElement(NAMESPACE, VALUE_ELEMENT, VALUE_ELEMENT_QNAME);
+            handler.endElement(NAMESPACE, VALUE_ELEMENT, VALUE_ELEMENT_PREFIXED_NAME);
         } else {
-            handler.startElement(NAMESPACE, VALUE_ELEMENT, VALUE_ELEMENT_QNAME, attrs);
+            handler.startElement(NAMESPACE, VALUE_ELEMENT, VALUE_ELEMENT_PREFIXED_NAME, attrs);
             final String value = item.getStringValue();
             handler.characters(value.toCharArray(), 0, value.length());
-            handler.endElement(NAMESPACE, VALUE_ELEMENT, VALUE_ELEMENT_QNAME);
+            handler.endElement(NAMESPACE, VALUE_ELEMENT, VALUE_ELEMENT_PREFIXED_NAME);
         }
     }
 
@@ -244,11 +243,13 @@ public class Marshaller {
         while (event != XMLStreamConstants.START_ELEMENT) {
             event = parser.next();
         }
+
         if (!NAMESPACE.equals(parser.getNamespaceURI())) {
             throw new XMLStreamException("Root element is not in the correct namespace. Expected: " + NAMESPACE);
         }
+
         if (!SEQ_ELEMENT.equals(parser.getLocalName())) {
-            throw new XMLStreamException("Root element should be a " + SEQ_ELEMENT_QNAME);
+            throw new XMLStreamException("Root element should be a " + SEQ_ELEMENT_PREFIXED_NAME);
         }
         final ValueSequence result = new ValueSequence();
         while ((event = parser.next()) != XMLStreamConstants.END_DOCUMENT) {
@@ -278,12 +279,15 @@ public class Marshaller {
                         result.add(item);
                     }
                     break;
+
                 case XMLStreamConstants.END_ELEMENT :
-                    if (NAMESPACE.equals(parser.getNamespaceURI()) && SEQ_ELEMENT.equals(parser.getLocalName()))
-                        {return result;}
+                    if (NAMESPACE.equals(parser.getNamespaceURI()) && SEQ_ELEMENT.equals(parser.getLocalName())) {
+                        return result;
+                    }
                     break;
             }
         }
+
         return result;
     }
 
@@ -297,7 +301,7 @@ public class Marshaller {
             throw new XMLStreamException("Sequence element is not in the correct namespace. Expected: " + NAMESPACE);
         }
         if (!SEQ_ELEMENT.equals(node.getLocalName())) {
-            throw new XMLStreamException("Element should be a " + SEQ_ELEMENT_QNAME);
+            throw new XMLStreamException("Element should be a " + SEQ_ELEMENT_PREFIXED_NAME);
         }
 
         return demarshallValues(context, node);
@@ -306,7 +310,8 @@ public class Marshaller {
     private static Sequence demarshallValues(final XQueryContext context, final NodeImpl node) throws XMLStreamException, XPathException {
         final ValueSequence result = new ValueSequence();
         final InMemoryNodeSet sxValues = new InMemoryNodeSet();
-        node.selectChildren(new NameTest(Type.ELEMENT, VALUE_QNAME), sxValues);
+        node.selectChildren(new NameTest(Type.ELEMENT, VALUE_ELEMENT_QNAME), sxValues);
+
         for (final SequenceIterator itSxValue = sxValues.iterate(); itSxValue.hasNext();) {
             final ElementImpl sxValue = (ElementImpl) itSxValue.nextItem();
             final Item item = demarshallValue(context, sxValue);

--- a/exist-core/src/main/java/org/exist/xqj/Marshaller.java
+++ b/exist-core/src/main/java/org/exist/xqj/Marshaller.java
@@ -57,13 +57,9 @@ import org.exist.xquery.XQueryContext;
 import org.exist.xquery.functions.array.ArrayType;
 import org.exist.xquery.functions.map.MapType;
 import org.exist.xquery.value.*;
-import org.w3c.dom.Comment;
-import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import org.w3c.dom.ProcessingInstruction;
-import org.w3c.dom.Text;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
@@ -329,7 +325,7 @@ public class Marshaller {
         return result;
     }
 
-    private static Item demarshallValue(final XQueryContext context, final ElementImpl sxValue) throws XMLStreamException, XPathException {
+    public static Item demarshallValue(final XQueryContext context, final ElementImpl sxValue) throws XMLStreamException, XPathException {
         int type = Type.ITEM;
         final String typeName = sxValue.getAttribute(ATTR_TYPE);
         if (!typeName.isEmpty()) {
@@ -347,7 +343,8 @@ public class Marshaller {
         final InMemoryNodeSet sxEntries = new InMemoryNodeSet();
         sxValue.selectChildren(new NameTest(Type.ELEMENT, ENTRY_ELEMENT_QNAME), sxEntries);
 
-        Node item = sxValue.getFirstChild();
+        @Nullable Node item = null;
+        item = sxValue.getFirstChild();
 
         if (type == Type.ATTRIBUTE || (type == Type.ITEM && attrNameString != null)) {
             if (attrNameString.isEmpty()) {
@@ -383,50 +380,73 @@ public class Marshaller {
 
             switch (type) {
                 case Type.ELEMENT:
-                    if (item instanceof Document) {
-                        return (ElementImpl) ((DocumentImpl) item).getDocumentElement();
-                    } else if (!(item instanceof Element)) {
-                        throw new XMLStreamException("sx:value should only contain an Element if type is " + typeName);
-                    } else {
-                        return (ElementImpl) item;
-                    }
+                    do {
+                        if (item.getNodeType() == Node.DOCUMENT_NODE) {
+                            item = ((DocumentImpl) item).getDocumentElement();
+                        }
+
+                        if (item.getNodeType() == Node.ELEMENT_NODE) {
+                            return (ElementImpl) item;
+                        }
+
+                        item = item.getNextSibling();
+                    } while (item != null);
+
+                    throw new XMLStreamException("sx:value must contain an Element if type is " + typeName);
+
 
                 case Type.COMMENT:
-                    if (!(item instanceof Comment)) {
-                        throw new XMLStreamException("sx:value should only contain a Comment node if type is " + typeName);
-                    }
-                    return (CommentImpl) item;
+                    do {
+                        if (item.getNodeType() == Node.COMMENT_NODE) {
+                            return (CommentImpl) item;
+                        }
+                        item = item.getNextSibling();
+                    } while (item != null);
+
+                    throw new XMLStreamException("sx:value must contain a Comment node if type is " + typeName);
+
 
                 case Type.PROCESSING_INSTRUCTION:
-                    if (!(item instanceof ProcessingInstruction)) {
-                        throw new XMLStreamException("sx:value should only contain a Processing Instruction node if type is " + typeName);
-                    }
-                    return (ProcessingInstructionImpl) item;
+                    do {
+                        if (item.getNodeType() == Node.PROCESSING_INSTRUCTION_NODE) {
+                            return (ProcessingInstructionImpl) item;
+                        }
+                        item = item.getNextSibling();
+                    } while (item != null);
+
+                    throw new XMLStreamException("sx:value must contain a Processing Instruction node if type is " + typeName);
+
 
                 case Type.TEXT:
-                    if (!(item instanceof Text)) {
-                        throw new XMLStreamException("sx:value should only contain a Text node if type is " + typeName);
-                    }
-                    return (TextImpl) item;
+                    do {
+                        if (item.getNodeType() == Node.TEXT_NODE) {
+                            return (TextImpl) item;
+                        }
+                        item = item.getNextSibling();
+                    } while (item != null);
+
 
                 case Type.DOCUMENT:
                 default:
-                    if (item instanceof Document || item instanceof Element) {
-                        final DocumentBuilderReceiver receiver = new DocumentBuilderReceiver(((NodeImpl) item).getExpression());
-                        try {
-                            receiver.startDocument();
-                            ((NodeImpl) item).copyTo(null, receiver);
-                            receiver.endDocument();
-                        } catch (final SAXException e) {
-                            throw new XPathException(item != null ? ((NodeImpl) item).getExpression() : null, "Error while demarshalling node: " + e.getMessage(), e);
+                    do {
+                        if (item.getNodeType() == Node.DOCUMENT_NODE || item.getNodeType() == Node.ELEMENT_NODE) {
+                            final DocumentBuilderReceiver receiver = new DocumentBuilderReceiver(((NodeImpl) item).getExpression());
+                            try {
+                                receiver.startDocument();
+                                ((NodeImpl) item).copyTo(null, receiver);
+                                receiver.endDocument();
+                            } catch (final SAXException e) {
+                                throw new XPathException(item != null ? ((NodeImpl) item).getExpression() : null, "Error while demarshalling node: " + e.getMessage(), e);
+                            }
+                            return (NodeImpl) receiver.getDocument();
                         }
-                        return (NodeImpl) receiver.getDocument();
-                    } else {
-                        throw new XMLStreamException("sx:value should only contain a Node if type is " + typeName);
-                    }
+                        item = item.getNextSibling();
+                    } while (item != null);
+
+                    throw new XMLStreamException("sx:value must contain a Document or Element if type is " + typeName);
             }
 
-        } else if (type == Type.ITEM && !(item instanceof Text)) {
+        } else if (type == Type.ITEM && item.getNodeType() != Node.TEXT_NODE) {
             // item() type requested and we have been given a node which is not a text() node
             return (NodeImpl) item;
 
@@ -461,13 +481,13 @@ public class Marshaller {
         } else {
             // specific non-node type or text()
             final StringBuilder data = new StringBuilder();
-            while (item != null) {
-                if (!(item.getNodeType() == Node.TEXT_NODE || item.getNodeType() == Node.CDATA_SECTION_NODE)) {
-                    throw new XMLStreamException("sx:value should only contain text if type is " + typeName);
+            do {
+                if (item.getNodeType() == Node.TEXT_NODE || item.getNodeType() == Node.CDATA_SECTION_NODE) {
+                    data.append(item.getNodeValue());
                 }
-                data.append(item.getNodeValue());
                 item = item.getNextSibling();
-            }
+            } while (item != null);
+
             return new StringValue(data.toString()).convertTo(type);
         }
     }

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -1231,6 +1231,7 @@ public class XQueryContext implements BinaryValueManager, Context {
             staticDocuments = protectedDocuments.toDocumentSet();
             return staticDocuments;
         }
+
         final MutableDocumentSet ndocs = new DefaultDocumentSet(40);
 
         if (staticDocumentPaths == null) {
@@ -1269,7 +1270,8 @@ public class XQueryContext implements BinaryValueManager, Context {
                 }
             }
         }
-        staticDocuments = ndocs;
+
+        this.staticDocuments = ndocs;
         return staticDocuments;
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/ExtCollection.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/ExtCollection.java
@@ -148,13 +148,21 @@ public class ExtCollection extends Function {
     }
 
     private Sequence getDefaultCollectionItems() throws XPathException {
-        final DocumentSet staticallyKnownDocuments = context.getStaticallyKnownDocuments();
-        final Sequence items = new ValueSequence(staticallyKnownDocuments.getDocumentCount());
-        addAll(staticallyKnownDocuments, items);
+        @Nullable Sequence items = null;
 
         @Nullable final Sequence dynamicCollection = context.getDynamicallyAvailableCollection("");
         if (dynamicCollection != null) {
-            items.addAll(dynamicCollection);
+            items = new ValueSequence(dynamicCollection);
+        }
+
+        if (items == null) {
+            final DocumentSet staticallyKnownDocuments = context.getStaticallyKnownDocuments();
+            items = new ValueSequence(staticallyKnownDocuments.getDocumentCount());
+            addAll(staticallyKnownDocuments, items);
+        }
+
+        if (items == null) {
+            items = Sequence.EMPTY_SEQUENCE;
         }
 
         return items;
@@ -186,6 +194,7 @@ public class ExtCollection extends Function {
 
         } else {
             @Nullable MutableDocumentSet docs = null;
+
             final XmldbURI uri = XmldbURI.create(collectionUri);
             try (@Nullable final Collection coll = context.getBroker().openCollection(uri, Lock.LockMode.READ_LOCK)) {
                 if (coll == null) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/ExtCollection.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/ExtCollection.java
@@ -63,6 +63,7 @@ import org.exist.xquery.*;
 import org.exist.xquery.functions.xmldb.XMLDBModule;
 import org.exist.xquery.value.*;
 
+import javax.annotation.Nullable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -114,88 +115,111 @@ public class ExtCollection extends Function {
                 context.getProfiler().message(this, Profiler.START_SEQUENCES, "CONTEXT ITEM", contextItem.toSequence());
             }
         }
+
         final List<String> args = getParameterValues(contextSequence, contextItem);
-        final Sequence result;
-        try {
-            if (args.isEmpty()) {
-                final Sequence docs = toSequence(context.getStaticallyKnownDocuments());
-                final Sequence dynamicCollection = context.getDynamicallyAvailableCollection("");
-                if (dynamicCollection != null) {
-                    result = new ValueSequence();
-                    result.addAll(docs);
-                    result.addAll(dynamicCollection);
-                } else {
-                    result = docs;
-                }
-            } else {
-                final Sequence dynamicCollection = context.getDynamicallyAvailableCollection(asUri(args.get(0)).toString());
-                if (dynamicCollection != null) {
-                    result = dynamicCollection;
-                } else {
-                    final MutableDocumentSet ndocs = new DefaultDocumentSet();
-                    for (final String next : args) {
-                        final XmldbURI uri = new AnyURIValue(this, next).toXmldbURI();
-                        try (final Collection coll = context.getBroker().openCollection(uri, Lock.LockMode.READ_LOCK)) {
-                            if (coll == null) {
-                                if (context.isRaiseErrorOnFailedRetrieval()) {
-                                    throw new XPathException(this, ErrorCodes.FODC0002, "Can not access collection '" + uri + "'");
-                                }
-                            } else {
-                                if (context.inProtectedMode()) {
-                                    context.getProtectedDocs().getDocsByCollection(coll, ndocs);
-                                } else {
-                                    coll.allDocs(context.getBroker(), ndocs,
-                                            includeSubCollections, context.getProtectedDocs());
-                                }
-                            }
-                        }
-                    }
-                    result = toSequence(ndocs);
-                }
+
+        @Nullable final List<URI> collectionUris;
+        if (args.isEmpty()) {
+            collectionUris = null;
+        } else {
+            collectionUris = new ArrayList<>(args.size());
+            for (final String arg : args) {
+                collectionUris.add(asUri(arg));
             }
-        } catch (final XPathException e) { //From AnyURIValue constructor
-            e.setLocation(line, column);
-            Sequence flattenedArgs = Sequence.EMPTY_SEQUENCE;
-            try {
-                flattenedArgs = argsToSeq(contextSequence, contextItem);
-            } catch (final XPathException xe) {
-                LOG.warn(e.getMessage(), xe);
-            }
-            throw new XPathException(this, ErrorCodes.FODC0002, e.getMessage(), flattenedArgs, e);
-        } catch (final PermissionDeniedException e) {
-            Sequence flattenedArgs = Sequence.EMPTY_SEQUENCE;
-            try {
-                flattenedArgs = argsToSeq(contextSequence, contextItem);
-            } catch (final XPathException xe) {
-                LOG.warn(e.getMessage(), xe);
-            }
-            throw new XPathException(this, ErrorCodes.FODC0002, "Can not access collection '" + e.getMessage() + "'", flattenedArgs, e);
-        } catch (final LockException e) {
-            Sequence flattenedArgs = Sequence.EMPTY_SEQUENCE;
-            try {
-                flattenedArgs = argsToSeq(contextSequence, contextItem);
-            } catch (final XPathException xe) {
-                LOG.warn(e.getMessage(), xe);
-            }
-            throw new XPathException(this, ErrorCodes.FODC0002, e.getMessage(), flattenedArgs, e);
         }
 
-        // iterate through all docs and create the node set
+        final Sequence result = getCollectionItems(collectionUris);
 
         registerUpdateListener();
         if (context.getProfiler().isEnabled()) {
             context.getProfiler().end(this, "", result);
         }
+
         return result;
     }
 
-    private Sequence argsToSeq(final Sequence contextSequence, final Item contextItem) throws XPathException {
-        final ValueSequence sequence = new ValueSequence();
-        for (int i = 0; i < getArgumentCount(); i++) {
-            final Sequence seq = getArgument(i).eval(contextSequence, contextItem);
-            sequence.addAll(seq);
+    protected Sequence getCollectionItems(@Nullable final List<URI> collectionUris) throws XPathException {
+        if (collectionUris == null) {
+            // no collection-uri(s)
+            return getDefaultCollectionItems();
         }
-        return sequence;
+
+        return getCollectionUriItems(collectionUris);
+    }
+
+    private Sequence getDefaultCollectionItems() throws XPathException {
+        final DocumentSet staticallyKnownDocuments = context.getStaticallyKnownDocuments();
+        final Sequence items = new ValueSequence(staticallyKnownDocuments.getDocumentCount());
+        addAll(staticallyKnownDocuments, items);
+
+        @Nullable final Sequence dynamicCollection = context.getDynamicallyAvailableCollection("");
+        if (dynamicCollection != null) {
+            items.addAll(dynamicCollection);
+        }
+
+        return items;
+    }
+
+    private Sequence getCollectionUriItems(final List<URI> collectionUris) throws XPathException {
+        @Nullable Sequence items = null;
+        for (final URI collectionUri : collectionUris) {
+            items = getCollectionUriItems(collectionUri, items);
+        }
+
+        if (items == null) {
+            items = Sequence.EMPTY_SEQUENCE;
+        }
+
+        return items;
+    }
+
+    private @Nullable Sequence getCollectionUriItems(final URI collectionUri, @Nullable Sequence items) throws XPathException {
+        @Nullable final Sequence dynamicCollection = context.getDynamicallyAvailableCollection(collectionUri.toString());
+        if (dynamicCollection != null) {
+            if (items == null) {
+                items = dynamicCollection;
+            } else {
+                items.addAll(dynamicCollection);
+            }
+
+            return items;
+
+        } else {
+            @Nullable MutableDocumentSet docs = null;
+            final XmldbURI uri = XmldbURI.create(collectionUri);
+            try (@Nullable final Collection coll = context.getBroker().openCollection(uri, Lock.LockMode.READ_LOCK)) {
+                if (coll == null) {
+                    if (context.isRaiseErrorOnFailedRetrieval()) {
+                        throw new XPathException(this, ErrorCodes.FODC0002, "Can not access collection '" + uri + "'");
+                    }
+                } else {
+                    docs = new DefaultDocumentSet();
+                    if (context.inProtectedMode()) {
+                        context.getProtectedDocs().getDocsByCollection(coll, docs);
+                    } else {
+                        coll.allDocs(context.getBroker(), docs, includeSubCollections, context.getProtectedDocs());
+                    }
+                }
+            } catch (final XPathException e) {  // From AnyURIValue constructor
+                throw new XPathException(this, ErrorCodes.FODC0002, e.getMessage(), new StringValue(collectionUri.toString()), e);
+            } catch (final PermissionDeniedException e) {
+                throw new XPathException(this, ErrorCodes.FODC0002, "Can not access collection '" + e.getMessage() + "'", new StringValue(collectionUri.toString()), e);
+            } catch (final LockException e) {
+                throw new XPathException(this, ErrorCodes.FODC0002, e.getMessage(), new StringValue(collectionUri.toString()), e);
+            }
+
+            if (docs == null || docs.getDocumentCount() == 0) {
+                return Sequence.EMPTY_SEQUENCE;
+            }
+
+            if (items == null) {
+                items = new ValueSequence(docs.getDocumentCount());
+            } else {
+                addAll(docs, items);
+            }
+
+            return items;
+        }
     }
 
     private URI asUri(final String path) throws XPathException {
@@ -231,8 +255,7 @@ public class ExtCollection extends Function {
         return args;
     }
 
-    private Sequence toSequence(final DocumentSet docs) throws XPathException {
-        final Sequence result = new ValueSequence();
+    private void addAll(final DocumentSet docs, final Sequence items) throws XPathException {
         final LockManager lockManager = context.getBroker().getBrokerPool().getLockManager();
         for (final Iterator<DocumentImpl> i = docs.getDocumentIterator(); i.hasNext(); ) {
             final DocumentImpl doc = i.next();
@@ -245,7 +268,7 @@ public class ExtCollection extends Function {
                     if (!context.inProtectedMode()) {
                         dlock = lockManager.acquireDocumentReadLock(doc.getURI());
                     }
-                    result.add(new NodeProxy(null, doc));
+                    items.add(new NodeProxy(this, doc));
                 } catch (final LockException e) {
                     throw new XPathException(this, ErrorCodes.FODC0002, e);
                 } finally {
@@ -255,8 +278,6 @@ public class ExtCollection extends Function {
                 }
             }
         }
-
-        return result;
     }
 
     protected void registerUpdateListener() {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAnalyzeString.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAnalyzeString.java
@@ -45,9 +45,16 @@
  */
 package org.exist.xquery.functions.fn;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.sf.cglib.proxy.Callback;
+import net.sf.cglib.proxy.Enhancer;
+import net.sf.cglib.proxy.MethodInterceptor;
+import net.sf.cglib.proxy.MethodProxy;
 import net.sf.saxon.Configuration;
 import net.sf.saxon.om.Item;
 import net.sf.saxon.regex.RegexIterator;
@@ -71,6 +78,25 @@ import javax.xml.XMLConstants;
  * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
 public class FunAnalyzeString extends BasicFunction {
+
+    /**
+     * Implements a cglib MethodInterceptor to implement the `characters`
+     * method of Saxon 9's net.sf.saxon.regex.RegexIterator$MatchHandler
+     * and Saxon 12's net.sf.saxon.regex.RegexMatchHandler
+     */
+    private static final MethodInterceptor CHARACTERS_INTERCEPTOR = (final Object obj, final Method method, final Object[] args, final MethodProxy proxy) -> {
+        if ("characters".equals(method.getName())) {
+            final MemTreeBuilder builder = ((AbstractSaxonRegexMatchHandler) obj).builder;
+            builder.characters(args[0].toString());
+            return null;
+        }
+        return proxy.invokeSuper(obj, args);
+    };
+
+    @SuppressWarnings("unchecked")
+    private static final Class<? extends AbstractSaxonRegexMatchHandler> SAXON_MATCH_HANDLER_CLASS = createSaxonMatchHandlerClass();
+    private static final Constructor<? extends AbstractSaxonRegexMatchHandler> SAXON_MATCH_HANDLER_CLASS_CONSTRUCTOR = getSaxonMatchHandlerClassConstructor(SAXON_MATCH_HANDLER_CLASS);
+    private static final Method SAXON_PROCESS_MATCHING_SUBSTRING_FN = getSaxonProcessMatchingSubstringFunction();
 
     private final static QName fnAnalyzeString = new QName("analyze-string", FnModule.NAMESPACE_URI);
 
@@ -189,26 +215,107 @@ public class FunAnalyzeString extends BasicFunction {
     
     private void match(final MemTreeBuilder builder, final RegexIterator regexIterator) throws net.sf.saxon.trans.XPathException {
         builder.startElement(QN_MATCH, null);
-        regexIterator.processMatchingSubstring(new RegexIterator.MatchHandler() {
-            @Override
-            public void characters(final CharSequence s) {
-                builder.characters(s);
-            }
 
-            @Override
-            public void onGroupStart(final int groupNumber) throws net.sf.saxon.trans.XPathException {
-                final AttributesImpl attributes = new AttributesImpl();
-                attributes.addAttribute("", QN_NR.getLocalPart(), QN_NR.getLocalPart(), "int", Integer.toString(groupNumber));
-
-                builder.startElement(QN_GROUP, attributes);
+        try {
+            Enhancer.registerCallbacks(SAXON_MATCH_HANDLER_CLASS, new Callback[]{ CHARACTERS_INTERCEPTOR });
+            try {
+                final AbstractSaxonRegexMatchHandler matchHandler = SAXON_MATCH_HANDLER_CLASS_CONSTRUCTOR.newInstance(builder);
+                SAXON_PROCESS_MATCHING_SUBSTRING_FN.invoke(regexIterator, matchHandler);
+            } finally {
+                Enhancer.registerCallbacks(SAXON_MATCH_HANDLER_CLASS, null);
             }
+        } catch (final InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            throw new net.sf.saxon.trans.XPathException("Unable to dynamically invoke net.sf.saxon.regex.RegexIterator#processMatchingSubstring: " + e.getMessage(), e);
+        }
 
-            @Override
-            public void onGroupEnd(final int groupNumber) throws net.sf.saxon.trans.XPathException {
-                builder.endElement();
-            }
-        });
         builder.endElement();
+    }
+
+    private static Method getSaxonProcessMatchingSubstringFunction() {
+        final String saxonVersion = net.sf.saxon.Version.getProductVersion();
+        try {
+            final Class<?> matchHandlerInterfaceClazz;
+            if (saxonVersion.startsWith("12.")) {
+                matchHandlerInterfaceClazz = getSaxon12MatchHandlerInterfaceClass();
+            } else {
+                matchHandlerInterfaceClazz = getSaxon9MatchHandlerInterfaceClass();
+            }
+
+            return RegexIterator.class.getMethod("processMatchingSubstring", matchHandlerInterfaceClazz);
+
+        } catch (final ClassNotFoundException | NoSuchMethodException e) {
+            throw new IllegalStateException("Unable to dynamically access Saxon RegexIterator#processMatchingSubstring method: " + e.getMessage(), e);
+        }
+    }
+
+    private static Constructor<? extends AbstractSaxonRegexMatchHandler> getSaxonMatchHandlerClassConstructor(final Class<? extends AbstractSaxonRegexMatchHandler> saxonMatchHandlerClass) {
+        try {
+            return saxonMatchHandlerClass.getDeclaredConstructor(MemTreeBuilder.class);
+        } catch (final NoSuchMethodException e) {
+            throw new IllegalStateException("Unable to get constructor of dynamic Saxon Match Handler class: " + e.getMessage(), e);
+        }
+    }
+
+    private static Class<? extends AbstractSaxonRegexMatchHandler> createSaxonMatchHandlerClass() {
+        final String saxonVersion = net.sf.saxon.Version.getProductVersion();
+        try {
+            if (saxonVersion.startsWith("12.")) {
+                return createSaxon12MatchHandlerClass();
+            } else {
+                return createSaxon9MatchHandlerClass();
+            }
+        } catch (final ClassNotFoundException e) {
+            throw new IllegalStateException("Unable to dynamically create Saxon Match Handler class: " + e.getMessage(), e);
+        }
+    }
+
+    private static Class<?> getSaxon12MatchHandlerInterfaceClass() throws ClassNotFoundException {
+        return Class.forName("net.sf.saxon.regex.RegexMatchHandler");
+    }
+
+    private static Class<?> getSaxon9MatchHandlerInterfaceClass() throws ClassNotFoundException {
+        return Class.forName("net.sf.saxon.regex.RegexIterator$MatchHandler");
+    }
+
+    private static Class<? extends AbstractSaxonRegexMatchHandler> createSaxon12MatchHandlerClass() throws ClassNotFoundException {
+        final Class<?> matchHandlerInterfaceClazz = getSaxon12MatchHandlerInterfaceClass();
+        return createSaxonMatchHandlerClass(matchHandlerInterfaceClazz);
+    }
+
+    private static Class<? extends AbstractSaxonRegexMatchHandler> createSaxon9MatchHandlerClass() throws ClassNotFoundException {
+        final Class<?> matchHandlerInterfaceClazz = getSaxon9MatchHandlerInterfaceClass();
+        return createSaxonMatchHandlerClass(matchHandlerInterfaceClazz);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<? extends AbstractSaxonRegexMatchHandler> createSaxonMatchHandlerClass(final Class<?> saxonMatchHandlerInterface) {
+        final Enhancer enhancer = new Enhancer();
+        enhancer.setSuperclass(AbstractSaxonRegexMatchHandler.class);
+        enhancer.setInterfaces(new Class[]{saxonMatchHandlerInterface});
+        enhancer.setCallbackType(MethodInterceptor.class);
+        return (Class<? extends AbstractSaxonRegexMatchHandler>) enhancer.createClass();
+    }
+
+    /**
+     * Implements the common methods of Saxon 9's net.sf.saxon.regex.RegexIterator$MatchHandler
+     * and Saxon 12's net.sf.saxon.regex.RegexMatchHandler
+     */
+    private static abstract class AbstractSaxonRegexMatchHandler {
+        private final MemTreeBuilder builder;
+
+        public AbstractSaxonRegexMatchHandler(final MemTreeBuilder builder) {
+            this.builder = builder;
+        }
+
+        public void onGroupStart(final int groupNumber) {
+            final AttributesImpl attributes = new AttributesImpl();
+            attributes.addAttribute("", QN_NR.getLocalPart(), QN_NR.getLocalPart(), "int", Integer.toString(groupNumber));
+            builder.startElement(QN_GROUP, attributes);
+        }
+
+        public void onGroupEnd(final int groupNumber) {
+            builder.endElement();
+        }
     }
 
     private void nonMatch(final MemTreeBuilder builder, final Item item) {

--- a/exist-core/src/main/java/org/exist/xquery/value/AbstractDateTimeValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/AbstractDateTimeValue.java
@@ -126,6 +126,12 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
         }
     }
 
+    protected static XMLGregorianCalendar toXMLGregorianCalendar(final GregorianCalendar gregorianCalendar) {
+        final XMLGregorianCalendar xgc = TimeUtils.getInstance().newXMLGregorianCalendar(gregorianCalendar);
+        xgc.normalize();
+        return xgc;
+    }
+
     /**
      * Utility method that is able to clone a calendar whose year is 0
      * (whatever a year 0 means).

--- a/exist-core/src/main/java/org/exist/xquery/value/DateTimeStampValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DateTimeStampValue.java
@@ -56,6 +56,7 @@ import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
 import java.nio.ByteBuffer;
+import java.time.ZonedDateTime;
 
 /**
  * @author <a href="mailto:radek@evolvedbinary.com">Radek Hübner</a>
@@ -80,6 +81,15 @@ public class DateTimeStampValue extends DateTimeValue {
 
     public DateTimeStampValue(final Expression expression, final String dateTime) throws XPathException {
         super(expression, dateTime);
+        checkValidTimezone();
+    }
+
+    public DateTimeStampValue(final ZonedDateTime zonedDateTime) throws XPathException {
+       this(null, zonedDateTime);
+    }
+
+    public DateTimeStampValue(final Expression expression, final ZonedDateTime zonedDateTime) throws XPathException {
+        super(expression, zonedDateTime);
         checkValidTimezone();
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/value/DateTimeValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DateTimeValue.java
@@ -57,6 +57,11 @@ import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
@@ -90,12 +95,39 @@ public class DateTimeValue extends AbstractDateTimeValue {
         normalize();
     }
 
+    public DateTimeValue(final Instant instant) {
+        this(null, instant);
+    }
+
+    public DateTimeValue(final Expression expression, final Instant instant) {
+        super(expression, toXMLGregorianCalendar(new Date(instant.toEpochMilli())));
+        normalize();
+    }
+
+    public DateTimeValue(final ZonedDateTime zonedDateTime) {
+        this(null, zonedDateTime);
+    }
+
+    public DateTimeValue(final Expression expression, final ZonedDateTime zonedDateTime) {
+        super(expression, toXMLGregorianCalendar(zonedDateTime));
+        normalize();
+    }
+
+    public DateTimeValue(final LocalDateTime localDateTime) {
+        this(null, localDateTime);
+    }
+
+    public DateTimeValue(final Expression expression, final LocalDateTime localDateTime) {
+        super(expression, toXMLGregorianCalendar(localDateTime));
+        normalize();
+    }
+
     public DateTimeValue(final Date date) {
         this(null, date);
     }
 
     public DateTimeValue(final Expression expression, Date date) {
-        super(expression, dateToXMLGregorianCalendar(date));
+        super(expression, toXMLGregorianCalendar(date));
         normalize();
     }
 
@@ -115,12 +147,33 @@ public class DateTimeValue extends AbstractDateTimeValue {
         normalize();
     }
 
-    private static XMLGregorianCalendar dateToXMLGregorianCalendar(Date date) {
+    private static XMLGregorianCalendar toXMLGregorianCalendar(final Date date) {
         final GregorianCalendar gc = new GregorianCalendar();
         gc.setTime(date);
-        final XMLGregorianCalendar xgc = TimeUtils.getInstance().newXMLGregorianCalendar(gc);
+        return toXMLGregorianCalendar(gc);
+    }
+
+    private static XMLGregorianCalendar toXMLGregorianCalendar(final LocalDateTime localDateTime) {
+        final XMLGregorianCalendar xgc = TimeUtils.getInstance().newXMLGregorianCalendar();
+        xgc.setYear(localDateTime.getYear());
+        xgc.setMonth(localDateTime.getMonthValue());
+        xgc.setDay(localDateTime.getDayOfMonth());
+        xgc.setHour(localDateTime.getHour());
+        xgc.setMinute(localDateTime.getMinute());
+        xgc.setSecond(localDateTime.getSecond());
+        xgc.setMillisecond(localDateTime.getNano() / 1_000_000);
+        xgc.setTimezone(DatatypeConstants.FIELD_UNDEFINED);
         xgc.normalize();
         return xgc;
+    }
+
+    private static XMLGregorianCalendar toXMLGregorianCalendar(final Instant instant) {
+        return toXMLGregorianCalendar(LocalDateTime.ofInstant(instant, ZoneOffset.UTC));
+    }
+
+    private static XMLGregorianCalendar toXMLGregorianCalendar(final ZonedDateTime zonedDateTime) {
+        final GregorianCalendar gc = GregorianCalendar.from(zonedDateTime);
+        return toXMLGregorianCalendar(gc);
     }
 
     private static XMLGregorianCalendar fillCalendar(XMLGregorianCalendar calendar) {
@@ -222,6 +275,12 @@ public class DateTimeValue extends AbstractDateTimeValue {
                 final ByteBuffer buf = ByteBuffer.allocate(SERIALIZED_SIZE);
                 serialize(buf);
                 return (T) buf;
+            } else if (target == ZonedDateTime.class) {
+                return (T) calendar.toGregorianCalendar().toZonedDateTime();
+            } else if (target == OffsetDateTime.class) {
+                return (T) calendar.toGregorianCalendar().toZonedDateTime().toOffsetDateTime();
+            } else if (target == LocalDateTime.class) {
+                return (T)calendar.toGregorianCalendar().toZonedDateTime().toLocalDateTime();
             } else {
                 return super.toJavaObject(target);
             }

--- a/exist-core/src/main/java/org/exist/xquery/value/DateValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DateValue.java
@@ -55,6 +55,7 @@ import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
 import java.nio.ByteBuffer;
+import java.time.LocalDate;
 import java.util.GregorianCalendar;
 
 /**
@@ -93,7 +94,7 @@ public class DateValue extends AbstractDateTimeValue {
         this(null, calendar);
     }
 
-    public DateValue(final Expression expression, XMLGregorianCalendar calendar) throws XPathException {
+    public DateValue(final Expression expression, final XMLGregorianCalendar calendar) throws XPathException {
         super(expression, stripCalendar(cloneXMLGregorianCalendar(calendar)));
     }
 
@@ -182,6 +183,8 @@ public class DateValue extends AbstractDateTimeValue {
             return (T) buf;
         } else if (target == Long.class || target == long.class) {
             return (T) Long.valueOf(serializeToLong());
+        } else if (target == LocalDate.class) {
+            return (T)calendar.toGregorianCalendar().toZonedDateTime().toLocalDate();
         } else {
             return super.toJavaObject(target);
         }

--- a/exist-core/src/main/java/org/exist/xquery/value/DayTimeDurationValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DayTimeDurationValue.java
@@ -72,11 +72,11 @@ public class DayTimeDurationValue extends OrderedDurationValue {
     public static final Duration CANONICAL_ZERO_DURATION =
             TimeUtils.getInstance().newDuration(true, null, null, null, null, null, ZERO_DECIMAL);
 
-    DayTimeDurationValue(final Duration duration) throws XPathException {
+    public DayTimeDurationValue(final Duration duration) throws XPathException {
         this(null, duration);
     }
 
-    DayTimeDurationValue(final Expression expression, Duration duration) throws XPathException {
+    public DayTimeDurationValue(final Expression expression, Duration duration) throws XPathException {
         super(expression, duration);
         if (duration.isSet(DatatypeConstants.YEARS) || duration.isSet(DatatypeConstants.MONTHS)) {
             throw new XPathException(getExpression(), ErrorCodes.XPTY0004, "the value '" + duration + "' is not an xdt:dayTimeDuration since it specifies year or month values");

--- a/exist-core/src/main/java/org/exist/xquery/value/TimeValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/TimeValue.java
@@ -56,6 +56,8 @@ import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
+import java.time.LocalTime;
+import java.time.OffsetTime;
 import java.util.GregorianCalendar;
 
 /**
@@ -174,6 +176,10 @@ public class TimeValue extends AbstractDateTimeValue {
             return (T) buf;
         } else if (target == Long.class || target == long.class) {
             return (T) Long.valueOf(serializeToLong());
+        } else if (target == OffsetTime.class) {
+            return (T)calendar.toGregorianCalendar().toZonedDateTime().toOffsetDateTime().toOffsetTime();
+        } else if (target == LocalTime.class) {
+            return (T)calendar.toGregorianCalendar().toZonedDateTime().toLocalTime();
         } else {
             return super.toJavaObject(target);
         }

--- a/exist-core/src/main/java/org/exist/xquery/value/YearMonthDurationValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/YearMonthDurationValue.java
@@ -71,11 +71,11 @@ public class YearMonthDurationValue extends OrderedDurationValue {
     public static final Duration CANONICAL_ZERO_DURATION =
             TimeUtils.getInstance().newDuration(true, null, BigInteger.ZERO, null, null, null, null);
 
-    YearMonthDurationValue(final Duration duration) throws XPathException {
+    public YearMonthDurationValue(final Duration duration) throws XPathException {
         this(null, duration);
     }
 
-    YearMonthDurationValue(final Expression expression, Duration duration) throws XPathException {
+    public YearMonthDurationValue(final Expression expression, Duration duration) throws XPathException {
         super(expression, duration);
         if (!duration.equals(DurationValue.CANONICAL_ZERO_DURATION)) {
             if (duration.isSet(DatatypeConstants.DAYS) ||

--- a/exist-core/src/main/xsd/rest-api.xsd
+++ b/exist-core/src/main/xsd/rest-api.xsd
@@ -42,6 +42,13 @@
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>
+                <xs:element name="default-collection" minOccurs="0">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element ref="sx:sequence"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
                 <xs:element name="variables" minOccurs="0">
                     <xs:complexType>
                         <xs:sequence>

--- a/exist-core/src/main/xsd/rest-api.xsd
+++ b/exist-core/src/main/xsd/rest-api.xsd
@@ -35,6 +35,13 @@
         <xs:complexType>
             <xs:sequence>
                 <xs:element name="text" type="xs:string"/>
+                <xs:element name="context-item" minOccurs="0">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element ref="sx:value"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
                 <xs:element name="variables" minOccurs="0">
                     <xs:complexType>
                         <xs:sequence>

--- a/exist-core/src/test/java/org/exist/http/RESTExternalVariableTest.java
+++ b/exist-core/src/test/java/org/exist/http/RESTExternalVariableTest.java
@@ -21,7 +21,7 @@
 package org.exist.http;
 
 import com.evolvedbinary.j8fu.tuple.Tuple2;
-import com.googlecode.junittoolbox.ParallelRunner;
+import com.googlecode.junittoolbox.ParallelParameterized;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -39,7 +39,9 @@ import org.exist.xquery.value.Type;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.w3c.dom.Attr;
+import org.w3c.dom.Node;
 import org.xmlunit.diff.DefaultNodeMatcher;
 import org.xmlunit.diff.ElementSelectors;
 import org.xmlunit.matchers.CompareMatcher;
@@ -50,6 +52,7 @@ import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Map;
 
 import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
@@ -66,14 +69,29 @@ import static org.exist.http.RESTExternalVariableTest.UntypedMapRep.untypedMap;
 import static org.exist.http.RESTExternalVariableTest.UntypedNamedValueRep.value;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.xmlunit.matchers.HasXPathMatcher.hasXPath;
 
 /**
  * See: <a href="https://github.com/eXist-db/exist/issues/5844">[BUG] The JavaDoc comments for variable in the REST API are inconsistent with the implementation</a>.
  *
  * @author <a href="mailto:adam@evolvedbinary.com>Adam Retter</a>
  */
-@RunWith(ParallelRunner.class)
+@RunWith(ParallelParameterized.class)
 public class RESTExternalVariableTest {
+
+    @Parameterized.Parameters(name = "{0}")
+    public static java.util.Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            { "xmlns-prefixed-ns", true },
+            { "xmlns-default-ns", false }
+        });
+    }
+
+    @Parameterized.Parameter
+    public String testTypeName;
+
+    @Parameterized.Parameter(value = 1)
+    public boolean useXmlnsPrefixes;
 
     @ClassRule
     public static final ExistWebServer existWebServer = new ExistWebServer(true, false, true, true);
@@ -316,13 +334,23 @@ public class RESTExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableUntypedSuppliedUntypedElementValue() throws IOException {
-        final ExternalVariableValueRep externalVariable = UntypedValueRep.value("<hello>world</hello>");
+        final ExternalVariableValueRep externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = UntypedValueRep.value("<hello>world</hello>");
+        } else {
+            externalVariable = UntypedValueRep.value("<hello xmlns=\"\">world</hello>");
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, null, externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableUntypedSuppliedElement() throws IOException {
-        final ExternalVariableValueRep externalVariable = value(Type.ELEMENT, "<hello>world</hello>");
+        final ExternalVariableValueRep externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = value(Type.ELEMENT, "<hello>world</hello>");
+        } else {
+            externalVariable = value(Type.ELEMENT, "<hello xmlns=\"\">world</hello>");
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, null, externalVariable);
     }
 
@@ -339,31 +367,56 @@ public class RESTExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableElementSuppliedElement() throws IOException {
-        final ExternalVariableValueRep externalVariable = value(Type.ELEMENT, "<hello>world</hello>");
+        final ExternalVariableValueRep externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = value(Type.ELEMENT, "<hello>world</hello>");
+        } else {
+            externalVariable = value(Type.ELEMENT, "<hello xmlns=\"\">world</hello>");
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, "element()", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableElementSuppliedElements() throws IOException {
-        final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>"), UntypedValueRep.value("<goodbye>see you soon</goodbye>") };
+        final ExternalVariableValueRep[] externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>"), UntypedValueRep.value("<goodbye>see you soon</goodbye>") };
+        } else {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello xmlns=\"\">world</hello>"), UntypedValueRep.value("<goodbye>see you soon</goodbye>") };
+        }
         queryPostWithExternalVariable(HttpStatus.BAD_REQUEST_400, "element()", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableElementSuppliedUntyped() throws IOException {
-        final ExternalVariableValueRep externalVariable = UntypedValueRep.value("<hello>world</hello>");
+        final ExternalVariableValueRep externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = UntypedValueRep.value("<hello>world</hello>");
+        } else {
+            externalVariable = UntypedValueRep.value("<hello xmlns=\"\">world</hello>");
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, "element()", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableUntypedSuppliedUntypedElements() throws IOException {
-        final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>"), UntypedValueRep.value("<goodbye>see you soon</goodbye>") };
+        final ExternalVariableValueRep[] externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>"), UntypedValueRep.value("<goodbye>see you soon</goodbye>") };
+        } else {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello xmlns=\"\">world</hello>"), UntypedValueRep.value("<goodbye xmlns=\"\">see you soon</goodbye>") };
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, null, externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableUntypedSuppliedElements() throws IOException {
-        final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { value(Type.ELEMENT, "<hello>world</hello>"), value(Type.ELEMENT, "<goodbye>see you soon</goodbye>") };
+        final ExternalVariableValueRep[] externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = new ExternalVariableValueRep[] { value(Type.ELEMENT, "<hello>world</hello>"), value(Type.ELEMENT, "<goodbye>see you soon</goodbye>") };
+        } else {
+            externalVariable = new ExternalVariableValueRep[] { value(Type.ELEMENT, "<hello xmlns=\"\">world</hello>"), value(Type.ELEMENT, "<goodbye xmlns=\"\">see you soon</goodbye>") };
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, null, externalVariable);
     }
 
@@ -380,19 +433,34 @@ public class RESTExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableOptElementSuppliedElement() throws IOException {
-        final ExternalVariableValueRep externalVariable = value(Type.ELEMENT, "<hello>world</hello>");
+        final ExternalVariableValueRep externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = value(Type.ELEMENT, "<hello>world</hello>");
+        } else {
+            externalVariable = value(Type.ELEMENT, "<hello xmlns=\"\">world</hello>");
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, "element()?", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableOptElementSuppliedElements() throws IOException {
-        final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { value(Type.ELEMENT, "<hello>world</hello>"), value(Type.ELEMENT, "<goodbye>see you soon</goodbye>") };
+        final ExternalVariableValueRep[] externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = new ExternalVariableValueRep[] { value(Type.ELEMENT, "<hello>world</hello>"), value(Type.ELEMENT, "<goodbye>see you soon</goodbye>") };
+        } else {
+            externalVariable = new ExternalVariableValueRep[] { value(Type.ELEMENT, "<hello xmlns=\"\">world</hello>"), value(Type.ELEMENT, "<goodbye xmlns=\"\">see you soon</goodbye>") };
+        }
         queryPostWithExternalVariable(HttpStatus.BAD_REQUEST_400, "element()?", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableOptElementSuppliedUntyped() throws IOException {
-        final ExternalVariableValueRep externalVariable = UntypedValueRep.value("<hello>world</hello>");
+        final ExternalVariableValueRep externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = UntypedValueRep.value("<hello>world</hello>");
+        } else {
+            externalVariable = UntypedValueRep.value("<hello xmlns=\"\">world</hello>");
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, "element()?", externalVariable);
     }
 
@@ -409,25 +477,45 @@ public class RESTExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableElementsSuppliedElement() throws IOException {
-        final ExternalVariableValueRep externalVariable = value(Type.ELEMENT, "<hello>world</hello>");
+        final ExternalVariableValueRep externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = value(Type.ELEMENT, "<hello>world</hello>");
+        } else {
+            externalVariable = value(Type.ELEMENT, "<hello xmlns=\"\">world</hello>");
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, "element()+", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableElementsSuppliedElements() throws IOException {
-        final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { value(Type.ELEMENT, "<hello>world</hello>"), value(Type.ELEMENT, "<goodbye>see you soon</goodbye>") };
+        final ExternalVariableValueRep[] externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = new ExternalVariableValueRep[] { value(Type.ELEMENT, "<hello>world</hello>"), value(Type.ELEMENT, "<goodbye>see you soon</goodbye>") };
+        } else {
+            externalVariable = new ExternalVariableValueRep[] { value(Type.ELEMENT, "<hello xmlns=\"\">world</hello>"), value(Type.ELEMENT, "<goodbye xmlns=\"\">see you soon</goodbye>") };
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, "element()+", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableElementsSuppliedUntyped() throws IOException {
-        final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>") };
+final ExternalVariableValueRep[] externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>") };
+        } else {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello xmlns=\"\">world</hello>") };
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, "element()+", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableElementsSuppliedUntypeds() throws IOException {
-        final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>"), UntypedValueRep.value("<goodbye>see you soon</goodbye>") };
+        final ExternalVariableValueRep[] externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>"), UntypedValueRep.value("<goodbye>see you soon</goodbye>") };
+        } else {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello xmlns=\"\">world</hello>"), UntypedValueRep.value("<goodbye xmlns=\"\">see you soon</goodbye>") };
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, "element()+", externalVariable);
     }
 
@@ -444,37 +532,67 @@ public class RESTExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableElementzSuppliedElement() throws IOException {
-        final ExternalVariableValueRep externalVariable = value(Type.ELEMENT, "<hello>world</hello>");
+        final ExternalVariableValueRep externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = value(Type.ELEMENT, "<hello>world</hello>");
+        } else {
+            externalVariable = value(Type.ELEMENT, "<hello xmlns=\"\">world</hello>");
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, "element()*", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableElementzSuppliedElements() throws IOException {
-        final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { value(Type.ELEMENT, "<hello>world</hello>"), value(Type.ELEMENT, "<goodbye>see you soon</goodbye>") };
+        final ExternalVariableValueRep[] externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = new ExternalVariableValueRep[] { value(Type.ELEMENT, "<hello>world</hello>"), value(Type.ELEMENT, "<goodbye>see you soon</goodbye>") };
+        } else {
+            externalVariable = new ExternalVariableValueRep[] { value(Type.ELEMENT, "<hello xmlns=\"\">world</hello>"), value(Type.ELEMENT, "<goodbye xmlns=\"\">see you soon</goodbye>") };
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, "element()*", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableElementszSuppliedUntyped() throws IOException {
-        final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>") };
+        final ExternalVariableValueRep[] externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>") };
+        } else {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello xmlns=\"\">world</hello>") };
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, "element()*", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableElementzSuppliedUntypeds() throws IOException {
-        final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>"), UntypedValueRep.value("<goodbye>see you soon</goodbye>") };
+        final ExternalVariableValueRep[] externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>"), UntypedValueRep.value("<goodbye>see you soon</goodbye>") };
+        } else {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello xmlns=\"\">world</hello>"), UntypedValueRep.value("<goodbye xmlns=\"\">see you soon</goodbye>") };
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, "element()*", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableUntypedSuppliedUntypedDocument() throws IOException {
-        final ExternalVariableValueRep externalVariable = UntypedValueRep.value("<hello>world</hello>");
+        final ExternalVariableValueRep externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = UntypedValueRep.value("<hello>world</hello>");
+        } else {
+            externalVariable = UntypedValueRep.value("<hello xmlns=\"\">world</hello>");
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, null, externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableUntypedSuppliedDocument() throws IOException {
-        final ExternalVariableValueRep externalVariable = value(Type.DOCUMENT, "<hello>world</hello>");
+        final ExternalVariableValueRep externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = value(Type.DOCUMENT, "<hello>world</hello>");
+        } else {
+            externalVariable = value(Type.DOCUMENT, "<hello xmlns=\"\">world</hello>");
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, null, externalVariable);
     }
 
@@ -491,32 +609,57 @@ public class RESTExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableDocumentSuppliedDocument() throws IOException {
-        final ExternalVariableValueRep externalVariable = value(Type.DOCUMENT, "<hello>world</hello>");
+        final ExternalVariableValueRep externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = value(Type.DOCUMENT, "<hello>world</hello>");
+        } else {
+            externalVariable = value(Type.DOCUMENT, "<hello xmlns=\"\">world</hello>");
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, "document-node()", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableDocumentSuppliedDocuments() throws IOException {
-        final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>"), UntypedValueRep.value("<goodbye>see you soon</goodbye>") };
+        final ExternalVariableValueRep[] externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>"), UntypedValueRep.value("<goodbye>see you soon</goodbye>") };
+        } else {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello xmlns=\"\">world</hello>"), UntypedValueRep.value("<goodbye xmlns=\"\">see you soon</goodbye>") };
+        }
         queryPostWithExternalVariable(HttpStatus.BAD_REQUEST_400, "document-node()", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableDocumentSuppliedUntyped() throws IOException {
-        final ExternalVariableValueRep externalVariable = UntypedValueRep.value("<hello>world</hello>");
+        final ExternalVariableValueRep externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = UntypedValueRep.value("<hello>world</hello>");
+        } else {
+            externalVariable = UntypedValueRep.value("<hello xmlns=\"\">world</hello>");
+        }
         final String expectedResponseError = "<exception><path>/db/test/test.xml</path><message>err:XPTY0004 Invalid type for variable $local:my-variable. Expected document-node(), got element()</message></exception>";
         queryPostWithExternalVariable(Tuple(HttpStatus.BAD_REQUEST_400, expectedResponseError), "document-node()", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableUntypedSuppliedUntypedDocuments() throws IOException {
-        final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>"), UntypedValueRep.value("<goodbye>see you soon</goodbye>") };
+        final ExternalVariableValueRep[] externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>"), UntypedValueRep.value("<goodbye>see you soon</goodbye>") };
+        } else {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello xmlns=\"\">world</hello>"), UntypedValueRep.value("<goodbye xmlns=\"\">see you soon</goodbye>") };
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, null, externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableUntypedSuppliedDocuments() throws IOException {
-        final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { value(Type.DOCUMENT, "<hello>world</hello>"), value(Type.DOCUMENT, "<goodbye>see you soon</goodbye>") };
+        final ExternalVariableValueRep[] externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = new ExternalVariableValueRep[] { value(Type.DOCUMENT, "<hello>world</hello>"), value(Type.DOCUMENT, "<goodbye>see you soon</goodbye>") };
+        } else {
+            externalVariable = new ExternalVariableValueRep[] { value(Type.DOCUMENT, "<hello xmlns=\"\">world</hello>"), value(Type.DOCUMENT, "<goodbye xmlns=\"\">see you soon</goodbye>") };
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, null, externalVariable);
     }
 
@@ -533,19 +676,34 @@ public class RESTExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableOptDocumentSuppliedDocument() throws IOException {
-        final ExternalVariableValueRep externalVariable = value(Type.DOCUMENT, "<hello>world</hello>");
+        final ExternalVariableValueRep externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = value(Type.DOCUMENT, "<hello>world</hello>");
+        } else {
+            externalVariable = value(Type.DOCUMENT, "<hello xmlns=\"\">world</hello>");
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, "document-node()?", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableOptDocumentSuppliedDocuments() throws IOException {
-        final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { value(Type.DOCUMENT, "<hello>world</hello>"), value(Type.DOCUMENT, "<goodbye>see you soon</goodbye>") };
+        final ExternalVariableValueRep[] externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = new ExternalVariableValueRep[] { value(Type.DOCUMENT, "<hello>world</hello>"), value(Type.DOCUMENT, "<goodbye>see you soon</goodbye>") };
+        } else {
+            externalVariable = new ExternalVariableValueRep[] { value(Type.DOCUMENT, "<hello xmlns=\"\">world</hello>"), value(Type.DOCUMENT, "<goodbye xmlns=\"\">see you soon</goodbye>") };
+        }
         queryPostWithExternalVariable(HttpStatus.BAD_REQUEST_400, "document-node()?", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableOptDocumentSuppliedUntyped() throws IOException {
-        final ExternalVariableValueRep externalVariable = UntypedValueRep.value("<hello>world</hello>");
+        final ExternalVariableValueRep externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = UntypedValueRep.value("<hello>world</hello>");
+        } else {
+            externalVariable = UntypedValueRep.value("<hello xmlns=\"\">world</hello>");
+        }
         final String expectedResponseError = "<exception><path>/db/test/test.xml</path><message>err:XPTY0004 Invalid type for variable $local:my-variable. Expected document-node(), got element()</message></exception>";
         queryPostWithExternalVariable(Tuple(HttpStatus.BAD_REQUEST_400, expectedResponseError), "document-node()?", externalVariable);
     }
@@ -563,26 +721,46 @@ public class RESTExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableDocumentsSuppliedDocument() throws IOException {
-        final ExternalVariableValueRep externalVariable = value(Type.DOCUMENT, "<hello>world</hello>");
+        final ExternalVariableValueRep externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = value(Type.DOCUMENT, "<hello>world</hello>");
+        } else {
+            externalVariable = value(Type.DOCUMENT, "<hello xmlns=\"\">world</hello>");
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, "document-node()+", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableDocumentsSuppliedDocuments() throws IOException {
-        final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { value(Type.DOCUMENT, "<hello>world</hello>"), value(Type.DOCUMENT, "<goodbye>see you soon</goodbye>") };
+        final ExternalVariableValueRep[] externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = new ExternalVariableValueRep[] { value(Type.DOCUMENT, "<hello>world</hello>"), value(Type.DOCUMENT, "<goodbye>see you soon</goodbye>") };
+        } else {
+            externalVariable = new ExternalVariableValueRep[] { value(Type.DOCUMENT, "<hello xmlns=\"\">world</hello>"), value(Type.DOCUMENT, "<goodbye xmlns=\"\">see you soon</goodbye>") };
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, "document-node()+", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableDocumentsSuppliedUntyped() throws IOException {
-        final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>") };
+        final ExternalVariableValueRep[] externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>") };
+        } else {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello xmlns=\"\">world</hello>") };
+        }
         final String expectedResponseError = "<exception><path>/db/test/test.xml</path><message>err:XPTY0004 Invalid type for variable $local:my-variable. Expected document-node(), got element()</message></exception>";
         queryPostWithExternalVariable(Tuple(HttpStatus.BAD_REQUEST_400, expectedResponseError), "document-node()+", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableDocumentsSuppliedUntypeds() throws IOException {
-        final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>"), UntypedValueRep.value("<goodbye>see you soon</goodbye>") };
+        final ExternalVariableValueRep[] externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>"), UntypedValueRep.value("<goodbye>see you soon</goodbye>") };
+        } else {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello xmlns=\"\">world</hello>"), UntypedValueRep.value("<goodbye xmlns=\"\">see you soon</goodbye>") };
+        }
         final String expectedResponseError = "<exception><path>/db/test/test.xml</path><message>err:XPTY0004 Invalid type for variable $local:my-variable. Expected document-node(), got element()</message></exception>";
         queryPostWithExternalVariable(Tuple(HttpStatus.BAD_REQUEST_400, expectedResponseError), "document-node()+", externalVariable);
     }
@@ -600,26 +778,46 @@ public class RESTExternalVariableTest {
 
     @Test
     public void queryPostWithExternalVariableDocumentzSuppliedDocument() throws IOException {
-        final ExternalVariableValueRep externalVariable = value(Type.DOCUMENT, "<hello>world</hello>");
+        final ExternalVariableValueRep externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = value(Type.DOCUMENT, "<hello>world</hello>");
+        } else {
+            externalVariable = value(Type.DOCUMENT, "<hello xmlns=\"\">world</hello>");
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, "document-node()*", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableDocumentzSuppliedDocuments() throws IOException {
-        final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { value(Type.DOCUMENT, "<hello>world</hello>"), value(Type.DOCUMENT, "<goodbye>see you soon</goodbye>") };
+        final ExternalVariableValueRep[] externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = new ExternalVariableValueRep[] { value(Type.DOCUMENT, "<hello>world</hello>"), value(Type.DOCUMENT, "<goodbye>see you soon</goodbye>") };
+        } else {
+            externalVariable = new ExternalVariableValueRep[] { value(Type.DOCUMENT, "<hello xmlns=\"\">world</hello>"), value(Type.DOCUMENT, "<goodbye xmlns=\"\">see you soon</goodbye>") };
+        }
         queryPostWithExternalVariable(HttpStatus.OK_200, "document-node()*", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableDocumentszSuppliedUntyped() throws IOException {
-        final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>") };
+        final ExternalVariableValueRep[] externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>") };
+        } else {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello xmlns=\"\">world</hello>") };
+        }
         final String expectedResponseError = "<exception><path>/db/test/test.xml</path><message>err:XPTY0004 Invalid type for variable $local:my-variable. Expected document-node(), got element()</message></exception>";
         queryPostWithExternalVariable(Tuple(HttpStatus.BAD_REQUEST_400, expectedResponseError), "document-node()*", externalVariable);
     }
 
     @Test
     public void queryPostWithExternalVariableDocumentzSuppliedUntypeds() throws IOException {
-        final ExternalVariableValueRep[] externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>"), UntypedValueRep.value("<goodbye>see you soon</goodbye>") };
+        final ExternalVariableValueRep[] externalVariable;
+        if (useXmlnsPrefixes) {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello>world</hello>"), UntypedValueRep.value("<goodbye>see you soon</goodbye>") };
+        } else {
+            externalVariable = new ExternalVariableValueRep[] { UntypedValueRep.value("<hello xmlns=\"\">world</hello>"), UntypedValueRep.value("<goodbye xmlns=\"\">see you soon</goodbye>") };
+        }
         final String expectedResponseError = "<exception><path>/db/test/test.xml</path><message>err:XPTY0004 Invalid type for variable $local:my-variable. Expected document-node(), got element()</message></exception>";
         queryPostWithExternalVariable(Tuple(HttpStatus.BAD_REQUEST_400, expectedResponseError), "document-node()*", externalVariable);
     }
@@ -1622,6 +1820,75 @@ public class RESTExternalVariableTest {
         queryPostWithExternalVariable(HttpStatus.OK_200, "map(*)*", externalVariable);
     }
 
+    @Test
+    public void queryPostWrappedTypedWithExternalVariableStringConstructElement() throws IOException {
+        queryPostWithExternalVariableStringConstructElement(true, true);
+    }
+
+    @Test
+    public void queryPostWrappedNotTypedWithExternalVariableStringConstructElement() throws IOException {
+        queryPostWithExternalVariableStringConstructElement(true, false);
+    }
+
+    @Test
+    public void queryPostNotWrappedTypedWithExternalVariableStringConstructElement() throws IOException {
+        queryPostWithExternalVariableStringConstructElement(false, true);
+    }
+
+    @Test
+    public void queryPostNotWrappedNotTypedWithExternalVariableStringConstructElement() throws IOException {
+        queryPostWithExternalVariableStringConstructElement(false, false);
+    }
+
+    private void queryPostWithExternalVariableStringConstructElement(final boolean wrap, final boolean typed) throws IOException {
+        final String query;
+        if (useXmlnsPrefixes) {
+            query = "<exist:query xmlns:exist=\"http://exist.sourceforge.net/NS/exist\" xmlns:sx=\"http://exist-db.org/xquery/types/serialized\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" wrap=\"" + (wrap ? "yes" : "no") + "\" typed=\"" + (typed ? "yes" : "no") + "\">\n" +
+                "\t<exist:variables>\n" +
+                "\t\t<exist:variable>\n" +
+                "\t\t\t<exist:qname>\n" +
+                "\t\t\t\t<exist:localname>my-variable</exist:localname>\n" +
+                "\t\t\t</exist:qname>\n" +
+                "\t\t\t<sx:sequence>\n" +
+                "\t\t\t\t<sx:value type=\"xs:string\">greeting</sx:value>" +
+                "\t\t\t</sx:sequence>\n" +
+                "\t\t</exist:variable>\n" +
+                "\t</exist:variables>\n" +
+                "\t<exist:text><![CDATA[\n" +
+                "declare variable $my-variable external;\n" +
+                "element { $my-variable } { text { \"Hello, world.\" } }\n" +
+                "\t]]></exist:text>\n" +
+                "</exist:query>\n";
+        } else {
+            query = "<query xmlns=\"http://exist.sourceforge.net/NS/exist\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" wrap=\"" + (wrap ? "yes" : "no") + "\" typed=\"" + (typed ? "yes" : "no") + "\">\n" +
+                "\t<variables>\n" +
+                "\t\t<variable>\n" +
+                "\t\t\t<qname>\n" +
+                "\t\t\t\t<localname>my-variable</localname>\n" +
+                "\t\t\t</qname>\n" +
+                "\t\t\t<sequence xmlns=\"http://exist-db.org/xquery/types/serialized\">\n" +
+                "\t\t\t\t<value type=\"xs:string\">greeting</value>" +
+                "\t\t\t</sequence>\n" +
+                "\t\t</variable>\n" +
+                "\t</variables>\n" +
+                "\t<text><![CDATA[\n" +
+                "declare variable $my-variable external;\n" +
+                "element { $my-variable } { text { \"Hello, world.\" } }\n" +
+                "\t]]></text>\n" +
+                "</query>\n";
+        }
+
+        final HttpResponse response = doPostWithAuth(getResourceUri(), query);
+        final int resultStatusCode = response.getStatusLine()
+            .getStatusCode();
+
+        assertEquals("Server returned response code: " + resultStatusCode, HttpStatus.OK_200, resultStatusCode);
+
+        //final String actual = "<xs:y xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"><greeting>Hello, world.</greeting></xs:y>";
+        final String actual = readResponse(response.getEntity());
+        assertThat(actual, hasXPath("//greeting[namespace-uri() = ''][text() = 'Hello, world.']").withNamespaceContext(NS_CONTEXT));
+    }
+
     private void queryPostWithExternalVariable(final int expectedResponseCode, @Nullable final String xqExternalVariableType, final ExternalVariableValueRep... externalVariableSequence) throws IOException {
         queryPostWithExternalVariable(Tuple(expectedResponseCode, null), externalVariableSequence, xqExternalVariableType, externalVariableSequence);
     }
@@ -1791,38 +2058,73 @@ public class RESTExternalVariableTest {
         return xdmType == Type.MAP || (xdmType == Type.ITEM && externalVariableValueRep instanceof MapRep);
     }
 
-    private static String buildQueryExternalVariable(@Nullable final String xqExternalVariableType, @Nullable final ExternalVariableValueRep... externalVariableSequence) {
+    private String buildQueryExternalVariable(@Nullable final String xqExternalVariableType, @Nullable final ExternalVariableValueRep... externalVariableSequence) {
         final StringBuilder builder = new StringBuilder();
-        builder.append("<exist:query xmlns:exist=\"http://exist.sourceforge.net/NS/exist\" xmlns:sx=\"http://exist-db.org/xquery/types/serialized\" xmlns:" + TEST_PREFIX + "=\"" + TEST_NAMESPACE + "\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" wrap=\"yes\" typed=\"yes\">\n");
 
-        if (externalVariableSequence!= null) {
-            builder.append("\t<exist:variables>\n");
-            builder.append("\t\t<exist:variable>\n");
-            builder.append("\t\t\t<exist:qname><exist:prefix>local</exist:prefix><exist:localname>my-variable</exist:localname></exist:qname>\n");
-            buildQueryExternalVariableSequence(builder, 3, externalVariableSequence);
-            builder.append("\t\t</exist:variable>\n");
-            builder.append("\t</exist:variables>\n");
-        }
+        if (useXmlnsPrefixes) {
+            builder.append("<exist:query xmlns:exist=\"http://exist.sourceforge.net/NS/exist\" xmlns:sx=\"http://exist-db.org/xquery/types/serialized\" xmlns:" + TEST_PREFIX + "=\"" + TEST_NAMESPACE + "\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" wrap=\"yes\" typed=\"yes\">\n");
 
-        builder.append("\t<exist:text><![CDATA[\n");
-        builder.append("declare variable $local:my-variable");
-        if (xqExternalVariableType != null) {
-            builder.append(" as ").append(xqExternalVariableType);
+            if (externalVariableSequence != null) {
+                builder.append("\t<exist:variables>\n");
+                builder.append("\t\t<exist:variable>\n");
+                builder.append("\t\t\t<exist:qname><exist:prefix>local</exist:prefix><exist:localname>my-variable</exist:localname></exist:qname>\n");
+                buildQueryExternalVariableSequence(builder, 3, externalVariableSequence);
+                builder.append("\t\t</exist:variable>\n");
+                builder.append("\t</exist:variables>\n");
+            }
+
+            builder.append("\t<exist:text><![CDATA[\n");
+            builder.append("declare variable $local:my-variable");
+            if (xqExternalVariableType != null) {
+                builder.append(" as ").append(xqExternalVariableType);
+            }
+            builder.append(" external;\n");
+            builder.append("$local:my-variable\n");
+            builder.append("\t]]></exist:text>\n");
+            builder.append("</exist:query>\n");
+
+        } else {
+            builder.append("<query xmlns=\"http://exist.sourceforge.net/NS/exist\" xmlns:" + TEST_PREFIX + "=\"" + TEST_NAMESPACE + "\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" wrap=\"yes\" typed=\"yes\">\n");
+
+            if (externalVariableSequence != null) {
+                builder.append("\t<variables>\n");
+                builder.append("\t\t<variable>\n");
+                builder.append("\t\t\t<qname><prefix>local</prefix><localname>my-variable</localname></qname>\n");
+                buildQueryExternalVariableSequence(builder, 3, externalVariableSequence);
+                builder.append("\t\t</variable>\n");
+                builder.append("\t</variables>\n");
+            }
+
+            builder.append("\t<text><![CDATA[\n");
+            builder.append("declare variable $local:my-variable");
+            if (xqExternalVariableType != null) {
+                builder.append(" as ").append(xqExternalVariableType);
+            }
+            builder.append(" external;\n");
+            builder.append("$local:my-variable\n");
+            builder.append("\t]]></text>\n");
+            builder.append("</query>\n");
         }
-        builder.append(" external;\n");
-        builder.append("$local:my-variable\n");
-        builder.append("\t]]></exist:text>\n");
-        builder.append("</exist:query>\n");
 
         return builder.toString();
     }
 
     private static final char[] INDENTS = { '\t', '\t', '\t', '\t', '\t', '\t', '\t', '\t', '\t', '\t', '\t', '\t', '\t', '\t', '\t', '\t' };
 
-    private static void buildQueryExternalVariableSequence(final StringBuilder builder, final int indentCount, final ExternalVariableValueRep... externalVariableSequence) {
-        builder.append(INDENTS, 0, indentCount).append("<sx:sequence>\n");
+    private void buildQueryExternalVariableSequence(final StringBuilder builder, final int indentCount, final ExternalVariableValueRep... externalVariableSequence) {
+        if (useXmlnsPrefixes) {
+            builder.append(INDENTS, 0, indentCount).append("<sx:sequence>\n");
+        } else {
+            builder.append(INDENTS, 0, indentCount).append("<sequence xmlns=\"http://exist-db.org/xquery/types/serialized\">\n");
+        }
+
         for (final ExternalVariableValueRep externalVariableSequenceItem : externalVariableSequence) {
-            builder.append(INDENTS, 0, indentCount + 1).append("<sx:value");
+            if (useXmlnsPrefixes) {
+                builder.append(INDENTS, 0, indentCount + 1).append("<sx:value");
+            } else {
+                builder.append(INDENTS, 0, indentCount + 1).append("<value");
+            }
+
             if (externalVariableSequenceItem instanceof ExternalVariableTypedValueRep) {
                 builder.append(" type=\"").append(Type.getTypeName(((ExternalVariableTypedValueRep) externalVariableSequenceItem).getXdmType())).append("\"");
             }
@@ -1846,15 +2148,31 @@ public class RESTExternalVariableTest {
                 // Map type
                 builder.append('\n');
                 for (final EntryRep entryRep : ((MapRep) externalVariableSequenceItem).getEntries()) {
-                    builder.append(INDENTS, 0, indentCount + 2).append("<sx:entry>\n");
-                    builder.append(INDENTS, 0, indentCount + 3).append("<sx:key");
+                    if (useXmlnsPrefixes) {
+                        builder.append(INDENTS, 0, indentCount + 2).append("<sx:entry>\n");
+                        builder.append(INDENTS, 0, indentCount + 3).append("<sx:key");
+                    } else {
+                        builder.append(INDENTS, 0, indentCount + 2).append("<entry>\n");
+                        builder.append(INDENTS, 0, indentCount + 3).append("<key");
+                    }
+
                     final ValueRep key = entryRep.key.key;
                     if (key instanceof ExternalVariableTypedValueRep) {
                         builder.append(" type=\"").append(Type.getTypeName(((ExternalVariableTypedValueRep) key).getXdmType())).append("\"");
                     }
-                    builder.append('>').append(key.getContent()).append("</sx:key>\n");
+                    if (useXmlnsPrefixes) {
+                        builder.append('>').append(key.getContent()).append("</sx:key>\n");
+                    } else {
+                        builder.append('>').append(key.getContent()).append("</key>\n");
+                    }
+
                     buildQueryExternalVariableSequence(builder, indentCount + 3, entryRep.value.values);
-                    builder.append(INDENTS, 0, indentCount + 2).append("</sx:entry>\n");
+
+                    if (useXmlnsPrefixes) {
+                        builder.append(INDENTS, 0, indentCount + 2).append("</sx:entry>\n");
+                    } else {
+                        builder.append(INDENTS, 0, indentCount + 2).append("</entry>\n");
+                    }
                 }
                 builder.append(INDENTS, 0, indentCount + 1);
 
@@ -1862,9 +2180,18 @@ public class RESTExternalVariableTest {
                 builder.append(((ValueRep) externalVariableSequenceItem).getContent());
             }
 
-            builder.append("</sx:value>\n");
+            if (useXmlnsPrefixes) {
+                builder.append("</sx:value>\n");
+            } else {
+                builder.append("</value>\n");
+            }
         }
-        builder.append(INDENTS, 0, indentCount).append("</sx:sequence>\n");
+
+        if (useXmlnsPrefixes) {
+            builder.append(INDENTS, 0, indentCount).append("</sx:sequence>\n");
+        } else {
+            builder.append(INDENTS, 0, indentCount).append("</sequence>\n");
+        }
     }
 
     private static String getServerUri() {

--- a/exist-core/src/test/java/org/exist/xquery/EmbeddedBinariesTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/EmbeddedBinariesTest.java
@@ -143,7 +143,7 @@ public class EmbeddedBinariesTest extends AbstractBinariesTest<Sequence, Item, I
 
                     consumer2E.accept(results);
                 } finally {
-                    //TODO(AR) performing #runCleanupTasks causes the stream to be closed, so if we do so before we are finished with the results, serialization fails.
+                    // NOTE(AR) performing #runCleanupTasks causes the stream to be closed, so if we do so before we are finished with the results, serialization fails.
                     if (fContext != null) {
                         fContext.runCleanupTasks();
                     }

--- a/extensions/modules/file/src/test/java/org/exist/xquery/modules/file/EmbeddedBinariesTest.java
+++ b/extensions/modules/file/src/test/java/org/exist/xquery/modules/file/EmbeddedBinariesTest.java
@@ -147,7 +147,7 @@ public class EmbeddedBinariesTest extends AbstractBinariesTest<Sequence, Item, I
 
                     consumer2E.accept(results);
                 } finally {
-                    //TODO(AR) performing #runCleanupTasks causes the stream to be closed, so if we do so before we are finished with the results, serialization fails.
+                    // NOTE(AR) performing #runCleanupTasks causes the stream to be closed, so if we do so before we are finished with the results, serialization fails.
                     if (fContext != null) {
                         fContext.runCleanupTasks();
                     }

--- a/schema/exist-rest-api.xsd
+++ b/schema/exist-rest-api.xsd
@@ -55,6 +55,16 @@
     </xs:annotation>
     <xs:complexType>
       <xs:sequence>
+        <xs:element name="context-item" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Context Item for the XQuery</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element ref="sx:value"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
         <xs:element name="properties" minOccurs="0">
           <xs:annotation>
             <xs:documentation>Properties to pass to the Serializer.</xs:documentation>

--- a/schema/exist-rest-api.xsd
+++ b/schema/exist-rest-api.xsd
@@ -65,6 +65,16 @@
             </xs:sequence>
           </xs:complexType>
         </xs:element>
+        <xs:element name="default-collection" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Values for the Default Collection of the Dynamic Context</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element ref="sx:sequence"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
         <xs:element name="properties" minOccurs="0">
           <xs:annotation>
             <xs:documentation>Properties to pass to the Serializer.</xs:documentation>


### PR DESCRIPTION
Backport of https://github.com/evolvedbinary/elemental/pull/199

This adds a number of fixes and features so that Elemental can be used for executing XQuery from XML Calabash 3 - see: https://codeberg.org/xmlcalabash/xmlcalabash3/pulls/673

Changes include:
* Better typing of input and output XDM values via the REST API.
* Ability to load the `conf.xml` from the package `org.exist.util` on the classpath.
* Context Item for query execution can now be set via the REST API.
* Default Collection of the Dynamic Context for query execution can now be set via the REST API.
* Auto Deployment of EXPath packages can be controlled from the CLI for the Java Admin Client and Jetty Server by using the argument `-a`.