### PR TITLE
[7.x.x] BaseURI is now a valid URI

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -806,6 +806,7 @@
                                 <include>src/test/xquery/base-uri.xql</include>
                                 <include>src/test/xquery/parenthesizedLocationStep.xml</include>
                                 <include>src/test/xquery/tail-recursion.xml</include>
+                                <include>src/test/xquery/indexing/indexes-base-uri.xq</include>
                                 <include>src/test/xquery/maps/maps.xqm</include>
                                 <include>src/test/xquery/numbers/format-numbers.xql</include>
                                 <include>src/test/xquery/util/util.xml</include>
@@ -894,6 +895,7 @@
                                 <include>src/main/java/org/exist/dom/QName.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/AbstractCharacterData.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/AttrImpl.java</include>
+                                <include>src/main/java/org/exist/dom/memtree/CDATASectionImpl.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/CommentImpl.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/DocumentBuilderReceiver.java</include>
                                 <include>src/main/java/org/exist/dom/memtree/DocumentImpl.java</include>
@@ -913,6 +915,7 @@
                                 <include>src/test/java/org/exist/dom/persistent/BasicNodeSetTest.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/BinaryDocument.java</include>
                                 <include>src/test/java/org/exist/dom/persistent/CDataIntergationTest.java</include>
+                                <include>src/main/java/org/exist/dom/persistent/CDATASectionImpl.java</include>
                                 <include>src/main/java/org/exist/dom/persistent/CommentImpl.java</include>
                                 <include>src/test/java/org/exist/dom/persistent/CommentTest.java</include>
                                 <include>src/test/java/org/exist/dom/persistent/DefaultDocumentSetTest.java</include>
@@ -1115,6 +1118,7 @@
                                 <include>src/test/java/org/exist/util/CollationsTest.java</include>
                                 <include>src/main/java/org/exist/util/Configuration.java</include>
                                 <include>src/test/java/org/exist/util/DOMSerializerTest.java</include>
+                                <include>src/main/java/org/exist/util/EXistURISchemeURIResolver.java</include>
                                 <include>src/test/java/org/exist/util/LeasableTest.java</include>
                                 <include>src/test/java/org/exist/util/MediaTypeResolverTest.java</include>
                                 <include>src/main/java/org/exist/util/MimeTable.java</include>
@@ -1417,6 +1421,7 @@
                                 <include>src/test/java/org/exist/xquery/functions/validate/JingSchematronTest.java</include>
                                 <include>src/test/java/org/exist/xquery/functions/validate/JingXsdTest.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/validation/Jaxp.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/validation/Shared.java</include>
                                 <include>src/test/java/org/exist/xquery/functions/xmldb/DbStore2Test.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/xmldb/FunXCollection.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/xmldb/XMLDBGetMimeType.java</include>
@@ -1522,6 +1527,7 @@
                                 <exclude>src/test/xquery/pi.xqm</exclude>
                                 <exclude>src/test/xquery/tail-recursion.xml</exclude>
                                 <exclude>src/test/xquery/type-promotion.xqm</exclude>
+                                <exclude>src/test/xquery/indexing/indexes-base-uri.xq</exclude>
                                 <exclude>src/test/xquery/maps/maps.xqm</exclude>
                                 <exclude>src/test/xquery/numbers/format-numbers.xql</exclude>
                                 <exclude>src/test/xquery/securitymanager/acl.xqm</exclude>
@@ -1616,7 +1622,8 @@
                                 <exclude>src/main/java/org/exist/dom/QName.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/AbstractCharacterData.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/AttrImpl.java</exclude>
-                                <include>src/main/java/org/exist/dom/memtree/CommentImpl.java</include>
+                                <exclude>src/main/java/org/exist/dom/memtree/CDATASectionImpl.java</exclude>
+                                <exclude>src/main/java/org/exist/dom/memtree/CommentImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/DocumentBuilderReceiver.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/memtree/DocumentImpl.java</exclude>
                                 <exclude>src/test/java/org/exist/dom/memtree/DocumentImplTest.java</exclude>
@@ -1643,6 +1650,7 @@
                                 <exclude>src/test/java/org/exist/dom/persistent/BasicNodeSetTest.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/BinaryDocument.java</exclude>
                                 <exclude>src/test/java/org/exist/dom/persistent/CDataIntergationTest.java</exclude>
+                                <exclude>src/main/java/org/exist/dom/persistent/CDATASectionImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/dom/persistent/CommentImpl.java</exclude>
                                 <exclude>src/test/java/org/exist/dom/persistent/CommentTest.java</exclude>
                                 <exclude>src/test/java/org/exist/dom/persistent/DefaultDocumentSetTest.java</exclude>
@@ -1913,6 +1921,7 @@
                                 <exclude>src/test/java/org/exist/util/CollectionOfArrayIteratorTest.java</exclude>
                                 <exclude>src/main/java/org/exist/util/Configuration.java</exclude>
                                 <exclude>src/test/java/org/exist/util/DOMSerializerTest.java</exclude>
+                                <exclude>src/main/java/org/exist/util/EXistURISchemeURIResolver.java</exclude>
                                 <exclude>src/main/java/org/exist/util/IPUtil.java</exclude>
                                 <exclude>src/main/java/org/exist/util/JREUtil.java</exclude>
                                 <exclude>src/test/java/org/exist/util/LeasableTest.java</exclude>
@@ -2254,6 +2263,7 @@
                                 <exclude>src/test/java/org/exist/xquery/functions/validate/JingSchematronTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/validate/JingXsdTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/validation/Jaxp.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/validation/Shared.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/xmldb/AbstractXMLDBTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/xmldb/DbStore2Test.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/xmldb/FunXCollection.java</exclude>

--- a/exist-core/src/main/java/org/exist/dom/memtree/CDATASectionImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/CDATASectionImpl.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -25,7 +49,10 @@ import org.exist.xquery.Expression;
 import org.exist.xquery.value.Type;
 import org.w3c.dom.CDATASection;
 import org.w3c.dom.DOMException;
+import org.w3c.dom.Node;
 import org.w3c.dom.Text;
+
+import javax.annotation.Nullable;
 
 
 /**
@@ -46,6 +73,15 @@ public class CDATASectionImpl extends AbstractCharacterData implements CDATASect
     @Override
     public int getItemType() {
         return Type.CDATA_SECTION;
+    }
+
+    @Override
+    public @Nullable String getBaseURI() {
+        @Nullable final Node parent = getParentNode();
+        if (parent == null) {
+            return null;
+        }
+        return parent.getBaseURI();
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/dom/persistent/AttrImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/AttrImpl.java
@@ -57,6 +57,7 @@ import org.exist.util.UTF8;
 import org.exist.util.XMLString;
 import org.exist.util.pool.NodePool;
 import org.exist.util.serializer.AttrList;
+import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.Expression;
 import org.w3c.dom.*;
 
@@ -425,7 +426,12 @@ public class AttrImpl extends NamedNode<AttrImpl> implements Attr {
     public @Nullable String getBaseURI() {
         @Nullable final Element e = getOwnerElement();
         if (e != null) {
-            return e.getBaseURI();
+            @Nullable String strBaseUri = e.getBaseURI();
+            if (strBaseUri != null && strBaseUri.startsWith("/db/")) {
+                // Must be a URI!
+                strBaseUri = XmldbURI.EMBEDDED_SERVER_URI_PREFIX + strBaseUri;
+            }
+            return strBaseUri;
         }
         return null;
     }

--- a/exist-core/src/main/java/org/exist/dom/persistent/CDATASectionImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/CDATASectionImpl.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -27,11 +51,14 @@ import org.exist.util.ByteArrayPool;
 import org.exist.util.ByteConversion;
 import org.exist.util.UTF8;
 import org.exist.util.XMLString;
+import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.Expression;
 import org.w3c.dom.CDATASection;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Node;
 import org.w3c.dom.Text;
+
+import javax.annotation.Nullable;
 
 public class CDATASectionImpl extends AbstractCharacterData implements CDATASection {
 
@@ -77,6 +104,20 @@ public class CDATASectionImpl extends AbstractCharacterData implements CDATASect
     }
 
     @Override
+    public @Nullable String getBaseURI() {
+        @Nullable final Node parent = getParentNode();
+        if (parent != null) {
+            @Nullable String strBaseUri = parent.getBaseURI();
+            if (strBaseUri != null && strBaseUri.startsWith("/db/")) {
+                // Must be a URI!
+                strBaseUri = XmldbURI.EMBEDDED_SERVER_URI_PREFIX + strBaseUri;
+            }
+            return strBaseUri;
+        } else {
+            return null;
+        }
+    }
+
     /**
      * Serializes a (persistent DOM) CDATA Section to a byte array
      *
@@ -94,6 +135,7 @@ public class CDATASectionImpl extends AbstractCharacterData implements CDATASect
      * @return the returned byte array after use must be returned to the ByteArrayPool
      *     by calling {@link ByteArrayPool#releaseByteArray(byte[])}
      */
+    @Override
     public byte[] serialize() {
         final int nodeIdLen = nodeId.size();
         final byte[] data = ByteArrayPool.getByteArray(LENGTH_SIGNATURE_LENGTH + NodeId.LENGTH_NODE_ID_UNITS +

--- a/exist-core/src/main/java/org/exist/dom/persistent/CommentImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/CommentImpl.java
@@ -49,6 +49,7 @@ import org.exist.numbering.NodeId;
 import org.exist.storage.Signatures;
 import org.exist.util.ByteConversion;
 import org.exist.util.pool.NodePool;
+import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.Expression;
 import org.w3c.dom.Comment;
 import org.w3c.dom.Node;
@@ -92,7 +93,12 @@ public class CommentImpl extends AbstractCharacterData<CommentImpl> implements C
     public @Nullable String getBaseURI() {
         @Nullable final Node parent = getParentNode();
         if (parent != null) {
-            return parent.getBaseURI();
+            @Nullable String strBaseUri = parent.getBaseURI();
+            if (strBaseUri != null && strBaseUri.startsWith("/db/")) {
+                // Must be a URI!
+                strBaseUri = XmldbURI.EMBEDDED_SERVER_URI_PREFIX + strBaseUri;
+            }
+            return strBaseUri;
         } else {
             return null;
         }

--- a/exist-core/src/main/java/org/exist/dom/persistent/DocumentImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/DocumentImpl.java
@@ -1681,7 +1681,7 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Resource, Do
 
     @Override
     public String getBaseURI() {
-        return getURI().toString();
+        return XmldbURI.EMBEDDED_SERVER_URI_PREFIX + getURI().getCollectionPath();
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/dom/persistent/ElementImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/ElementImpl.java
@@ -2003,7 +2003,12 @@ public class ElementImpl extends NamedNode<ElementImpl> implements Element {
     public @Nullable String getBaseURI() {
         @Nullable final XmldbURI baseURI = calculateBaseURI();
         if (baseURI != null) {
-            return baseURI.toString();
+            String strBaseUri = baseURI.toString();
+            if (strBaseUri.startsWith("/db/")) {
+                // Must be a URI!
+                strBaseUri = XmldbURI.EMBEDDED_SERVER_URI_PREFIX + baseURI;
+            }
+            return strBaseUri;
         }
 
         return null;

--- a/exist-core/src/main/java/org/exist/dom/persistent/ProcessingInstructionImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/ProcessingInstructionImpl.java
@@ -50,6 +50,7 @@ import org.exist.numbering.NodeId;
 import org.exist.storage.Signatures;
 import org.exist.util.ByteConversion;
 import org.exist.util.pool.NodePool;
+import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.Expression;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Node;
@@ -154,7 +155,12 @@ public class ProcessingInstructionImpl extends NamedNode<ProcessingInstructionIm
     public @Nullable String getBaseURI() {
         @Nullable final StoredNode parent = getParentStoredNode();
         if (parent != null) {
-            return parent.getBaseURI();
+            @Nullable String strBaseUri = parent.getBaseURI();
+            if (strBaseUri != null && strBaseUri.startsWith("/db/")) {
+                // Must be a URI!
+                strBaseUri = XmldbURI.EMBEDDED_SERVER_URI_PREFIX + strBaseUri;
+            }
+            return strBaseUri;
         } else {
             return getOwnerDocument().getBaseURI();
         }

--- a/exist-core/src/main/java/org/exist/dom/persistent/TextImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/TextImpl.java
@@ -52,6 +52,7 @@ import org.exist.util.ByteArrayPool;
 import org.exist.util.ByteConversion;
 import org.exist.util.UTF8;
 import org.exist.util.pool.NodePool;
+import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.Expression;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Node;
@@ -180,7 +181,12 @@ public class TextImpl extends AbstractCharacterData<TextImpl> implements Text {
     public @Nullable String getBaseURI() {
         @Nullable final Node parent = getParentNode();
         if (parent != null) {
-            return parent.getBaseURI();
+            @Nullable String strBaseUri = parent.getBaseURI();
+            if (strBaseUri != null && strBaseUri.startsWith("/db/")) {
+                // Must be a URI!
+                strBaseUri = XmldbURI.EMBEDDED_SERVER_URI_PREFIX + strBaseUri;
+            }
+            return strBaseUri;
         } else {
             return null;
         }

--- a/exist-core/src/main/java/org/exist/util/EXistURISchemeURIResolver.java
+++ b/exist-core/src/main/java/org/exist/util/EXistURISchemeURIResolver.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -56,6 +80,8 @@ public class EXistURISchemeURIResolver implements URIResolver {
                 uri = uri.replace("exist://localhost/db", "/db");
             } else if (uri.startsWith("exist://")) {
                 uri = uri.replace("exist://", "xmldb:exist://");
+            } else if (uri.startsWith("exist:/")) {
+                uri = uri.replace("exist:/", "xmldb:exist:///");
             }
         }
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/Options.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/Options.java
@@ -54,6 +54,7 @@ import net.sf.saxon.functions.SystemProperty;
 import net.sf.saxon.s9api.QName;
 import net.sf.saxon.s9api.XdmValue;
 import org.exist.dom.memtree.NamespaceNode;
+import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
@@ -490,7 +491,13 @@ class Options {
         final List<Tuple2<String, Source>> results = new ArrayList<>(1);
         final Optional<String> stylesheetLocation = Options.STYLESHEET_LOCATION.get(options).map(StringValue::getStringValue);
         if (stylesheetLocation.isPresent()) {
-            results.add(Tuple(stylesheetLocation.get(), resolveStylesheetLocation(stylesheetLocation.get())));
+            final String strStylesheetLocationUri;
+            if (stylesheetLocation.get().startsWith("/db/")) {
+                strStylesheetLocationUri = XmldbURI.EMBEDDED_SERVER_URI_PREFIX + stylesheetLocation.get();
+            } else {
+                strStylesheetLocationUri = stylesheetLocation.get();
+            }
+            results.add(Tuple(strStylesheetLocationUri, resolveStylesheetLocation(stylesheetLocation.get())));
         }
 
         final Optional<Node> stylesheetNode = Options.STYLESHEET_NODE.get(options).map(NodeValue::getNode);

--- a/exist-core/src/main/java/org/exist/xquery/functions/transform/Transform.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/transform/Transform.java
@@ -181,7 +181,11 @@ public class Transform extends BasicFunction {
 
         // Parameter 1 & 2
         final Sequence inputNode = args[0];
-        final Item stylesheetItem = args[1].itemAt(0);
+        Item stylesheetItem = args[1].itemAt(0);
+        if (stylesheetItem instanceof StringValue sv && sv.toString().startsWith("/db/")) {
+            // adjust /db like URI to xmldb:exist:///db/ like URI
+            stylesheetItem = new StringValue(XmldbURI.EMBEDDED_SERVER_URI_PREFIX + sv.toString().substring(3));
+        }
 
         // Parse 3rd parameter
         final Node options = args[2].isEmpty() ? null : ((NodeValue) args[2].itemAt(0)).getNode();

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/Shared.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/Shared.java
@@ -1,4 +1,28 @@
 /*
+ * Elemental
+ * Copyright (C) 2024, Evolved Binary Ltd
+ *
+ * admin@evolvedbinary.com
+ * https://www.evolvedbinary.com | https://www.elemental.xyz
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ *       The original license header is included below.
+ *
+ * =====================================================================
+ *
  * eXist-db Open Source Native XML Database
  * Copyright (C) 2001 The eXist-db Authors
  *
@@ -145,7 +169,7 @@ public class Shared {
             LOG.debug("Streaming element or document node");
 
             if (item instanceof NodeProxy np) {
-                final String url = "xmldb:exist://" + np.getOwnerDocument().getBaseURI();
+                final String url = np.getOwnerDocument().getBaseURI();
                 LOG.debug("Document detected, adding URL {}", url);
                 streamSource.setSystemId(url);
             }

--- a/exist-core/src/test/java/org/exist/xquery/TransformTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/TransformTest.java
@@ -95,6 +95,50 @@ public class TransformTest {
                 "<p>End Template 1</p>" +
                 "</doc>", result);
     }
+
+    @Test
+    public void transformWithSameDirectoryImportViaDbLocation() throws XMLDBException {
+        final String query =
+            "import module namespace transform='http://exist-db.org/xquery/transform';\n" +
+            "let $xml := <empty/>\n" +
+            "let $xsl := '/db/" + TEST_COLLECTION_NAME + "/same-dir/a.xsl'\n" +
+            "return transform:transform($xml, $xsl, ())";
+        final String result = execQuery(query);
+        assertEquals("<doc><p>From A</p><p>From B</p></doc>", result);
+    }
+
+    @Test
+    public void transformWithSameDirectoryImportViaXmldbLocation() throws XMLDBException {
+        final String query =
+            "import module namespace transform='http://exist-db.org/xquery/transform';\n" +
+            "let $xml := <empty/>\n" +
+            "let $xsl := 'xmldb:exist:///db/" + TEST_COLLECTION_NAME + "/same-dir/a.xsl'\n" +
+            "return transform:transform($xml, $xsl, ())";
+        final String result = execQuery(query);
+        assertEquals("<doc><p>From A</p><p>From B</p></doc>", result);
+    }
+
+    @Test
+    public void transformWithSameDirectoryImportViaDbNode() throws XMLDBException {
+        final String query =
+            "import module namespace transform='http://exist-db.org/xquery/transform';\n" +
+            "let $xml := <empty/>\n" +
+            "let $xsl := doc('/db/" + TEST_COLLECTION_NAME + "/same-dir/a.xsl')\n" +
+            "return transform:transform($xml, $xsl, ())";
+        final String result = execQuery(query);
+        assertEquals("<doc><p>From A</p><p>From B</p></doc>", result);
+    }
+
+    @Test
+    public void transformWithSameDirectoryImportViaXmldbNode() throws XMLDBException {
+        final String query =
+            "import module namespace transform='http://exist-db.org/xquery/transform';\n" +
+            "let $xml := <empty/>\n" +
+            "let $xsl := doc('xmldb:exist:///db/" + TEST_COLLECTION_NAME + "/same-dir/a.xsl')\n" +
+            "return transform:transform($xml, $xsl, ())";
+        final String result = execQuery(query);
+        assertEquals("<doc><p>From A</p><p>From B</p></doc>", result);
+    }
     
     
     private String execQuery(String query) throws XMLDBException {
@@ -171,6 +215,31 @@ public class TransformTest {
         addXMLDocument(xsl1, doc1, "1.xsl");
         addXMLDocument(xsl2, doc2, "2.xsl");
         addXMLDocument(xsl3, doc3, "3.xsl");
+
+        service =
+                testCollection.getService(
+                    CollectionManagementService.class);
+
+        Collection sameDir = service.createCollection("same-dir");
+        assertNotNull(sameDir);
+
+        String docA = "<?xml version='1.0' encoding='UTF-8'?>\n" +
+        "<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='1.0'>\n"+
+        "<xsl:import href='b.xsl'/>\n" +
+        "<xsl:template match='/'>" +
+        "<doc><p>From A</p><xsl:call-template name='from-b'/></doc>" +
+        "</xsl:template>" +
+        "</xsl:stylesheet>";
+
+        String docB = "<?xml version='1.0' encoding='UTF-8'?>\n" +
+        "<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='1.0'>\n"+
+        "<xsl:template name='from-b'>" +
+        "<p>From B</p>" +
+        "</xsl:template>" +
+        "</xsl:stylesheet>";
+
+        addXMLDocument(sameDir, docA, "a.xsl");
+        addXMLDocument(sameDir, docB, "b.xsl");
     }
 
     @After

--- a/exist-core/src/test/java/org/exist/xquery/XQueryTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryTest.java
@@ -2578,14 +2578,14 @@ public class XQueryTest {
         ResourceSet result = service.query(query);
 
         assertEquals(1, result.getSize());
-        assertEquals("/db/test/baseuri.xml", result.getResource(0).getContent().toString());
+        assertEquals("xmldb:exist:///db/test/baseuri.xml", result.getResource(0).getContent().toString());
 
         query = "doc('/db/test/baseuri.xml')/Root/Node1/base-uri()";
 
         result = service.query(query);
 
         assertEquals(1, result.getSize());
-        assertEquals("/db/test/baseuri.xml", result.getResource(0).getContent().toString());
+        assertEquals("xmldb:exist:///db/test/baseuri.xml", result.getResource(0).getContent().toString());
 
 
         query = "doc('/db/test/baseuri.xml')/Root/Node1/Node2/base-uri()";
@@ -2593,14 +2593,14 @@ public class XQueryTest {
         result = service.query(query);
 
         assertEquals(1, result.getSize());
-        assertEquals("/db/test/baseuri.xml", result.getResource(0).getContent().toString());
+        assertEquals("xmldb:exist:///db/test/baseuri.xml", result.getResource(0).getContent().toString());
 
         query = "doc('/db/test/baseuri.xml')/Root/Node1/Node2/Node3/base-uri()";
 
         result = service.query(query);
 
         assertEquals(1, result.getSize());
-        assertEquals("/db/test/baseuri.xml", result.getResource(0).getContent().toString());
+        assertEquals("xmldb:exist:///db/test/baseuri.xml", result.getResource(0).getContent().toString());
     }
 
     /**

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/transform/FunTransformITTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/transform/FunTransformITTest.java
@@ -58,6 +58,47 @@ import static org.junit.Assert.*;
  */
 public class FunTransformITTest {
 
+    private static final XmldbURI TEST_IMPORT_XSLT_COLLECTION = XmldbURI.create("/db/fn-transform-import-test");
+    private static final XmldbURI IMPORT_A_XSLT_NAME = XmldbURI.create("a.xsl");
+    private static final XmldbURI IMPORT_B_XSLT_NAME = XmldbURI.create("b.xsl");
+
+    private static final String IMPORT_A_XSLT =
+        "<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"1.0\">\n" +
+        "  <xsl:import href=\"b.xsl\"/>\n" +
+        "  <xsl:template match=\"/\">\n" +
+        "    <doc><p>From A</p><xsl:call-template name=\"from-b\"/></doc>\n" +
+        "  </xsl:template>\n" +
+        "</xsl:stylesheet>";
+
+    private static final String IMPORT_B_XSLT =
+        "<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"1.0\">\n" +
+        "  <xsl:template name=\"from-b\"><p>From B</p></xsl:template>\n" +
+        "</xsl:stylesheet>";
+
+    private static final String SAME_DIR_IMPORT_VIA_DB_LOCATION_QUERY =
+        "fn:transform(map {\n" +
+        "  \"stylesheet-location\": \"/db/fn-transform-import-test/a.xsl\",\n" +
+        "  \"source-node\": document { <empty/> }\n" +
+        "})?output";
+
+    private static final String SAME_DIR_IMPORT_VIA_XMLDB_LOCATION_QUERY =
+        "fn:transform(map {\n" +
+        "  \"stylesheet-location\": \"xmldb:exist:///db/fn-transform-import-test/a.xsl\",\n" +
+        "  \"source-node\": document { <empty/> }\n" +
+        "})?output";
+
+    private static final String SAME_DIR_IMPORT_VIA_DB_NODE_QUERY =
+        "fn:transform(map {\n" +
+        "  \"stylesheet-node\": doc(\"/db/fn-transform-import-test/a.xsl\"),\n" +
+        "  \"source-node\": document { <empty/> }\n" +
+        "})?output";
+
+    private static final String SAME_DIR_IMPORT_VIA_XMLDB_NODE_QUERY =
+        "fn:transform(map {\n" +
+        "  \"stylesheet-node\": doc(\"xmldb:exist:///db/fn-transform-import-test/a.xsl\"),\n" +
+        "  \"source-node\": document { <empty/> }\n" +
+        "})?output";
+
     private static final XmldbURI TEST_IDENTITY_XSLT_COLLECTION = XmldbURI.create("/db/transform-identity-test");
     private static final XmldbURI IDENTITY_XSLT_NAME = XmldbURI.create("xsl-identity.xslt");
 
@@ -144,6 +185,30 @@ public class FunTransformITTest {
     public static ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
 
     @Test
+    public void sameDirectoryImportViaDbLocation() throws XPathException, PermissionDeniedException, EXistException {
+        final Source expected = Input.fromString("<doc><p>From A</p><p>From B</p></doc>").build();
+        expectQuery(SAME_DIR_IMPORT_VIA_DB_LOCATION_QUERY, expected);
+    }
+
+    @Test
+    public void sameDirectoryImportViaXmldbLocation() throws XPathException, PermissionDeniedException, EXistException {
+        final Source expected = Input.fromString("<doc><p>From A</p><p>From B</p></doc>").build();
+        expectQuery(SAME_DIR_IMPORT_VIA_XMLDB_LOCATION_QUERY, expected);
+    }
+
+    @Test
+    public void sameDirectoryImportViaDbNode() throws XPathException, PermissionDeniedException, EXistException {
+        final Source expected = Input.fromString("<doc><p>From A</p><p>From B</p></doc>").build();
+        expectQuery(SAME_DIR_IMPORT_VIA_DB_NODE_QUERY, expected);
+    }
+
+    @Test
+    public void sameDirectoryImportViaXmldbNode() throws XPathException, PermissionDeniedException, EXistException {
+        final Source expected = Input.fromString("<doc><p>From A</p><p>From B</p></doc>").build();
+        expectQuery(SAME_DIR_IMPORT_VIA_XMLDB_NODE_QUERY, expected);
+    }
+
+    @Test
     public void identityPersistentDom() throws XPathException, PermissionDeniedException, EXistException {
         final Source expected = Input.fromString(IDENTITY_XML).build();
         expectQuery(IDENTITY_PERSISTENT_XSLT_QUERY, expected);
@@ -210,6 +275,11 @@ public class FunTransformITTest {
             createCollection(broker, transaction, TEST_IDENTITY_XSLT_COLLECTION,
                 Tuple(IDENTITY_XSLT_NAME, IDENTITY_XSLT),
                 Tuple(IDENTITY_XML_NAME, IDENTITY_XML)
+            );
+
+            createCollection(broker, transaction, TEST_IMPORT_XSLT_COLLECTION,
+                Tuple(IMPORT_A_XSLT_NAME, IMPORT_A_XSLT),
+                Tuple(IMPORT_B_XSLT_NAME, IMPORT_B_XSLT)
             );
 
             transaction.commit();

--- a/exist-core/src/test/xquery/base-uri.xql
+++ b/exist-core/src/test/xquery/base-uri.xql
@@ -118,7 +118,7 @@ function baseuri:cleanup() {
 
 
 declare
-    %test:assertEquals("-/db/base-uri/test.xml")
+    %test:assertEquals("-xmldb:exist:///db/base-uri/test.xml")
 function baseuri:root() {
      $baseuri:DOCUMENT/base-uri() || "-" || base-uri(doc($baseuri:full_path_document))
 };
@@ -131,7 +131,7 @@ function baseuri:sub1() {
 };
 
 declare
-    %test:assertEquals("http://example.org/a/","http://example.org/b/","http://example.org/c/","/yy","/db/base-uri/zz")
+    %test:assertEquals("http://example.org/a/","http://example.org/b/","http://example.org/c/","/yy","xmldb:exist:///db/base-uri/zz")
 function baseuri:sub2() {
      for $sub in doc($baseuri:full_path_document)//sub
      return base-uri($sub)

--- a/exist-core/src/test/xquery/indexing/indexes-base-uri.xq
+++ b/exist-core/src/test/xquery/indexing/indexes-base-uri.xq
@@ -1,4 +1,28 @@
 (:
+ : Elemental
+ : Copyright (C) 2024, Evolved Binary Ltd
+ :
+ : admin@evolvedbinary.com
+ : https://www.evolvedbinary.com | https://www.elemental.xyz
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; version 2.1.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :
+ : NOTE: Parts of this file contain code from 'The eXist-db Authors'.
+ :       The original license header is included below.
+ :
+ : =====================================================================
+ :
  : eXist-db Open Source Native XML Database
  : Copyright (C) 2001 The eXist-db Authors
  :
@@ -50,7 +74,7 @@ function but:tearDown() {
 
 declare
     %test:pending("Each test interferes with each other test, we need to figure out how to have but:tearDown called after every test")
-    %test:assertEquals("/db/but/a/data/test.xml", "/db/but/a/data/test.xml", "/db/but/b/data/test.xml")
+    %test:assertEquals("xmldb:exist:///db/but/a/data/test.xml", "xmldb:exist:///db/but/a/data/test.xml", "xmldb:exist:///db/but/b/data/test.xml")
 function but:base-uri-after-collection-copy() {
     let $test-col-a-data-uri := xmldb:create-collection($but:test-col-a-uri, "data")
     let $doc-path := xmldb:store($test-col-a-data-uri, "test.xml", $but:XML)
@@ -66,7 +90,7 @@ function but:base-uri-after-collection-copy() {
 };
 
 declare
-    %test:assertEquals("/db/but/a/data/test.xml", "/db/but/b/data/test.xml")
+    %test:assertEquals("xmldb:exist:///db/but/a/data/test.xml", "xmldb:exist:///db/but/b/data/test.xml")
 function but:base-uri-after-collection-move() {
     let $test-col-a-data-uri := xmldb:create-collection($but:test-col-a-uri, "data")
     let $doc-path := xmldb:store($test-col-a-data-uri, "test.xml", $but:XML)
@@ -83,7 +107,7 @@ function but:base-uri-after-collection-move() {
 
 declare
     %test:pending("Each test interferes with each other test, we need to figure out how to have but:tearDown called after every test")
-    %test:assertEquals("/db/but/a/data/test.xml", "/db/but/a/data/test.xml", "/db/but/b/test.xml")
+    %test:assertEquals("xmldb:exist:///db/but/a/data/test.xml", "xmldb:exist:///db/but/a/data/test.xml", "xmldb:exist:///db/but/b/test.xml")
 function but:base-uri-after-resource-copy() {
     let $test-col-a-data-uri := xmldb:create-collection($but:test-col-a-uri, "data")
     let $doc-path := xmldb:store($test-col-a-data-uri, "test.xml", $but:XML)
@@ -100,7 +124,7 @@ function but:base-uri-after-resource-copy() {
 
 declare
     %test:pending("Each test interferes with each other test, we need to figure out how to have but:tearDown called after every test")
-    %test:assertEquals("/db/but/a/data/test.xml", "/db/but/b/test.xml")
+    %test:assertEquals("xmldb:exist:///db/but/a/data/test.xml", "xmldb:exist:///db/but/b/test.xml")
 function but:base-uri-after-resource-move() {
     let $test-col-a-data-uri := xmldb:create-collection($but:test-col-a-uri, "data")
     let $doc-path := xmldb:store($test-col-a-data-uri, "test.xml", $but:XML)

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/AbstractFieldConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/AbstractFieldConfig.java
@@ -172,20 +172,30 @@ public abstract class AbstractFieldConfig {
         }
     }
 
-    private String resolveURI(String baseURI, String location) {
+    private String resolveURI(@Nullable final String strBaseUri, final String strLocation) {
         try {
-            final URI uri = new URI(location);
-            if (!uri.isAbsolute() && baseURI != null && baseURI.startsWith(CollectionConfigurationManager.CONFIG_COLLECTION)) {
-                String base = baseURI.substring(CollectionConfigurationManager.CONFIG_COLLECTION.length());
-                final int lastSlash = base.lastIndexOf('/');
-                if (lastSlash > -1) {
-                    base = base.substring(0, lastSlash);
+            final URI uriLocation = new URI(strLocation);
+            if (!uriLocation.isAbsolute() && strBaseUri != null) {
+                if (strBaseUri.startsWith(CollectionConfigurationManager.CONFIG_COLLECTION)) {
+                    String base = strBaseUri.substring(CollectionConfigurationManager.CONFIG_COLLECTION.length());
+                    final int lastSlash = base.lastIndexOf('/');
+                    if (lastSlash > -1) {
+                        base = base.substring(0, lastSlash);
+                    }
+                    final String resolved = XmldbURI.EMBEDDED_SERVER_URI_PREFIX + base + '/' + strLocation;
+                    return resolved;
                 }
-                return XmldbURI.EMBEDDED_SERVER_URI_PREFIX + base + '/' + location;
+
+                if (strBaseUri.startsWith(XmldbURI.EMBEDDED_SERVER_URI_PREFIX + CollectionConfigurationManager.CONFIG_COLLECTION)) {
+                    final String basePath = strBaseUri.substring((XmldbURI.EMBEDDED_SERVER_URI_PREFIX + CollectionConfigurationManager.CONFIG_COLLECTION).length());
+                    final String locationPath = new URI(basePath).resolve(uriLocation).toString();
+                    final String resolved = XmldbURI.EMBEDDED_SERVER_URI_PREFIX + locationPath;
+                    return resolved;
+                }
             }
-        } catch (URISyntaxException e) {
+        } catch (final URISyntaxException e) {
             // ignore and return location
         }
-        return location;
+        return strLocation;
     }
 }

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
@@ -258,7 +258,7 @@ public class Query extends Function implements Optimizable {
         final LuceneIndexWorker index = (LuceneIndexWorker) context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
 
         final DocumentSet docs = contextSequence.getDocumentSet();
-        final Item key = getKey(contextSequence, null);
+        @Nullable final Item key = getKey(contextSequence, null);
         @Nullable final List<QName> qnames = contextQNames != null ? Arrays.asList(contextQNames) : null;
         final QueryOptions options = parseOptions(this, contextSequence, null, 3);
         try {


### PR DESCRIPTION
`Node#getBaseURI()` and the XPath function `fn:base-uri()` now return a URI.

Instead of `/db/a/b/c.xml` the result is now `xmldb:exist:///db/a/b/c.xml`. This fixes a number of issues with relative XSLT stylesheet imports.

Closes https://github.com/evolvedbinary/elemental/issues/169