### PR TITLE
[bugfix] fix relative xsl:import path resolution when stylesheet load

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/URIResolution.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/URIResolution.java
@@ -56,8 +56,13 @@ public class URIResolution {
         if (relativeURI.isAbsolute()) {
             return relative;
         }
-        var baseURI = new URI(base.getStringValue() );
+        var baseURI = new URI(base.getStringValue());
         if (!baseURI.isAbsolute()) {
+            var basePath = base.getStringValue();
+            if (basePath.startsWith("/")) {
+                var baseDir = basePath.substring(0, basePath.lastIndexOf('/') + 1);
+                return new AnyURIValue(XmldbURI.EMBEDDED_SERVER_URI_PREFIX + baseDir + relative.getStringValue());
+            }
             return relative;
         }
         try {

--- a/exist-core/src/test/java/org/exist/xquery/TransformTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/TransformTest.java
@@ -95,6 +95,38 @@ public class TransformTest {
                 "<p>End Template 1</p>" +
                 "</doc>", result);
     }
+
+    /**
+     * Tests that a stylesheet can import another stylesheet stored in the
+     * same database collection using a relative path (filename only, no directory).
+     * Stylesheet passed as a URI string.
+     */
+    @Test
+    public void transformWithSameDirectoryImport() throws XMLDBException {
+        String query =
+            "import module namespace transform='http://exist-db.org/xquery/transform';\n" +
+            "let $xml := <empty/>\n" +
+            "let $xsl := 'xmldb:exist:///db/"+TEST_COLLECTION_NAME+"/same-dir/a.xsl'\n" +
+            "return transform:transform($xml, $xsl, ())";
+        String result = execQuery(query);
+        assertEquals("<doc><p>From A</p><p>From B</p></doc>", result);
+    }
+
+    /**
+     * Tests that a stylesheet can import another stylesheet stored in the
+     * same database collection using a relative path (filename only, no directory).
+     * Stylesheet passed as a node via doc().
+     */
+    @Test
+    public void transformWithSameDirectoryImportViaNode() throws XMLDBException {
+        String query =
+            "import module namespace transform='http://exist-db.org/xquery/transform';\n" +
+            "let $xml := <empty/>\n" +
+            "let $xsl := doc('xmldb:exist:///db/"+TEST_COLLECTION_NAME+"/same-dir/a.xsl')\n" +
+            "return transform:transform($xml, $xsl, ())";
+        String result = execQuery(query);
+        assertEquals("<doc><p>From A</p><p>From B</p></doc>", result);
+    }
     
     
     private String execQuery(String query) throws XMLDBException {
@@ -171,6 +203,31 @@ public class TransformTest {
         addXMLDocument(xsl1, doc1, "1.xsl");
         addXMLDocument(xsl2, doc2, "2.xsl");
         addXMLDocument(xsl3, doc3, "3.xsl");
+
+        service =
+                testCollection.getService(
+                    CollectionManagementService.class);
+
+        Collection sameDir = service.createCollection("same-dir");
+        assertNotNull(sameDir);
+
+        String docA = "<?xml version='1.0' encoding='UTF-8'?>\n" +
+        "<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='1.0'>\n"+
+        "<xsl:import href='b.xsl'/>\n" +
+        "<xsl:template match='/'>" +
+        "<doc><p>From A</p><xsl:call-template name='from-b'/></doc>" +
+        "</xsl:template>" +
+        "</xsl:stylesheet>";
+
+        String docB = "<?xml version='1.0' encoding='UTF-8'?>\n" +
+        "<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='1.0'>\n"+
+        "<xsl:template name='from-b'>" +
+        "<p>From B</p>" +
+        "</xsl:template>" +
+        "</xsl:stylesheet>";
+
+        addXMLDocument(sameDir, docA, "a.xsl");
+        addXMLDocument(sameDir, docB, "b.xsl");
     }
 
     @After

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/transform/FunTransformITTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/transform/FunTransformITTest.java
@@ -58,6 +58,35 @@ import static org.junit.Assert.*;
  */
 public class FunTransformITTest {
 
+    private static final XmldbURI TEST_IMPORT_XSLT_COLLECTION = XmldbURI.create("/db/fn-transform-import-test");
+    private static final XmldbURI IMPORT_A_XSLT_NAME = XmldbURI.create("a.xsl");
+    private static final XmldbURI IMPORT_B_XSLT_NAME = XmldbURI.create("b.xsl");
+
+    private static final String IMPORT_A_XSLT =
+        "<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"1.0\">\n" +
+        "  <xsl:import href=\"b.xsl\"/>\n" +
+        "  <xsl:template match=\"/\">\n" +
+        "    <doc><p>From A</p><xsl:call-template name=\"from-b\"/></doc>\n" +
+        "  </xsl:template>\n" +
+        "</xsl:stylesheet>";
+
+    private static final String IMPORT_B_XSLT =
+        "<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"1.0\">\n" +
+        "  <xsl:template name=\"from-b\"><p>From B</p></xsl:template>\n" +
+        "</xsl:stylesheet>";
+
+    private static final String SAME_DIR_IMPORT_QUERY =
+        "fn:transform(map {\n" +
+        "  \"stylesheet-location\": \"xmldb:exist:///db/fn-transform-import-test/a.xsl\",\n" +
+        "  \"source-node\": document { <empty/> }\n" +
+        "})?output";
+
+    private static final String SAME_DIR_IMPORT_VIA_NODE_QUERY =
+        "fn:transform(map {\n" +
+        "  \"stylesheet-node\": doc(\"xmldb:exist:///db/fn-transform-import-test/a.xsl\"),\n" +
+        "  \"source-node\": document { <empty/> }\n" +
+        "})?output";
+
     private static final XmldbURI TEST_IDENTITY_XSLT_COLLECTION = XmldbURI.create("/db/transform-identity-test");
     private static final XmldbURI IDENTITY_XSLT_NAME = XmldbURI.create("xsl-identity.xslt");
 
@@ -143,6 +172,26 @@ public class FunTransformITTest {
     @ClassRule
     public static ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
 
+    /**
+     * Tests that fn:transform can resolve a relative xsl:import (same directory)
+     * when the stylesheet is given as a URI location.
+     */
+    @Test
+    public void sameDirectoryImportViaLocation() throws XPathException, PermissionDeniedException, EXistException {
+        final Source expected = Input.fromString("<doc><p>From A</p><p>From B</p></doc>").build();
+        expectQuery(SAME_DIR_IMPORT_QUERY, expected);
+    }
+
+    /**
+     * Tests that fn:transform can resolve a relative xsl:import (same directory)
+     * when the stylesheet is given as a node loaded from the database.
+     */
+    @Test
+    public void sameDirectoryImportViaNode() throws XPathException, PermissionDeniedException, EXistException {
+        final Source expected = Input.fromString("<doc><p>From A</p><p>From B</p></doc>").build();
+        expectQuery(SAME_DIR_IMPORT_VIA_NODE_QUERY, expected);
+    }
+
     @Test
     public void identityPersistentDom() throws XPathException, PermissionDeniedException, EXistException {
         final Source expected = Input.fromString(IDENTITY_XML).build();
@@ -210,6 +259,11 @@ public class FunTransformITTest {
             createCollection(broker, transaction, TEST_IDENTITY_XSLT_COLLECTION,
                 Tuple(IDENTITY_XSLT_NAME, IDENTITY_XSLT),
                 Tuple(IDENTITY_XML_NAME, IDENTITY_XML)
+            );
+
+            createCollection(broker, transaction, TEST_IMPORT_XSLT_COLLECTION,
+                Tuple(IMPORT_A_XSLT_NAME, IMPORT_A_XSLT),
+                Tuple(IMPORT_B_XSLT_NAME, IMPORT_B_XSLT)
             );
 
             transaction.commit();


### PR DESCRIPTION
When a stylesheet is loaded from the database via `doc()`, the base URI comes through as a plain path like `/db/collection/a.xsl` with no `xmldb:exist://` scheme. The URI resolver treated it as non-absolute and just returned the relative `href` unchanged, so `<xsl:import href="b.xsl"/>` failed even when `b.xsl` was sitting in the same collection.

The fix checks if the base path starts with `/` and if so rebuilds it as a full `xmldb:exist://` URI before resolving the import.