### PR TITLE
[6.x.x] Fix a regression fn:collection and xmldb:xcollection

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/ExtCollection.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/ExtCollection.java
@@ -218,15 +218,13 @@ public class ExtCollection extends Function {
             }
 
             if (docs == null || docs.getDocumentCount() == 0) {
-                return Sequence.EMPTY_SEQUENCE;
+                return items;
             }
 
             if (items == null) {
                 items = new ValueSequence(docs.getDocumentCount());
-            } else {
-                addAll(docs, items);
             }
-
+            addAll(docs, items);
             return items;
         }
     }


### PR DESCRIPTION
Fixes a regression introduced in 18ba2c0 where `fn:collection` and `xmldb:xcollection` under some circumstances could incorrectly return an empty sequence.