### PR TITLE
[6.x.x] Correct an issue with the Base URI of in-memory documents

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -777,6 +777,7 @@
                                 <include>src/test/resources/log4j2.xml</include>
                                 <include>src/test/resources/standalone-webapp/WEB-INF/web.xml</include>
                                 <include>src/main/xjb/rest-api.xjb</include>
+                                <include>src/test/xquery/base-uri.xql</include>
                                 <include>src/test/xquery/parenthesizedLocationStep.xml</include>
                                 <include>src/test/xquery/tail-recursion.xml</include>
                                 <include>src/test/xquery/maps/maps.xqm</include>
@@ -1483,6 +1484,7 @@
                                 <exclude>src/test/resources/log4j2.xml</exclude>
                                 <exclude>src/test/resources/standalone-webapp/WEB-INF/web.xml</exclude>
                                 <exclude>src/main/xjb/rest-api.xjb</exclude>
+                                <exclude>src/test/xquery/base-uri.xql</exclude>
                                 <exclude>src/test/xquery/binary-value.xqm</exclude>
                                 <exclude>src/test/xquery/parenthesizedLocationStep.xml</exclude>
                                 <exclude>src/test/xquery/pi.xqm</exclude>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -865,6 +865,7 @@
                                 <include>src/main/java/org/exist/dom/QName.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/AbstractCharacterData.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/AttrImpl.java</include>
+                                <include>src/main/java/org/exist/dom/memtree/CommentImpl.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/DocumentBuilderReceiver.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/DocumentImpl.java</include>
                                 <include>src/test/java/org/exist/dom/memtree/DocumentImplTest.java</include>
@@ -896,6 +897,7 @@
                                 <include>src/main/java/org/exist/dom/persistent/LockToken.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/Match.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java</include>
+                                <include>src/main/java/org/exist/dom/persistent/NodeImpl.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/NodeProxy.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/NodeSet.java</include>
                                 <include>src/test/java/org/exist/dom/persistent/NodeTest.java</include>
@@ -1576,6 +1578,7 @@
                                 <exclude>src/main/java/org/exist/dom/QName.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/AbstractCharacterData.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/AttrImpl.java</exclude>
+                                <include>src/main/java/org/exist/dom/memtree/CommentImpl.java</include>
                                 <exclude>src/main/java/org/exist/dom/memtree/DocumentBuilderReceiver.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/DocumentImpl.java</exclude>
                                 <exclude>src/test/java/org/exist/dom/memtree/DocumentImplTest.java</exclude>
@@ -1615,6 +1618,7 @@
                                 <exclude>src/main/java/org/exist/dom/persistent/LockToken.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/Match.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java</exclude>
+                                <exclude>src/main/java/org/exist/dom/persistent/NodeImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/NodeProxy.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/NodeSet.java</exclude>
                                 <exclude>src/test/java/org/exist/dom/persistent/NodeTest.java</exclude>

--- a/exist-core/src/main/java/org/exist/dom/memtree/AttrImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/AttrImpl.java
@@ -53,6 +53,8 @@ import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.Type;
 import org.w3c.dom.*;
 
+import javax.annotation.Nullable;
+
 
 public class AttrImpl extends NodeImpl implements Attr {
 
@@ -90,9 +92,9 @@ public class AttrImpl extends NodeImpl implements Attr {
     }
 
     @Override
-    public String getBaseURI() {
-        final Node parent = document.getNode(document.attrParent[nodeNumber]);
-        if(parent == null) {
+    public @Nullable String getBaseURI() {
+        @Nullable final Node parent = document.getNode(document.attrParent[nodeNumber]);
+        if (parent == null) {
             return null;
         }
         return parent.getBaseURI();

--- a/exist-core/src/main/java/org/exist/dom/memtree/CommentImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/CommentImpl.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -29,6 +53,8 @@ import org.exist.xquery.value.Type;
 import org.w3c.dom.Comment;
 import org.w3c.dom.Node;
 
+import javax.annotation.Nullable;
+
 public class CommentImpl extends AbstractCharacterData implements Comment {
 
     public CommentImpl(final DocumentImpl doc, final int nodeNumber) {
@@ -53,9 +79,9 @@ public class CommentImpl extends AbstractCharacterData implements Comment {
     }
 
     @Override
-    public String getBaseURI() {
-        final Node parent = getParentNode();
-        if(parent == null) {
+    public @Nullable String getBaseURI() {
+        @Nullable final Node parent = getParentNode();
+        if (parent == null) {
             return null;
         }
         return parent.getBaseURI();

--- a/exist-core/src/main/java/org/exist/dom/memtree/DocumentImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/DocumentImpl.java
@@ -1657,19 +1657,29 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
     }
 
     @Override
-    public String getBaseURI() {
-        final String docURI = getDocumentURI();
-        if(docURI != null) {
-            return docURI;
-        }
-        if(context != null && context.isBaseURIDeclared()) {
-            try {
-                return context.getBaseURI().getStringValue();
-            } catch(final XPathException e) {
-                //TODO : make something !
+    public @Nullable String getBaseURI() {
+        @Nullable final Element el = getDocumentElement();
+        if (el != null) {
+            final String baseURI = getDocumentElement().getAttributeNS(Namespaces.XML_NS, "base");
+            if (!baseURI.isEmpty()) {
+                return baseURI;
             }
         }
-        return XmldbURI.EMPTY_URI.toString();
+
+        @Nullable final String docURI = getDocumentURI();
+        if (docURI != null) {
+            return docURI;
+        } else {
+            if (context != null && context.isBaseURIDeclared()) {
+                try {
+                    return context.getBaseURI().getStringValue();
+                } catch (final XPathException e) {
+                    // no-op
+                }
+            }
+
+            return null;
+        }
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/dom/memtree/DocumentImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/DocumentImpl.java
@@ -1658,26 +1658,18 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
 
     @Override
     public String getBaseURI() {
-        final Element el = getDocumentElement();
-        if(el != null) {
-            final String baseURI = getDocumentElement().getAttributeNS(Namespaces.XML_NS, "base");
-            if(baseURI != null) {
-                return baseURI;
-            }
-        }
         final String docURI = getDocumentURI();
         if(docURI != null) {
             return docURI;
-        } else {
-            if(context!=null && context.isBaseURIDeclared()) {
-                try {
-                    return context.getBaseURI().getStringValue();
-                } catch(final XPathException e) {
-                    //TODO : make something !
-                }
-            }
-            return XmldbURI.EMPTY_URI.toString();
         }
+        if(context != null && context.isBaseURIDeclared()) {
+            try {
+                return context.getBaseURI().getStringValue();
+            } catch(final XPathException e) {
+                //TODO : make something !
+            }
+        }
+        return XmldbURI.EMPTY_URI.toString();
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/dom/memtree/ElementImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/ElementImpl.java
@@ -61,6 +61,7 @@ import org.exist.xquery.value.Type;
 import org.exist.xquery.value.ValueSequence;
 import org.w3c.dom.*;
 
+import javax.annotation.Nullable;
 import javax.xml.XMLConstants;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -619,18 +620,18 @@ public class ElementImpl extends NodeImpl implements Element {
     }
 
     @Override
-    public String getBaseURI() {
-        final XmldbURI baseURI = calculateBaseURI();
-        if(baseURI != null) {
+    public @Nullable String getBaseURI() {
+        @Nullable final XmldbURI baseURI = calculateBaseURI();
+        if (baseURI != null) {
             return baseURI.toString();
         }
 
-        return "";//UNDERSTAND: is it ok?
+        return null;
     }
 
     // NOTE(AR) please keep in sync with org.exist.dom.persistent.ElementImpl
-    private XmldbURI calculateBaseURI() {
-        XmldbURI baseURI = null;
+    private @Nullable XmldbURI calculateBaseURI() {
+        @Nullable XmldbURI baseURI = null;
 
         final String nodeBaseURI = getAttributeNS(Namespaces.XML_NS, "base");
         if (!nodeBaseURI.isEmpty()) {
@@ -648,27 +649,32 @@ public class ElementImpl extends NodeImpl implements Element {
 
         if (parent != -1) {
             if (nodeBaseURI.isEmpty()) {
-                baseURI = ((ElementImpl) document.getNode(parent))
-                    .calculateBaseURI();
+                baseURI = ((ElementImpl) document.getNode(parent)).calculateBaseURI();
             } else {
-                final XmldbURI parentsBaseURI = ((ElementImpl) document.getNode(parent)).calculateBaseURI();
-                if (parentsBaseURI.toString().endsWith("/") || !parentsBaseURI.toString().contains("/")) {
-                    baseURI = parentsBaseURI.append(baseURI);
+                @Nullable final XmldbURI parentsBaseURI = ((ElementImpl) document.getNode(parent)).calculateBaseURI();
+                if (parentsBaseURI == null) {
+                    baseURI = null;
                 } else {
-                    // there is a filename, remove it
-                    baseURI = parentsBaseURI.removeLastSegment().append(baseURI);
+                    if (parentsBaseURI.toString().endsWith("/") || !parentsBaseURI.toString().contains("/")) {
+                        baseURI = parentsBaseURI.append(baseURI);
+                    } else {
+                        // there is a filename, remove it
+                        baseURI = parentsBaseURI.removeLastSegment().append(baseURI);
+                    }
                 }
             }
         } else {
-            if (nodeBaseURI.isEmpty()) {
-                return XmldbURI.create(getOwnerDocument().getBaseURI(), false);
+            @Nullable final String docBaseURI = getOwnerDocument().getBaseURI();
+            if (docBaseURI == null) {
+                baseURI = null;
+            } else if (nodeBaseURI.isEmpty()) {
+                baseURI = XmldbURI.create(docBaseURI, false);
             } else if (nodeNumber != 1) {
-                final String docBaseURI = getOwnerDocument().getBaseURI();
                 if (docBaseURI.endsWith("/")) {
-                    baseURI = XmldbURI.create(getOwnerDocument().getBaseURI(), false);
+                    baseURI = XmldbURI.create(docBaseURI, false);
                     baseURI.append(baseURI);
                 } else {
-                    baseURI = XmldbURI.create(getOwnerDocument().getBaseURI(), false);
+                    baseURI = XmldbURI.create(docBaseURI, false);
                     baseURI = baseURI.removeLastSegment();
                     baseURI.append(baseURI);
                 }

--- a/exist-core/src/main/java/org/exist/dom/memtree/NodeImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/NodeImpl.java
@@ -804,7 +804,7 @@ public abstract class NodeImpl<T extends NodeImpl<T>> implements INode<DocumentI
     }
 
     @Override
-    public String getBaseURI() {
+    public @Nullable String getBaseURI() {
         return null;
     }
 

--- a/exist-core/src/main/java/org/exist/dom/memtree/ProcessingInstructionImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/ProcessingInstructionImpl.java
@@ -57,6 +57,8 @@ import org.w3c.dom.DOMException;
 import org.w3c.dom.Node;
 import org.w3c.dom.ProcessingInstruction;
 
+import javax.annotation.Nullable;
+
 
 public class ProcessingInstructionImpl extends NodeImpl implements ProcessingInstruction {
 
@@ -102,37 +104,12 @@ public class ProcessingInstructionImpl extends NodeImpl implements ProcessingIns
     }
 
     @Override
-    public String getBaseURI() {
-        String baseURI = "";
-        int parent = -1;
-        int test = document.getParentNodeFor(nodeNumber);
-
-        if(document.nodeKind[test] != Node.DOCUMENT_NODE) {
-            parent = test;
+    public @Nullable String getBaseURI() {
+        @Nullable final Node parent = getParentNode();
+        if (parent == null) {
+            return null;
         }
-
-        // fixme! Testa med 0/ljo
-        while((parent != -1) && (document.getNode(parent).getBaseURI() != null)) {
-
-            if(baseURI.isEmpty()) {
-                baseURI = document.getNode(parent).getBaseURI();
-            } else {
-                baseURI = document.getNode(parent).getBaseURI() + "/" + baseURI;
-            }
-
-            test = document.getParentNodeFor(parent);
-
-            if(document.nodeKind[test] == Node.DOCUMENT_NODE) {
-                return (baseURI);
-            } else {
-                parent = test;
-            }
-        }
-
-        if(baseURI.isEmpty()) {
-            baseURI = getOwnerDocument().getBaseURI();
-        }
-        return (baseURI);
+        return parent.getBaseURI();
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/dom/memtree/TextImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/TextImpl.java
@@ -24,7 +24,10 @@ package org.exist.dom.memtree;
 import org.exist.xquery.Expression;
 import org.exist.xquery.value.Type;
 import org.w3c.dom.DOMException;
+import org.w3c.dom.Node;
 import org.w3c.dom.Text;
+
+import javax.annotation.Nullable;
 
 
 public class TextImpl extends AbstractCharacterData implements Text {
@@ -40,6 +43,15 @@ public class TextImpl extends AbstractCharacterData implements Text {
     @Override
     public int getItemType() {
         return Type.TEXT;
+    }
+
+    @Override
+    public @Nullable String getBaseURI() {
+        @Nullable final Node parent = getParentNode();
+        if (parent == null) {
+            return null;
+        }
+        return parent.getBaseURI();
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/dom/persistent/AttrImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/AttrImpl.java
@@ -60,6 +60,7 @@ import org.exist.util.serializer.AttrList;
 import org.exist.xquery.Expression;
 import org.w3c.dom.*;
 
+import javax.annotation.Nullable;
 import javax.xml.XMLConstants;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -430,9 +431,9 @@ public class AttrImpl extends NamedNode<AttrImpl> implements Attr {
     }
 
     @Override
-    public String getBaseURI() {
-        final Element e = getOwnerElement();
-        if(e != null) {
+    public @Nullable String getBaseURI() {
+        @Nullable final Element e = getOwnerElement();
+        if (e != null) {
             return e.getBaseURI();
         }
         return null;

--- a/exist-core/src/main/java/org/exist/dom/persistent/CommentImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/CommentImpl.java
@@ -53,6 +53,8 @@ import org.exist.xquery.Expression;
 import org.w3c.dom.Comment;
 import org.w3c.dom.Node;
 
+import javax.annotation.Nullable;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class CommentImpl extends AbstractCharacterData<CommentImpl> implements Comment {
@@ -84,6 +86,16 @@ public class CommentImpl extends AbstractCharacterData<CommentImpl> implements C
     @Override
     public String toString() {
         return "<!-- " + cdata.toString() + " -->";
+    }
+
+    @Override
+    public @Nullable String getBaseURI() {
+        @Nullable final Node parent = getParentNode();
+        if (parent != null) {
+            return parent.getBaseURI();
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/dom/persistent/ElementImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/ElementImpl.java
@@ -2018,18 +2018,18 @@ public class ElementImpl extends NamedNode<ElementImpl> implements Element {
     }
 
     @Override
-    public String getBaseURI() {
-        final XmldbURI baseURI = calculateBaseURI();
-        if(baseURI != null) {
+    public @Nullable String getBaseURI() {
+        @Nullable final XmldbURI baseURI = calculateBaseURI();
+        if (baseURI != null) {
             return baseURI.toString();
         }
 
-        return ""; //UNDERSTAND: is it ok?
+        return null;
     }
 
     // NOTE(AR) please keep in sync with org.exist.dom.memtree.ElementImpl
     private XmldbURI calculateBaseURI() {
-        XmldbURI baseURI = null;
+        @Nullable XmldbURI baseURI = null;
 
         final String nodeBaseURI = getAttributeNS(Namespaces.XML_NS, "base");
         if (!nodeBaseURI.isEmpty()) {
@@ -2040,28 +2040,35 @@ public class ElementImpl extends NamedNode<ElementImpl> implements Element {
         }
 
         final IStoredNode<?> parent = getParentStoredNode();
+
         if (parent != null) {
             if (nodeBaseURI.isEmpty()) {
                 baseURI = ((ElementImpl) parent).calculateBaseURI();
             } else {
-                final XmldbURI parentsBaseURI = ((ElementImpl) parent).calculateBaseURI();
-                if (parentsBaseURI.toString().endsWith("/") || !parentsBaseURI.toString().contains("/")) {
-                    baseURI = parentsBaseURI.append(baseURI);
+                @Nullable final XmldbURI parentsBaseURI = ((ElementImpl) parent).calculateBaseURI();
+                if (parentsBaseURI == null) {
+                    baseURI = null;
                 } else {
-                    // there is a filename, remove it
-                    baseURI = parentsBaseURI.removeLastSegment().append(baseURI);
+                    if (parentsBaseURI.toString().endsWith("/") || !parentsBaseURI.toString().contains("/")) {
+                        baseURI = parentsBaseURI.append(baseURI);
+                    } else {
+                        // there is a filename, remove it
+                        baseURI = parentsBaseURI.removeLastSegment().append(baseURI);
+                    }
                 }
             }
         } else {
-            if (nodeBaseURI.isEmpty()) {
-                return XmldbURI.create(getOwnerDocument().getBaseURI(), false);
+            @Nullable final String docBaseURI = getOwnerDocument().getBaseURI();
+            if (docBaseURI == null) {
+                baseURI = null;
+            } else if (nodeBaseURI.isEmpty()) {
+                baseURI = XmldbURI.create(docBaseURI, false);
             } else {
-                final String docBaseURI = getOwnerDocument().getBaseURI();
                 if (docBaseURI.endsWith("/")) {
-                    baseURI = XmldbURI.create(getOwnerDocument().getBaseURI(), false);
+                    baseURI = XmldbURI.create(docBaseURI, false);
                     baseURI.append(baseURI);
                 } else {
-                    baseURI = XmldbURI.create(getOwnerDocument().getBaseURI(), false);
+                    baseURI = XmldbURI.create(docBaseURI, false);
                     baseURI = baseURI.removeLastSegment();
                     baseURI.append(baseURI);
                 }

--- a/exist-core/src/main/java/org/exist/dom/persistent/NodeImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NodeImpl.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -30,6 +54,7 @@ import org.exist.storage.txn.Txn;
 import org.exist.xquery.Expression;
 import org.w3c.dom.*;
 
+import javax.annotation.Nullable;
 import javax.xml.XMLConstants;
 
 public abstract class NodeImpl<T extends NodeImpl> implements INode<DocumentImpl, T> {
@@ -187,8 +212,8 @@ public abstract class NodeImpl<T extends NodeImpl> implements INode<DocumentImpl
     }
 
     @Override
-    public String getBaseURI() {
-        throw unsupported();
+    public @Nullable String getBaseURI() {
+        return null;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/dom/persistent/ProcessingInstructionImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/ProcessingInstructionImpl.java
@@ -55,6 +55,8 @@ import org.w3c.dom.DOMException;
 import org.w3c.dom.Node;
 import org.w3c.dom.ProcessingInstruction;
 
+import javax.annotation.Nullable;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -148,13 +150,10 @@ public class ProcessingInstructionImpl extends NamedNode<ProcessingInstructionIm
         this.data = data;
     }
 
-    /**
-     * ? @see org.w3c.dom.Node#getBaseURI()
-     */
     @Override
-    public String getBaseURI() {
-        final StoredNode parent = getParentStoredNode();
-        if(parent != null) {
+    public @Nullable String getBaseURI() {
+        @Nullable final StoredNode parent = getParentStoredNode();
+        if (parent != null) {
             return parent.getBaseURI();
         } else {
             return getOwnerDocument().getBaseURI();

--- a/exist-core/src/main/java/org/exist/dom/persistent/TextImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/TextImpl.java
@@ -58,6 +58,8 @@ import org.w3c.dom.Node;
 import org.w3c.dom.Text;
 import org.w3c.dom.UserDataHandler;
 
+import javax.annotation.Nullable;
+
 /**
  * TextImpl.java
  *
@@ -175,9 +177,9 @@ public class TextImpl extends AbstractCharacterData<TextImpl> implements Text {
     }
 
     @Override
-    public String getBaseURI() {
-        final Node parent = getParentNode();
-        if(parent != null) {
+    public @Nullable String getBaseURI() {
+        @Nullable final Node parent = getParentNode();
+        if (parent != null) {
             return parent.getBaseURI();
         } else {
             return null;

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunBaseURI.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunBaseURI.java
@@ -50,6 +50,7 @@ import org.exist.xquery.*;
 import org.exist.xquery.value.*;
 import org.w3c.dom.Node;
 
+import javax.annotation.Nullable;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -172,7 +173,7 @@ public class FunBaseURI extends BasicFunction {
         final boolean hasContextBaseURI = context.isBaseURIDeclared();
 
         // "" when not set, can be null
-        final String nodeBaseURI = node.getBaseURI();
+        @Nullable final String nodeBaseURI = node.getBaseURI();
         final boolean hasNodeBaseURI = notNullOrEmptyOrWs(nodeBaseURI);
 
         try {

--- a/exist-core/src/test/java/org/exist/dom/memtree/DocumentImplTest.java
+++ b/exist-core/src/test/java/org/exist/dom/memtree/DocumentImplTest.java
@@ -206,6 +206,36 @@ public class DocumentImplTest {
         assertEquals(Namespaces.XHTML_NS, namespaceUri);
     }
 
+    @Test
+    public void getBaseURI_withDocumentURI() throws IOException, SAXException, ParserConfigurationException {
+        final DocumentImpl doc;
+        try(final InputStream is = new UnsynchronizedByteArrayInputStream("<root/>".getBytes(UTF_8))) {
+            doc = parseExist(is);
+        }
+        doc.setDocumentURI("file:///intranet/xsl/template.xsl");
+        assertEquals("file:///intranet/xsl/template.xsl", doc.getBaseURI());
+    }
+
+    @Test
+    public void getBaseURI_prefersXmlBaseOnRoot() throws IOException, SAXException, ParserConfigurationException {
+        final DocumentImpl doc;
+        try(final InputStream is = new UnsynchronizedByteArrayInputStream(
+                "<root xml:base=\"http://example.org/\"/>".getBytes(UTF_8))) {
+            doc = parseExist(is);
+        }
+        doc.setDocumentURI("file:///intranet/xsl/template.xsl");
+        assertEquals("http://example.org/", doc.getBaseURI());
+    }
+
+    @Test
+    public void getBaseURI_noDocumentURI() throws IOException, SAXException, ParserConfigurationException {
+        final DocumentImpl doc;
+        try(final InputStream is = new UnsynchronizedByteArrayInputStream("<root/>".getBytes(UTF_8))) {
+            doc = parseExist(is);
+        }
+        assertNull("", doc.getBaseURI());
+    }
+
     private Document parseXerces(final InputStream is) throws ParserConfigurationException, SAXException, IOException {
         final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(true);

--- a/exist-core/src/test/xquery/base-uri.xql
+++ b/exist-core/src/test/xquery/base-uri.xql
@@ -1,4 +1,28 @@
 (:
+ : Elemental
+ : Copyright (C) 2024, Evolved Binary Ltd
+ :
+ : admin@evolvedbinary.com
+ : https://www.evolvedbinary.com | https://www.elemental.xyz
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; version 2.1.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :
+ : NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ :       The original license header is included below.
+ :
+ : =====================================================================
+ :
  : eXist-db Open Source Native XML Database
  : Copyright (C) 2001 The eXist-db Authors
  :
@@ -100,7 +124,7 @@ function baseuri:root() {
 };
 
 declare
-    %test:assertEquals("http://example.org/a/","http://example.org/b/","http://example.org/c/","/yy","zz")
+    %test:assertEquals("http://example.org/a/","http://example.org/b/","http://example.org/c/","/yy")
 function baseuri:sub1() {
      for $sub in $baseuri:DOCUMENT//sub
      return base-uri($sub)


### PR DESCRIPTION
Backport of https://github.com/evolvedbinary/elemental/pull/204

1. Base URI of in-memory documents is now correctly returned. 

2. The DOM implementation for both persistent and in-memory nodes has been updated to match the W3C DOM spec for `org.w3.dom.Node#getBaseURI()`.

3. Base URI is now implemented for in-memory DOM Text and Comment Nodes.

Closes #186 