### PR TITLE
[6.x.x] Repair the Docker healthcheck command

### DIFF
--- a/exist-core/src/main/java/org/exist/client/InteractiveClient.java
+++ b/exist-core/src/main/java/org/exist/client/InteractiveClient.java
@@ -1265,7 +1265,7 @@ public class InteractiveClient {
             consoleOut("Sort-by = " + sortBy);
         }
 
-        final EXistXPathQueryService service = (EXistXPathQueryService) getCollection().getService("EXistXPathQueryService", "1.0");
+        final EXistXPathQueryService service = (EXistXPathQueryService) getCollection().getService("XPathQueryService", "1.0");
         service.setProperty(OutputKeys.INDENT, properties.getProperty(INDENT));
         service.setProperty(OutputKeys.ENCODING, properties.getProperty(ENCODING));
 


### PR DESCRIPTION
Repairs the Docker healthcheck command by fixing a regression introduced in e04b0cb when backporting https://github.com/evolvedbinary/elemental/pull/224 to 6.x.x