### PR TITLE
[6.x.x] Adds missing OxygenXML libs

### DIFF
--- a/exist-core/src/main/java/org/exist/webstart/JnlpJarFiles.java
+++ b/exist-core/src/main/java/org/exist/webstart/JnlpJarFiles.java
@@ -87,7 +87,7 @@ public class JnlpJarFiles {
             "elemental-media-type-impl-%latest%",
             "jargo-%latest%",
             "bcprov-jdk18on-%latest%",
-            "fastutil-%latest%-min",
+            "fastutil-%latest%",
             "j8fu-%latest%",
             "jackson-core-%latest%",
             "jcip-annotations-%latest%",

--- a/exist-core/src/main/java/org/exist/webstart/JnlpJarFiles.java
+++ b/exist-core/src/main/java/org/exist/webstart/JnlpJarFiles.java
@@ -83,6 +83,8 @@ public class JnlpJarFiles {
             "commons-io-%latest%",
             "commons-logging-%latest%",
             "commons-pool-%latest%",
+            "elemental-media-type-api-%latest%",
+            "elemental-media-type-impl-%latest%",
             "jargo-%latest%",
             "bcprov-jdk18on-%latest%",
             "fastutil-%latest%-min",


### PR DESCRIPTION
Backport of https://github.com/evolvedbinary/elemental/pull/215

This PR Closes https://github.com/evolvedbinary/elemental/issues/209 which states:
```
Check datasource configuration. Could not instantiate: ro.sync.db.nxd.exist.ExistSession 
due to: java.lang.NoClassDefFoundError: xyz/elemental/mediatype/MediaType

```
Thanks to @adamretter suggestion adding the missing libs to `exist-core\src\main\java\org\exist\webstart\JnlpJarFiles.java` should fix the connection.